### PR TITLE
feat(cmd): add `add <owner/repo>` subcommand for fleet onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # See fleet.json (committed example) vs fleet.local.json (your real fleet).
 fleet.local.json
 
+# Speckit feature json
+.specify/feature.json
+
 # Local PR draft — regenerated per session via /pr-message.
 PR_MESSAGE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,20 @@ go run . list         # Fastest sanity check — exercises LoadConfig end-to-end
 go run . template fetch   # ~3 min (serial); do not run in subagents with strict timeouts.
 ```
 
+### Local gate — run before claiming any code change complete
+
+`go build` / `go vet` are necessary but **not sufficient**. CI runs stricter checks (gofmt alignment, golangci-lint, full test suite) that build+vet do not. Before reporting any code change "done," run the full gate:
+
+```bash
+make fmt         # apply gofmt in place (or `make fmt-check` to verify without writing)
+make lint        # golangci-lint — can exceed 5 minutes; use extended timeout, do NOT skip
+make test        # full test suite
+# — or, in one shot: —
+make ci          # runs: fmt-check vet lint test  (this is the CI gate)
+```
+
+**Do not claim a task complete until `make ci` passes locally.** `go build` passing means nothing — prior commits have landed lint/fmt failures that CI rejected because only build+vet were run. When in doubt, run `make ci`.
+
 The CLI has two config files: `fleet.local.json` (private, gitignored, real fleet state) and `fleet.json` (public, committed, example tracking only `rshade/gh-aw-fleet`). `LoadConfig` tries `fleet.local.json` first and falls back. `go run . list` prints `(loaded fleet.local.json)` or `(loaded fleet.json)` to stderr so you know which is active.
 
 ## Architecture big-picture
@@ -49,3 +63,10 @@ The `skills/` directory contains four SKILL.md files codifying recurring operato
 ## .claude/settings.json
 
 Committed at repo root; shared with collaborators and subagents. Allows `go build/vet/test/run`, `gh aw/api/repo/pr`, `git` read ops, and common shell tools. Denies `git add`, `git commit`, `git rebase --continue`, `git push --force`, `git reset --hard`. When adding a new developer command, add it to the allowlist so subagents don't prompt.
+
+## Active Technologies
+- Go 1.25.8 (from `go.mod`) + `github.com/spf13/cobra` v1.10.2 (CLI (001-add-subcommand)
+- `fleet.local.json` (the private source of truth — target (001-add-subcommand)
+
+## Recent Changes
+- 001-add-subcommand: Added Go 1.25.8 (from `go.mod`) + `github.com/spf13/cobra` v1.10.2 (CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ The `skills/` directory contains four SKILL.md files codifying recurring operato
 Committed at repo root; shared with collaborators and subagents. Allows `go build/vet/test/run`, `gh aw/api/repo/pr`, `git` read ops, and common shell tools. Denies `git add`, `git commit`, `git rebase --continue`, `git push --force`, `git reset --hard`. When adding a new developer command, add it to the allowlist so subagents don't prompt.
 
 ## Active Technologies
-- Go 1.25.8 (from `go.mod`) + `github.com/spf13/cobra` v1.10.2 (CLI (001-add-subcommand)
-- `fleet.local.json` (the private source of truth — target (001-add-subcommand)
+- Go 1.25.8 (from `go.mod`), using `github.com/spf13/cobra` v1.10.2 for CLI wiring.
+- `fleet.local.json` is the private, gitignored source of truth; `fleet.json` is the committed public example.
 
 ## Recent Changes
-- 001-add-subcommand: Added Go 1.25.8 (from `go.mod`) + `github.com/spf13/cobra` v1.10.2 (CLI
+- 001-add-subcommand: added `gh-aw-fleet add <owner/repo>` subcommand (cobra) for onboarding repos into `fleet.local.json`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Declarative fleet manager for GitHub Agentic Workflows.
 
 ## Status
 
-Early work-in-progress. The core reconcile loop (`deploy`, `sync`, `upgrade`) is functional. Commands `add` and `status` are stubs; `template fetch` works but is incomplete. Architecture and APIs are actively evolving.
+Early work-in-progress. The core reconcile loop (`deploy`, `sync`, `upgrade`) is functional, along with `add` for onboarding repos into `fleet.local.json`. The `status` command is still a stub; `template fetch` works but is incomplete. Architecture and APIs are actively evolving.
 
 ## Why
 
@@ -48,6 +48,13 @@ Fetch the upstream catalog (templates.json) so you can review new workflows:
 ./gh-aw-fleet template fetch
 ```
 
+Onboard a new repo into `fleet.local.json` with a profile (dry-run first, then `--apply`):
+
+```bash
+./gh-aw-fleet add acme/widgets --profile default
+./gh-aw-fleet add acme/widgets --profile default --apply --yes
+```
+
 Dry-run a deploy to one repo (shows what would be added, no changes made):
 
 ```bash
@@ -77,12 +84,12 @@ Upgrade all repos to the latest gh-aw and agentics versions:
 | Command | Description |
 |---------|-------------|
 | `list` | List tracked repos and their resolved workflow sets |
+| `add <owner/repo>` | Register a repo in `fleet.local.json` with a profile (dry-run by default) |
 | `deploy <repo>` | Apply the declared workflow set to a repo via `gh aw add` + PR |
 | `sync <repo>` | Reconcile a repo to match its declared profile (add missing, flag drift) |
 | `upgrade [repo\|--all]` | Bump profile pins + run `gh aw upgrade` + update across repos |
 | `template fetch` | Refresh `templates.json` from gh-aw and agentics |
 | `status [repo]` | Diff desired (fleet.json) vs actual state (not yet implemented) |
-| `add <owner/repo>` | Register a repo in fleet.json with a profile (not yet implemented) |
 
 ## Configuration
 
@@ -186,7 +193,7 @@ When a command fails (e.g., `gh aw add` returns an error), the tool scans output
 - **No `--work-dir` persistence.** The `--work-dir` flag exists but doesn't resume from a previous state. A full retry re-clones and re-starts.
 - **Sync dry-run doesn't do deploy preflight.** `sync --dry-run` computes the diff but doesn't pre-validate that the workflows would deploy successfully.
 - **No GitHub extension packaging yet.** `gh-aw-fleet` is not yet installable as a `gh` extension. Build and invoke directly for now.
-- **`add` and `status` are stubs.** These commands are planned but not yet implemented.
+- **`status` is still a stub.** Planned but not yet implemented.
 
 ## Contributing & Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,22 +50,16 @@ on every run.
 
 ### Deploy UX — warn before broken deploys
 
-This trio shares a theme: surface broken-deploy conditions to the operator
-*before* a PR merges, instead of letting workflows fail silently in
-production.
+This theme surfaces broken-deploy conditions to the operator *before* a PR
+merges, instead of letting workflows fail silently in production. #6 landed
+in 2026-Q2; #7 and #11 continue the work.
 
-- [ ] [#6](https://github.com/rshade/gh-aw-fleet/issues/6) Check org-level
-  secrets to avoid false-positive missing-secret warnings `[S]`
-  *Today `checkEngineSecret` only queries repo secrets. Org-managed
-  installations get spurious warnings on every deploy. Mirror upstream
-  `add-wizard` behavior: check repo, then fall back to org. Patch is
-  drafted in the issue body. Prerequisite for #7 to be accurate.*
 - [ ] [#7](https://github.com/rshade/gh-aw-fleet/issues/7) Surface
   missing-secret warning in PR body `[S]`
   *CLI prints the warning to the operator's terminal but the PR body is
   silent. Reviewers merging hours later land broken workflows. Append a
   `⚠ Setup Required` section to `prBody()` when `MissingSecret` is set.
-  Implement after or alongside #6.*
+  Now unblocked since #6 shipped accurate org-level checks.*
 - [ ] [#11](https://github.com/rshade/gh-aw-fleet/issues/11) Preflight
   check for Actions enabled and workflow write permissions `[M]`
   *Two repo-level settings (Actions toggle, workflow token permissions)
@@ -83,8 +77,24 @@ production.
 ## Near-Term Vision (v0.3 — operator quality of life)
 
 Once the CLI is complete, the next layer is making it pleasant under load —
-preflight before destructive ops, faster sanity checks, packaging.
+preflight before destructive ops, faster sanity checks, packaging, and
+making the tool legible to LLM agents piping its output.
 
+- [ ] [#24](https://github.com/rshade/gh-aw-fleet/issues/24) Introduce
+  zerolog for errors, warnings, and diagnostics `[M]`
+  *Foundational: add a thin `internal/log` package over zerolog. Configure
+  once from cobra `PersistentPreRunE` with `--log-level` / `--log-format`.
+  User-facing tabwriter output stays; errors, warnings, and subprocess
+  diagnostics become structured. Prerequisite for #25's stderr warning
+  emission.*
+- [ ] [#25](https://github.com/rshade/gh-aw-fleet/issues/25) Add
+  `--output json` to `list`/`deploy`/`sync`/`upgrade` for LLM consumption
+  `[M]`
+  *No new data — just marshal the existing `DeployResult` / `SyncResult` /
+  `UpgradeResult` structs as a versioned JSON envelope
+  (`schema_version: 1`) when `-o json` is set. Unlocks agentic consumers
+  without regex-scraping tabwriter tables. Depends on #24 for stderr
+  warning emission.*
 - [ ] `sync --dry-run` runs deploy preflight `[M]`
   *Today `sync --dry-run` computes the diff but doesn't validate that the
   resolved workflows would actually `gh aw add` cleanly (404s on bad pins,
@@ -214,6 +224,12 @@ ideas close the loop without becoming a daemon.
 
 ### 2026-Q2
 
+- [x] [#6](https://github.com/rshade/gh-aw-fleet/issues/6) Check org-level
+  secrets to avoid false-positive missing-secret warnings `[S]`
+  *`checkEngineSecret` now queries repo secrets first, then falls back to
+  org secrets — mirroring upstream `add-wizard`. Eliminates spurious
+  warnings on org-managed installations. Unblocks #7 (PR-body warning
+  accuracy).*
 - [x] Bootstrap CLI, profiles, and operator skills (commit `8543956`)
   *Initial scaffolding: `cmd/`, `internal/fleet/`, `profiles/default.json`,
   four Claude skills, CI + release tooling, commitlint, golangci-lint.*
@@ -238,6 +254,7 @@ Any roadmap item that violates these is rejected, not negotiated.
 - **Effort labels**: `effort/small`, `effort/medium`, `effort/large`
 - **Contribution flags**: `community`, `cross-repo`, `spec-first`
 
-> Immediate Focus items (#8, #9, #10) are tracked as GitHub issues. The
+> Immediate Focus items (#7, #8, #9, #10, #11, #12) and the two Near-Term
+> infrastructure items (#24, #25) are tracked as GitHub issues. The remaining
 > Near-Term and Future items don't have issues yet — open them as work picks
 > up, then run `/roadmap sync` to keep this file aligned.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -80,6 +80,9 @@ func newAddCmd(flagDir *string) *cobra.Command {
 
 func resolveConfirmation(cmd *cobra.Command, apply, yes bool) (bool, error) {
 	if !apply {
+		if yes {
+			fmt.Fprintln(cmd.ErrOrStderr(), "ignored: --yes has no effect without --apply")
+		}
 		return false, nil
 	}
 	if yes {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
+)
+
+func newAddCmd(flagDir *string) *cobra.Command {
+	var (
+		flagProfiles []string
+		flagEngine   string
+		flagExcludes []string
+		flagExtras   []string
+		flagApply    bool
+		flagYes      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "add <owner/repo>",
+		Short: "Register a repo in fleet.local.json with a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug, err := fleet.ValidateSlug(args[0])
+			if err != nil {
+				return err
+			}
+
+			confirmed, err := resolveConfirmation(cmd, flagApply, flagYes)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := fleet.LoadConfig(*flagDir)
+			if err != nil {
+				return err
+			}
+
+			opts := fleet.AddOptions{
+				Repo:           slug,
+				Profiles:       flagProfiles,
+				Engine:         flagEngine,
+				Excludes:       flagExcludes,
+				ExtraWorkflows: flagExtras,
+				Apply:          flagApply,
+				Confirmed:      confirmed,
+				Dir:            *flagDir,
+			}
+			res, addErr := fleet.Add(cfg, opts)
+			if addErr != nil {
+				return addErr
+			}
+			printAdd(cmd, res)
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&flagProfiles, "profile", nil,
+		"Profile name(s) to assign (repeatable or comma-separated); required")
+	cmd.Flags().StringVar(&flagEngine, "engine", "",
+		"Engine override (e.g. claude, copilot); validated against EngineSecrets")
+	cmd.Flags().StringArrayVar(&flagExcludes, "exclude", nil,
+		"Workflow name to exclude from selected profiles (repeatable)")
+	cmd.Flags().StringArrayVar(&flagExtras, "extra-workflow", nil,
+		"Extra workflow spec to add outside profiles (repeatable). "+
+			"Accepts: name | owner/repo/name@ref | owner/repo/.github/workflows/name.md@ref")
+	cmd.Flags().BoolVar(&flagApply, "apply", false,
+		"Actually write fleet.local.json (default is dry-run)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false,
+		"Confirm --apply without an interactive prompt (required in non-TTY)")
+	_ = cmd.MarkFlagRequired("profile")
+	return cmd
+}
+
+func resolveConfirmation(cmd *cobra.Command, apply, yes bool) (bool, error) {
+	if !apply {
+		return false, nil
+	}
+	if yes {
+		return true, nil
+	}
+	fd := int(os.Stdin.Fd()) //nolint:gosec // fd numbers are small and always fit in int
+	if !term.IsTerminal(fd) {
+		return false, errors.New("--apply requires --yes in a non-interactive shell")
+	}
+	fmt.Fprint(cmd.ErrOrStderr(), "Write fleet.local.json? [y/N] ")
+	reader := bufio.NewReader(cmd.InOrStdin())
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	resp := strings.ToLower(strings.TrimSpace(line))
+	if resp != "y" && resp != "yes" {
+		return false, errors.New("aborted: re-run with --apply --yes to confirm")
+	}
+	return true, nil
+}
+
+func printAdd(cmd *cobra.Command, res *fleet.AddResult) {
+	stderr := cmd.ErrOrStderr()
+	stdout := cmd.OutOrStdout()
+	verb := "would add"
+	if res.WroteLocal {
+		verb = "added"
+		if res.SynthesizedLocal {
+			fmt.Fprintln(stderr,
+				"creating fleet.local.json (minimal; profiles/defaults still resolved from fleet.json)")
+		}
+	}
+	fmt.Fprintf(stderr, "%s %s with profiles [%s] (%d workflows)\n",
+		verb, res.Repo, strings.Join(res.Profiles, ","), len(res.Resolved))
+	if res.Engine != "" {
+		fmt.Fprintf(stderr, "engine override: %s\n", res.Engine)
+	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", w)
+	}
+	for _, w := range res.Resolved {
+		fmt.Fprintf(stdout, "- %s\n", w.Name)
+	}
+	if res.WroteLocal {
+		fmt.Fprintf(stderr, "next: gh-aw-fleet deploy %s\n", res.Repo)
+	} else {
+		fmt.Fprintln(stderr, "next: re-run with --apply to persist")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ and calling Claude when a deploy or merge needs judgment.`,
 	root.AddCommand(
 		newListCmd(&flagDir),
 		newStatusCmd(),
-		newAddCmd(),
+		newAddCmd(&flagDir),
 		newTemplateCmd(&flagDir),
 		newDeployCmd(&flagDir),
 		newSyncCmd(&flagDir),

--- a/cmd/stubs.go
+++ b/cmd/stubs.go
@@ -14,14 +14,6 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
-func newAddCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "add <owner/repo>",
-		Short: "Register a repo in fleet.json with a profile",
-		RunE:  notImplemented("add"),
-	}
-}
-
 func notImplemented(name string) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("%s: not yet implemented", name)

--- a/fleet.json
+++ b/fleet.json
@@ -8,7 +8,7 @@
       "description": "Baseline every tracked repo gets. Low-noise, broadly useful.",
       "sources": {
         "github/gh-aw": { "ref": "v0.68.3" },
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "audit-workflows",          "source": "github/gh-aw" },
@@ -28,7 +28,7 @@
     "quality-plus": {
       "description": "PR-generating quality agents. Noisier — opt in for actively-developed repos.",
       "sources": {
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "daily-test-improver",         "source": "githubnext/agentics" },
@@ -50,7 +50,7 @@
     "docs-plus": {
       "description": "Heavier docs maintenance. Assumes the repo has a real docs site.",
       "sources": {
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "glossary-maintainer",           "source": "githubnext/agentics" },
@@ -64,7 +64,7 @@
     "community-plus": {
       "description": "Contributor-facing helpers. All command-triggered or event-scoped, dormant when idle.",
       "sources": {
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "grumpy-reviewer",      "source": "githubnext/agentics" },

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.8
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -11,5 +12,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/fleet/add.go
+++ b/internal/fleet/add.go
@@ -1,0 +1,291 @@
+package fleet
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	// slugHalves is the number of `/`-separated halves in a valid owner/repo slug.
+	slugHalves = 2
+	// extraSpecShortParts is the 3-part extra-workflow spec: owner/repo/name@ref (agentics layout).
+	extraSpecShortParts = 3
+)
+
+type AddOptions struct {
+	Repo           string
+	Profiles       []string
+	Engine         string
+	Excludes       []string
+	ExtraWorkflows []string
+	Apply          bool
+	Confirmed      bool
+	Dir            string
+}
+
+type AddResult struct {
+	Repo             string
+	Profiles         []string
+	Engine           string
+	Resolved         []ResolvedWorkflow
+	Warnings         []string
+	WroteLocal       bool
+	SynthesizedLocal bool
+	LocalPath        string
+}
+
+var slugHalfRE = regexp.MustCompile(`^[a-z0-9._-]+$`)
+
+// ValidateSlug normalizes and validates an owner/repo slug. Every error
+// includes a valid-form example so operators can fix their input without
+// consulting docs.
+func ValidateSlug(s string) (string, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", fmt.Errorf("invalid repo slug %q: empty string; expected form: owner/repo", s)
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != slugHalves {
+		return "", fmt.Errorf(
+			"invalid repo slug %q: must contain exactly one %q; expected form: owner/repo",
+			s, "/",
+		)
+	}
+	owner := strings.TrimSpace(parts[0])
+	repo := strings.TrimSpace(parts[1])
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf(
+			"invalid repo slug %q: owner and repo halves must both be non-empty; expected form: owner/repo",
+			s,
+		)
+	}
+	owner = strings.ToLower(owner)
+	repo = strings.ToLower(repo)
+	if !slugHalfRE.MatchString(owner) || !slugHalfRE.MatchString(repo) {
+		return "", fmt.Errorf(
+			"invalid repo slug %q: halves must match [a-z0-9._-]+; expected form: owner/repo",
+			s,
+		)
+	}
+	return owner + "/" + repo, nil
+}
+
+func Add(cfg *Config, opts AddOptions) (*AddResult, error) {
+	if opts.Apply && !opts.Confirmed {
+		return nil, errors.New("--apply requires --yes or interactive confirmation")
+	}
+	if len(opts.Profiles) == 0 {
+		return nil, errors.New("at least one --profile must be specified")
+	}
+	if _, exists := cfg.Repos[opts.Repo]; exists {
+		return nil, duplicateRepoError(cfg, opts.Dir, opts.Repo)
+	}
+	for _, p := range opts.Profiles {
+		if _, ok := cfg.Profiles[p]; !ok {
+			return nil, unknownKeyError("profile", p, cfg.Profiles)
+		}
+	}
+	if opts.Engine != "" {
+		if _, ok := EngineSecrets[opts.Engine]; !ok {
+			return nil, unknownKeyError("engine", opts.Engine, EngineSecrets)
+		}
+	}
+
+	parsedExtras := make([]ExtraWorkflow, 0, len(opts.ExtraWorkflows))
+	for _, raw := range opts.ExtraWorkflows {
+		extra, parseErr := parseExtraWorkflowSpec(raw)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		parsedExtras = append(parsedExtras, extra)
+	}
+
+	candidate := RepoSpec{
+		Profiles:            opts.Profiles,
+		Engine:              opts.Engine,
+		ExtraWorkflows:      parsedExtras,
+		ExcludeFromProfiles: opts.Excludes,
+	}
+
+	// Insert the candidate transiently so ResolveRepoWorkflows sees it in
+	// the merged view. Always remove before returning — the caller's Config
+	// must not carry unpersisted state.
+	cfg.Repos[opts.Repo] = candidate
+	resolved, err := cfg.ResolveRepoWorkflows(opts.Repo)
+	delete(cfg.Repos, opts.Repo)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workflows for %q: %w", opts.Repo, err)
+	}
+
+	localPath := resolve(opts.Dir, LocalConfigFile)
+	res := &AddResult{
+		Repo:             opts.Repo,
+		Profiles:         opts.Profiles,
+		Engine:           opts.Engine,
+		Resolved:         resolved,
+		Warnings:         collectAddWarnings(cfg, opts, parsedExtras, resolved),
+		SynthesizedLocal: !strings.Contains(cfg.LoadedFrom, LocalConfigFile),
+		LocalPath:        localPath,
+	}
+
+	if !opts.Apply {
+		return res, nil
+	}
+
+	minimal := BuildMinimalLocalConfig(opts.Repo, candidate)
+	if saveErr := SaveLocalConfig(opts.Dir, minimal); saveErr != nil {
+		return res, fmt.Errorf("write %s: %w", localPath, saveErr)
+	}
+	res.WroteLocal = true
+	return res, nil
+}
+
+// unknownKeyError formats a consistent "X not defined; available: [...]" error
+// across profile-mismatch and engine-mismatch paths.
+func unknownKeyError[V any](kind, value string, available map[string]V) error {
+	keys := make([]string, 0, len(available))
+	for k := range available {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Errorf("%s %q not defined; available %ss: [%s]",
+		kind, value, kind, strings.Join(keys, ", "))
+}
+
+func collectAddWarnings(
+	cfg *Config, opts AddOptions, parsedExtras []ExtraWorkflow, resolved []ResolvedWorkflow,
+) []string {
+	profileNames := map[string]bool{}
+	for _, p := range opts.Profiles {
+		prof, ok := cfg.Profiles[p]
+		if !ok {
+			continue
+		}
+		for _, w := range prof.Workflows {
+			profileNames[w.Name] = true
+		}
+	}
+
+	var warnings []string
+	for _, excl := range opts.Excludes {
+		if !profileNames[excl] {
+			warnings = append(warnings, fmt.Sprintf(
+				"--exclude %q did not match any workflow in the selected profile(s); the exclusion is a no-op",
+				excl,
+			))
+		}
+	}
+	for _, extra := range parsedExtras {
+		if profileNames[extra.Name] {
+			warnings = append(warnings, fmt.Sprintf(
+				"--extra-workflow %q shadows a profile workflow; the extra will be dropped by deduplication",
+				extra.Name,
+			))
+		}
+	}
+	if len(resolved) == 0 {
+		warnings = append(warnings,
+			"no workflows resolved for this repo; zero workflows will be deployed (check --profile and --exclude)",
+		)
+	}
+	return warnings
+}
+
+// duplicateRepoError names the source file(s) declaring repo. When LoadConfig
+// loaded only one file, the answer is carried in cfg.LoadedFrom with no disk
+// I/O. In the merged-load case we re-read both files to disambiguate.
+func duplicateRepoError(cfg *Config, dir, repo string) error {
+	basePath := resolve(dir, ConfigFile)
+	localPath := resolve(dir, LocalConfigFile)
+	switch cfg.LoadedFrom {
+	case basePath:
+		return fmt.Errorf("repo %q already exists in %s", repo, ConfigFile)
+	case localPath:
+		return fmt.Errorf("repo %q already exists in %s", repo, LocalConfigFile)
+	}
+
+	var sources []string
+	if base, err := loadConfigFile(basePath); err == nil && base != nil {
+		if _, ok := base.Repos[repo]; ok {
+			sources = append(sources, ConfigFile)
+		}
+	}
+	if local, err := loadConfigFile(localPath); err == nil && local != nil {
+		if _, ok := local.Repos[repo]; ok {
+			sources = append(sources, LocalConfigFile)
+		}
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("repo %q already exists in fleet config", repo)
+	}
+	return fmt.Errorf("repo %q already exists in %s", repo, strings.Join(sources, " + "))
+}
+
+// parseExtraWorkflowSpec accepts three forms:
+//   - `name`                                             → local
+//   - `owner/repo/name@ref`                              → 3-part (agentics)
+//   - `owner/repo/.github/workflows/name.md@ref`         → 4-part (gh-aw)
+func parseExtraWorkflowSpec(s string) (ExtraWorkflow, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return ExtraWorkflow{}, fmt.Errorf(
+			"invalid --extra-workflow %q: empty; expected name | owner/repo/name@ref | owner/repo/.github/workflows/name.md@ref",
+			s,
+		)
+	}
+	if !strings.Contains(trimmed, "/") {
+		return ExtraWorkflow{Name: trimmed, Source: SourceLocal}, nil
+	}
+
+	atIdx := strings.Index(trimmed, "@")
+	if atIdx < 0 {
+		return ExtraWorkflow{}, fmt.Errorf(
+			"invalid --extra-workflow %q: missing @ref; expected owner/repo/name@ref or owner/repo/.github/workflows/name.md@ref",
+			s,
+		)
+	}
+	lhs := trimmed[:atIdx]
+	ref := trimmed[atIdx+1:]
+	if ref == "" {
+		return ExtraWorkflow{}, fmt.Errorf(
+			"invalid --extra-workflow %q: empty ref after @; expected owner/repo/name@ref",
+			s,
+		)
+	}
+	parts := strings.Split(lhs, "/")
+	switch {
+	case len(parts) == extraSpecShortParts:
+		return ExtraWorkflow{
+			Name:   parts[2],
+			Source: parts[0] + "/" + parts[1],
+			Ref:    ref,
+		}, nil
+	case len(parts) >= 5 && parts[2] == ".github" && parts[3] == "workflows":
+		path := strings.Join(parts[2:], "/")
+		name := strings.TrimSuffix(parts[len(parts)-1], ".md")
+		return ExtraWorkflow{
+			Name:   name,
+			Source: parts[0] + "/" + parts[1],
+			Ref:    ref,
+			Path:   path,
+		}, nil
+	default:
+		return ExtraWorkflow{}, fmt.Errorf(
+			"invalid --extra-workflow %q: expected owner/repo/name@ref or owner/repo/.github/workflows/name.md@ref",
+			s,
+		)
+	}
+}
+
+// BuildMinimalLocalConfig builds a Config carrying only Version and a single
+// Repos entry. Defaults / profiles / peer repos are NOT copied — mergeConfigs
+// supplies those at load time from fleet.json.
+func BuildMinimalLocalConfig(repo string, spec RepoSpec) *Config {
+	return &Config{
+		Version: SchemaVersion,
+		Repos:   map[string]RepoSpec{repo: spec},
+	}
+}

--- a/internal/fleet/add.go
+++ b/internal/fleet/add.go
@@ -112,7 +112,11 @@ func Add(cfg *Config, opts AddOptions) (*AddResult, error) {
 
 	// Insert the candidate transiently so ResolveRepoWorkflows sees it in
 	// the merged view. Always remove before returning — the caller's Config
-	// must not carry unpersisted state.
+	// must not carry unpersisted state. cfg.Repos may be nil when a config
+	// file omits the "repos" key; initialize defensively before writing.
+	if cfg.Repos == nil {
+		cfg.Repos = make(map[string]RepoSpec)
+	}
 	cfg.Repos[opts.Repo] = candidate
 	resolved, err := cfg.ResolveRepoWorkflows(opts.Repo)
 	delete(cfg.Repos, opts.Repo)

--- a/internal/fleet/add_test.go
+++ b/internal/fleet/add_test.go
@@ -1,0 +1,647 @@
+package fleet
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestValidateSlug(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantOut    string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{name: "simple lowercase", in: "rshade/gh-aw-fleet", wantOut: "rshade/gh-aw-fleet"},
+		{name: "dots allowed", in: "acme/foo.bar", wantOut: "acme/foo.bar"},
+		{name: "underscores allowed", in: "acme/foo_bar", wantOut: "acme/foo_bar"},
+		{name: "uppercase normalized", in: "Owner/Repo", wantOut: "owner/repo"},
+		{name: "mixed case normalized", in: "GitHub/gh-AW", wantOut: "github/gh-aw"},
+		{name: "leading/trailing whitespace trimmed", in: "  rshade/foo  ", wantOut: "rshade/foo"},
+
+		// Error cases — each error must contain "owner/repo" as a valid example.
+		{name: "empty", in: "", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "whitespace only", in: "   ", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "no slash", in: "justaword", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "too many slashes", in: "owner/repo/extra", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "empty owner half", in: "/repo", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "empty repo half", in: "owner/", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "whitespace owner half", in: "  /repo", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "whitespace repo half", in: "owner/  ", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "invalid char in owner", in: "owner!/repo", wantErr: true, wantErrSub: "owner/repo"},
+		{name: "space inside half", in: "owner name/repo", wantErr: true, wantErrSub: "owner/repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateSlug(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got output %q", tt.in, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain expected substring %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if got != tt.wantOut {
+				t.Errorf("ValidateSlug(%q) = %q, want %q", tt.in, got, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestBuildMinimalLocalConfig(t *testing.T) {
+	spec := RepoSpec{Profiles: []string{"default"}}
+	cfg := BuildMinimalLocalConfig("rshade/foo", spec)
+
+	if cfg.Version != SchemaVersion {
+		t.Errorf("Version = %d, want %d", cfg.Version, SchemaVersion)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("Repos has %d entries, want 1", len(cfg.Repos))
+	}
+	if _, ok := cfg.Repos["rshade/foo"]; !ok {
+		t.Errorf("Repos does not contain rshade/foo; got %+v", cfg.Repos)
+	}
+
+	// Round-trip through JSON and assert exactly two top-level keys.
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if unmarshalErr := json.Unmarshal(data, &raw); unmarshalErr != nil {
+		t.Fatalf("json.Unmarshal: %v", unmarshalErr)
+	}
+	gotKeys := make([]string, 0, len(raw))
+	for k := range raw {
+		gotKeys = append(gotKeys, k)
+	}
+	sort.Strings(gotKeys)
+	wantKeys := []string{"repos", "version"}
+	if !slices.Equal(gotKeys, wantKeys) {
+		t.Errorf(
+			"top-level keys = %v, want exactly %v (no defaults, no profiles per FR-015)",
+			gotKeys, wantKeys,
+		)
+	}
+	var repos map[string]RepoSpec
+	if err := json.Unmarshal(raw["repos"], &repos); err != nil {
+		t.Fatalf("unmarshal repos: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Errorf("repos has %d entries, want 1", len(repos))
+	}
+}
+
+// seedBaseConfigWithDefaultProfile writes a fleet.json to dir with a single
+// "default" profile that contains two workflows from a fake "upstream/x"
+// source. Returns the loaded (merged) Config, matching what LoadConfig
+// would produce for that state.
+func seedBaseConfigWithDefaultProfile(t *testing.T, dir string) *Config {
+	t.Helper()
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"upstream/x": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "workflow-a", Source: "upstream/x"},
+					{Name: "workflow-b", Source: "upstream/x"},
+				},
+			},
+			"experimental": {
+				Sources:   map[string]SourcePin{"upstream/x": {Ref: "main"}},
+				Workflows: []ProfileWorkflow{{Name: "workflow-c", Source: "upstream/x"}},
+			},
+		},
+		Repos: map[string]RepoSpec{},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
+	basePath := filepath.Join(dir, ConfigFile)
+	if writeErr := os.WriteFile(basePath, append(data, '\n'), 0o600); writeErr != nil {
+		t.Fatalf("seed fleet.json: %v", writeErr)
+	}
+	loaded, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig after seed: %v", err)
+	}
+	return loaded
+}
+
+func TestAdd_DryRun_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	opts := AddOptions{
+		Repo:     "rshade/new-repo",
+		Profiles: []string{"default"},
+		Dir:      dir,
+	}
+	res, err := Add(cfg, opts)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if res.Repo != "rshade/new-repo" {
+		t.Errorf("Repo = %q, want rshade/new-repo", res.Repo)
+	}
+	if !slices.Equal(res.Profiles, []string{"default"}) {
+		t.Errorf("Profiles = %v, want [default]", res.Profiles)
+	}
+	if len(res.Resolved) != 2 {
+		t.Errorf("Resolved count = %d, want 2", len(res.Resolved))
+	}
+	if res.WroteLocal {
+		t.Errorf("WroteLocal = true, want false for dry-run")
+	}
+	// Assert no fleet.local.json was created in the temp dir.
+	if _, err := os.Stat(filepath.Join(dir, LocalConfigFile)); !os.IsNotExist(err) {
+		t.Errorf("fleet.local.json exists after dry-run: stat err=%v", err)
+	}
+}
+
+func TestAdd_Apply_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	basePath := filepath.Join(dir, ConfigFile)
+	baseBefore, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("read fleet.json: %v", err)
+	}
+
+	opts := AddOptions{
+		Repo:      "rshade/new-repo",
+		Profiles:  []string{"default"},
+		Apply:     true,
+		Confirmed: true,
+		Dir:       dir,
+	}
+	res, err := Add(cfg, opts)
+	if err != nil {
+		t.Fatalf("Add --apply: %v", err)
+	}
+	if !res.WroteLocal {
+		t.Errorf("WroteLocal = false, want true")
+	}
+
+	localPath := filepath.Join(dir, LocalConfigFile)
+	localData, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read fleet.local.json: %v", err)
+	}
+	wantMinimal, err := json.MarshalIndent(
+		BuildMinimalLocalConfig("rshade/new-repo", RepoSpec{Profiles: []string{"default"}}),
+		"", "  ",
+	)
+	if err != nil {
+		t.Fatalf("marshal expected minimal: %v", err)
+	}
+	if strings.TrimRight(string(localData), "\n") != string(wantMinimal) {
+		t.Errorf(
+			"fleet.local.json contents differ from BuildMinimalLocalConfig output\ngot:\n%s\nwant:\n%s",
+			localData, wantMinimal,
+		)
+	}
+
+	baseAfter, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("re-read fleet.json: %v", err)
+	}
+	if string(baseBefore) != string(baseAfter) {
+		t.Errorf("fleet.json was modified by Add --apply")
+	}
+}
+
+func TestAdd_Apply_SynthesizesLocalFromJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	// Sanity: fleet.local.json does not exist yet.
+	if _, err := os.Stat(filepath.Join(dir, LocalConfigFile)); !os.IsNotExist(err) {
+		t.Fatalf("precondition failed: fleet.local.json already exists")
+	}
+
+	opts := AddOptions{
+		Repo:      "rshade/new-repo",
+		Profiles:  []string{"default"},
+		Apply:     true,
+		Confirmed: true,
+		Dir:       dir,
+	}
+	res, err := Add(cfg, opts)
+	if err != nil {
+		t.Fatalf("Add --apply: %v", err)
+	}
+	if !res.SynthesizedLocal {
+		t.Errorf("SynthesizedLocal = false, want true when fleet.local.json did not exist")
+	}
+	if _, err := os.Stat(filepath.Join(dir, LocalConfigFile)); err != nil {
+		t.Errorf("fleet.local.json was not created: %v", err)
+	}
+}
+
+func TestAdd_DuplicateRepo_NamesSourceFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		inBase       bool
+		inLocal      bool
+		wantContains []string
+	}{
+		{
+			name:         "exists in fleet.json only",
+			inBase:       true,
+			wantContains: []string{"rshade/existing", ConfigFile},
+		},
+		{
+			name:         "exists in fleet.local.json only",
+			inLocal:      true,
+			wantContains: []string{"rshade/existing", LocalConfigFile},
+		},
+		{
+			name:         "exists in both",
+			inBase:       true,
+			inLocal:      true,
+			wantContains: []string{"rshade/existing", ConfigFile, LocalConfigFile},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			base := &Config{
+				Version: SchemaVersion,
+				Profiles: map[string]Profile{
+					"default": {
+						Sources:   map[string]SourcePin{"upstream/x": {Ref: "v1.0.0"}},
+						Workflows: []ProfileWorkflow{{Name: "workflow-a", Source: "upstream/x"}},
+					},
+				},
+				Repos: map[string]RepoSpec{},
+			}
+			if tt.inBase {
+				base.Repos["rshade/existing"] = RepoSpec{Profiles: []string{"default"}}
+			}
+			baseData, _ := json.MarshalIndent(base, "", "  ")
+			if err := os.WriteFile(filepath.Join(dir, ConfigFile), append(baseData, '\n'), 0o600); err != nil {
+				t.Fatalf("seed fleet.json: %v", err)
+			}
+
+			if tt.inLocal {
+				local := &Config{
+					Version: SchemaVersion,
+					Repos:   map[string]RepoSpec{"rshade/existing": {Profiles: []string{"default"}}},
+				}
+				localData, _ := json.MarshalIndent(local, "", "  ")
+				localPath := filepath.Join(dir, LocalConfigFile)
+				if err := os.WriteFile(localPath, append(localData, '\n'), 0o600); err != nil {
+					t.Fatalf("seed fleet.local.json: %v", err)
+				}
+			}
+
+			cfg, err := LoadConfig(dir)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+
+			opts := AddOptions{
+				Repo:     "rshade/existing",
+				Profiles: []string{"default"},
+				Dir:      dir,
+			}
+			_, addErr := Add(cfg, opts)
+			if addErr == nil {
+				t.Fatal("Add returned nil error for duplicate repo")
+			}
+			msg := addErr.Error()
+			for _, sub := range tt.wantContains {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q does not contain %q", msg, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestAdd_UnknownProfile_ListsAvailable(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	opts := AddOptions{
+		Repo:     "rshade/foo",
+		Profiles: []string{"nonexistent"},
+		Dir:      dir,
+	}
+	_, err := Add(cfg, opts)
+	if err == nil {
+		t.Fatal("Add returned nil error for unknown profile")
+	}
+	msg := err.Error()
+	for _, sub := range []string{"nonexistent", "default", "experimental"} {
+		if !strings.Contains(msg, sub) {
+			t.Errorf("error %q does not contain %q", msg, sub)
+		}
+	}
+	// Profile list must be alphabetically sorted. "default" < "experimental".
+	if strings.Index(msg, "default") > strings.Index(msg, "experimental") {
+		t.Errorf("profile list not alphabetically sorted in %q", msg)
+	}
+}
+
+func TestParseExtraWorkflowSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    ExtraWorkflow
+		wantErr bool
+	}{
+		{
+			name: "bare name → local",
+			in:   "my-local-thing",
+			want: ExtraWorkflow{Name: "my-local-thing", Source: "local"},
+		},
+		{
+			name: "3-part agentics with ref",
+			in:   "githubnext/agentics/security-guardian@v0.4.1",
+			want: ExtraWorkflow{
+				Name:   "security-guardian",
+				Source: "githubnext/agentics",
+				Ref:    "v0.4.1",
+			},
+		},
+		{
+			name: "4-part gh-aw with ref",
+			in:   "github/gh-aw/.github/workflows/custom.md@v0.68.3",
+			want: ExtraWorkflow{
+				Name:   "custom",
+				Source: "github/gh-aw",
+				Ref:    "v0.68.3",
+				Path:   ".github/workflows/custom.md",
+			},
+		},
+
+		// Error cases.
+		{name: "3-part without ref", in: "owner/repo/name", wantErr: true},
+		{name: "owner/repo alone", in: "owner/repo", wantErr: true},
+		{name: "empty ref after @", in: "owner/repo/name@", wantErr: true},
+		{name: "malformed path prefix", in: "owner/repo/foo/bar.md@v1", wantErr: true},
+		{name: "empty string", in: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExtraWorkflowSpec(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %+v", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseExtraWorkflowSpec(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdd_UnknownEngine(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	opts := AddOptions{
+		Repo:     "rshade/foo",
+		Profiles: []string{"default"},
+		Engine:   "fictional-engine",
+		Dir:      dir,
+	}
+	_, err := Add(cfg, opts)
+	if err == nil {
+		t.Fatal("Add returned nil error for unknown engine")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "fictional-engine") {
+		t.Errorf("error %q does not name rejected engine", msg)
+	}
+	for _, engine := range []string{"claude", "codex", "copilot", "gemini"} {
+		if !strings.Contains(msg, engine) {
+			t.Errorf("error %q does not list %q", msg, engine)
+		}
+	}
+	// Engine list must be alphabetically sorted.
+	last := -1
+	for _, engine := range []string{"claude", "codex", "copilot", "gemini"} {
+		idx := strings.Index(msg, engine)
+		if idx <= last {
+			t.Errorf("engine list not alphabetically sorted in %q (found %q at %d, prev %d)", msg, engine, idx, last)
+		}
+		last = idx
+	}
+}
+
+func TestAdd_CustomizationFlags_WriteCorrectSpec(t *testing.T) {
+	dir := t.TempDir()
+	cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+	opts := AddOptions{
+		Repo:     "rshade/foo",
+		Profiles: []string{"default"},
+		Engine:   "claude",
+		Excludes: []string{"workflow-a"},
+		ExtraWorkflows: []string{
+			"my-local",
+			"githubnext/agentics/security-guardian@v0.4.1",
+		},
+		Apply:     true,
+		Confirmed: true,
+		Dir:       dir,
+	}
+	res, err := Add(cfg, opts)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !res.WroteLocal {
+		t.Fatal("WroteLocal = false")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, LocalConfigFile))
+	if err != nil {
+		t.Fatalf("read fleet.local.json: %v", err)
+	}
+	var written Config
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parse fleet.local.json: %v", err)
+	}
+	spec, ok := written.Repos["rshade/foo"]
+	if !ok {
+		t.Fatal("rshade/foo missing from written file")
+	}
+	if spec.Engine != "claude" {
+		t.Errorf("Engine = %q, want claude", spec.Engine)
+	}
+	if !slices.Equal(spec.ExcludeFromProfiles, []string{"workflow-a"}) {
+		t.Errorf("ExcludeFromProfiles = %v, want [workflow-a]", spec.ExcludeFromProfiles)
+	}
+	if len(spec.ExtraWorkflows) != 2 {
+		t.Fatalf("ExtraWorkflows len = %d, want 2", len(spec.ExtraWorkflows))
+	}
+	if spec.ExtraWorkflows[0].Source != "local" || spec.ExtraWorkflows[0].Name != "my-local" {
+		t.Errorf("ExtraWorkflows[0] = %+v, want local/my-local", spec.ExtraWorkflows[0])
+	}
+	if spec.ExtraWorkflows[1].Source != "githubnext/agentics" ||
+		spec.ExtraWorkflows[1].Ref != "v0.4.1" ||
+		spec.ExtraWorkflows[1].Name != "security-guardian" {
+		t.Errorf("ExtraWorkflows[1] = %+v", spec.ExtraWorkflows[1])
+	}
+}
+
+func TestAdd_Warnings(t *testing.T) {
+	t.Run("no-op exclude", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+		opts := AddOptions{
+			Repo:     "rshade/foo",
+			Profiles: []string{"default"},
+			Excludes: []string{"does-not-exist"},
+			Dir:      dir,
+		}
+		res, err := Add(cfg, opts)
+		if err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if len(res.Warnings) == 0 {
+			t.Fatal("expected a warning for no-op exclude")
+		}
+		found := false
+		for _, w := range res.Warnings {
+			if strings.Contains(w, "does-not-exist") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("warnings %v do not mention the no-op exclude name", res.Warnings)
+		}
+	})
+
+	t.Run("shadowed extra", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+		opts := AddOptions{
+			Repo:           "rshade/foo",
+			Profiles:       []string{"default"},
+			ExtraWorkflows: []string{"workflow-a"}, // already in default
+			Dir:            dir,
+		}
+		res, err := Add(cfg, opts)
+		if err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		found := false
+		for _, w := range res.Warnings {
+			if strings.Contains(w, "workflow-a") && strings.Contains(w, "shadow") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("warnings %v do not mention the shadowed extra", res.Warnings)
+		}
+	})
+
+	t.Run("zero resolved workflows", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := seedBaseConfigWithDefaultProfile(t, dir)
+
+		opts := AddOptions{
+			Repo:     "rshade/foo",
+			Profiles: []string{"default"},
+			Excludes: []string{"workflow-a", "workflow-b"},
+			Dir:      dir,
+		}
+		res, err := Add(cfg, opts)
+		if err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if len(res.Resolved) != 0 {
+			t.Fatalf("expected 0 resolved workflows, got %d", len(res.Resolved))
+		}
+		found := false
+		for _, w := range res.Warnings {
+			if strings.Contains(w, "zero") || strings.Contains(w, "no workflows") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("warnings %v do not mention zero-resolved condition", res.Warnings)
+		}
+	})
+}
+
+func TestSaveLocalConfig_WritesLocalFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a fleet.json so we can assert it is NOT touched.
+	baseCfg := &Config{
+		Version:  SchemaVersion,
+		Profiles: map[string]Profile{"default": {}},
+	}
+	baseData, err := json.MarshalIndent(baseCfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
+	basePath := filepath.Join(dir, ConfigFile)
+	if writeErr := os.WriteFile(basePath, append(baseData, '\n'), 0o600); writeErr != nil {
+		t.Fatalf("seed fleet.json: %v", writeErr)
+	}
+	baseBefore, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("read fleet.json: %v", err)
+	}
+
+	localCfg := BuildMinimalLocalConfig("rshade/foo", RepoSpec{Profiles: []string{"default"}})
+	if err := SaveLocalConfig(dir, localCfg); err != nil {
+		t.Fatalf("SaveLocalConfig: %v", err)
+	}
+
+	localPath := filepath.Join(dir, LocalConfigFile)
+	if _, err := os.Stat(localPath); err != nil {
+		t.Fatalf("fleet.local.json not created: %v", err)
+	}
+
+	localData, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read fleet.local.json: %v", err)
+	}
+	var roundTrip Config
+	if err := json.Unmarshal(localData, &roundTrip); err != nil {
+		t.Fatalf("parse fleet.local.json: %v", err)
+	}
+	if _, ok := roundTrip.Repos["rshade/foo"]; !ok {
+		t.Errorf("round-tripped fleet.local.json missing rshade/foo: %+v", roundTrip.Repos)
+	}
+
+	baseAfter, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("re-read fleet.json: %v", err)
+	}
+	if string(baseBefore) != string(baseAfter) {
+		t.Errorf("fleet.json was modified by SaveLocalConfig\nbefore: %s\nafter:  %s", baseBefore, baseAfter)
+	}
+}

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -107,7 +107,7 @@ func addResolvedWorkflows(
 	ctx context.Context, res *DeployResult, resolved []ResolvedWorkflow, opts DeployOpts, engine string,
 ) {
 	for _, w := range resolved {
-		if w.Source == "local" {
+		if w.Source == SourceLocal {
 			continue
 		}
 		if fileExists(filepath.Join(res.CloneDir, ".github/workflows", w.Name+".md")) && !opts.Force {

--- a/internal/fleet/load.go
+++ b/internal/fleet/load.go
@@ -11,6 +11,10 @@ const (
 	ConfigFile      = "fleet.json"
 	LocalConfigFile = "fleet.local.json"
 	TemplatesFile   = "templates.json"
+
+	// SourceLocal marks an ExtraWorkflow / ResolvedWorkflow as living in the
+	// target repo itself (no upstream fetch; `gh aw add` takes a local path).
+	SourceLocal = "local"
 )
 
 // LoadConfig reads fleet.json as the base config, then overlays fleet.local.json if present.
@@ -92,9 +96,10 @@ func mergeConfigs(base, local *Config) *Config {
 	return &merged
 }
 
-// SaveConfig writes fleet.json atomically to the given directory.
-func SaveConfig(dir string, c *Config) error {
-	path := resolve(dir, ConfigFile)
+// SaveLocalConfig writes fleet.local.json atomically to the given directory.
+// No symmetric SaveConfig exists: fleet.json is read-only from this package.
+func SaveLocalConfig(dir string, c *Config) error {
+	path := resolve(dir, LocalConfigFile)
 	return writeJSON(path, c)
 }
 
@@ -211,7 +216,7 @@ type ResolvedWorkflow struct {
 // 3-part form: "owner/repo/name@ref".
 // Local workflows pass through unchanged.
 func (r ResolvedWorkflow) Spec() string {
-	if r.Source == "local" {
+	if r.Source == SourceLocal {
 		if r.Path != "" {
 			return r.Path
 		}

--- a/internal/fleet/schema.go
+++ b/internal/fleet/schema.go
@@ -9,8 +9,8 @@ const SchemaVersion = 1
 // `fleet sync` and `fleet upgrade` reconcile repos toward it.
 type Config struct {
 	Version    int                 `json:"version"`
-	Defaults   Defaults            `json:"defaults"`
-	Profiles   map[string]Profile  `json:"profiles"`
+	Defaults   Defaults            `json:"defaults,omitzero"`
+	Profiles   map[string]Profile  `json:"profiles,omitempty"`
 	Repos      map[string]RepoSpec `json:"repos"`
 	LoadedFrom string              `json:"-"`
 }

--- a/profiles/default.json
+++ b/profiles/default.json
@@ -2,7 +2,7 @@
   "description": "Baseline profile. Workflows pulled from agentics (the curated library) wherever an equivalent exists; gh-aw only for dogfooded items with no agentics counterpart (audit-workflows, docs-noob-tester, mergefest).",
   "sources": {
     "github/gh-aw": { "ref": "v0.68.3" },
-    "githubnext/agentics": { "ref": "main" }
+    "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
   },
   "workflows": [
     { "name": "audit-workflows",          "source": "github/gh-aw" },

--- a/skills/fleet-onboard-repo/SKILL.md
+++ b/skills/fleet-onboard-repo/SKILL.md
@@ -52,49 +52,33 @@ Ask the user for each of these. Propose defaults based on the repo's shape (lang
 
 Don't ask about deploy timing yet — that question makes more sense after the user has seen and approved the actual JSON diff (Step 3). Asking too early forces them to commit to a flow before they know what's being registered.
 
-### Step 3 — compose the fleet.local.json edit, confirm, then ask about deploy timing
+### Step 3 — dry-run `add` to preview the registration
 
-Read the current `fleet.local.json`:
+Run the `add` subcommand in dry-run mode (default) to see what would be registered:
 
 ```bash
-jq '.repos' fleet.local.json
+go run . add <owner>/<repo> --profile default
 ```
 
-Compose the new entry. For most repos, this is tight:
+With exclusions or other customizations:
 
-```json
-"<owner>/<repo>": {
-  "profiles": ["default"]
-}
+```bash
+go run . add <owner>/<repo> \
+    --profile default \
+    --exclude daily-doc-updater --exclude docs-noob-tester
 ```
 
-With exclusions:
-
-```json
-"<owner>/<repo>": {
-  "profiles": ["default"],
-  "exclude": ["daily-doc-updater", "docs-noob-tester"]
-}
-```
-
-Show the user the diff — either the single new entry, or the full `repos` section with the entry added. Get explicit confirmation.
-
-Once the user approves the diff, **then** ask about the follow-up:
+Dry-run prints (stderr) `would add <owner>/<repo> with profiles [default] (N workflows)` plus the workflow list on stdout. No file is written. Show the user the preview, then ask about the follow-up:
 
 > "After registering, deploy immediately via `fleet-deploy`, or just register for now?"
 
-This lets them see exactly what's being registered before committing to a next step.
-
-### Step 4 — write fleet.local.json
-
-Use `jq` for atomic edits (avoid hand-editing JSON to preserve formatting):
+### Step 4 — apply
 
 ```bash
-jq '.repos["<owner>/<repo>"] = {
-  "profiles": ["default"],
-  "exclude": ["daily-doc-updater", "docs-noob-tester"]
-}' fleet.local.json > fleet.local.json.tmp && mv fleet.local.json.tmp fleet.local.json
+go run . add <owner>/<repo> --profile default --apply --yes
 ```
+
+The command writes `fleet.local.json` atomically and never touches `fleet.json`. If `fleet.local.json` didn't exist, it's synthesized as a minimal file (only `version` + the new repo entry); profiles and defaults continue to resolve from `fleet.json`.
 
 ### Step 5 — verify
 
@@ -108,7 +92,7 @@ Confirm:
 - Engine shows the expected value.
 - `(loaded fleet.local.json)` appears at the top (not `fleet.json` — proving our edit hit the right file).
 
-If anything is off, roll back the jq edit and restart.
+If anything is off, delete the `fleet.local.json` entry (or the whole file if this was the first `add`) and restart.
 
 ### Step 6 — hand off to fleet-deploy
 
@@ -127,8 +111,8 @@ If the user said "register only":
 
 - **Never edit `fleet.json`** in this skill. That file is the committed public example. If it accidentally contains private repo names, flag that as a bug — they shouldn't be there.
 - **Never commit `fleet.local.json`**. It's in `.gitignore` by design. Don't suggest `git add fleet.local.json`.
-- **Always verify via `go run . list`** after edits. Syntactic errors in fleet.local.json would show up as parse errors — catching them before handoff saves a confused deploy run.
-- **Use `jq` for atomic writes**. Hand-editing multi-line JSON risks stray commas / trailing-comma bugs. `jq` produces valid output.
+- **Always verify via `go run . list`** after `--apply`. Syntactic errors would show up as parse errors — catching them before handoff saves a confused deploy run.
+- **Never hand-edit `fleet.local.json`** in this flow. Use `go run . add ... --apply --yes`. The tool handles atomic writes and schema correctness; hand-editing risks stray commas or drift from the `RepoSpec` schema.
 - **Don't suggest editing `profiles/` or `fleet.json` profile definitions** as part of onboarding. If a new repo needs a workflow that's not in any existing profile, that's a separate discussion (often involving `fleet-eval-templates` to check the upstream catalog first).
 - **Scope the gh repo view check** to basic info only. Don't read the target repo's code; that's noise and potential privacy leak.
 
@@ -196,8 +180,9 @@ You:
 User: looks good, deploy immediately
 
 You:
-  - jq-edit fleet.local.json. Verify with `go run . list`.
-  - Hand off to fleet-deploy flow. Dry-run rshade/finfocus-style three-turn pattern begins.
+  - Run `go run . add HavenTrack/user-service --profile default --exclude daily-doc-updater --exclude docs-noob-tester --apply --yes`.
+  - Verify with `go run . list`.
+  - Hand off to fleet-deploy flow. Dry-run three-turn pattern begins.
 ```
 
 ### Example 2 — library with docs
@@ -214,7 +199,8 @@ You:
 User: register only
 
 You:
-  - Edit fleet.local.json. Verify list. Report registered + next-step command.
+  - Run `go run . add rshade/opencommit --profile default --profile docs-plus --profile community-plus --apply --yes`.
+  - Verify with `go run . list`. Report registered + next-step command.
 ```
 
 ### Example 3 — user said "deploy to X" but X isn't tracked

--- a/specs/001-add-subcommand/checklists/requirements.md
+++ b/specs/001-add-subcommand/checklists/requirements.md
@@ -1,0 +1,56 @@
+# Specification Quality Checklist: `add <owner/repo>` Subcommand for Fleet Onboarding
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- **Reviewer note on "no implementation details"**: The spec does
+  reference the existing codebase entities (`LoadConfig`,
+  `RepoSpec`, `SaveConfig`, `writeJSON`, `ResolveRepoWorkflows`,
+  `EngineSecrets`) because this is a refactor/extension of an
+  existing internal package with a tight operator-facing surface
+  — the spec must anchor to the code that already exists to be
+  testable. These references describe *existing behavior the
+  feature must preserve or extend*, not *how the new code will
+  be implemented*. Planning (`/speckit.plan`) will make the
+  actual implementation-structure decisions.
+- **Clarification sessions 2026-04-19**: 4 total questions
+  asked across two sessions. See `## Clarifications` section in
+  `spec.md`.
+  Resolved: `--extra-workflow` spec syntax (FR-008), engine
+  validation source (FR-006), preview output format (FR-013),
+  `fleet.local.json` synthesis semantics (FR-015 — minimal
+  file, leans on `mergeConfigs`).
+  Deferred to planning: `--profile` flag implementation
+  (StringArray vs StringSlice), `SaveConfig` helper strategy
+  (rename vs. new function), warning emission rules for
+  no-op `--exclude` / shadowed `--extra-workflow` (details of
+  FR-013 warning text).

--- a/specs/001-add-subcommand/contracts/cli.md
+++ b/specs/001-add-subcommand/contracts/cli.md
@@ -1,0 +1,213 @@
+# CLI Contract: `gh-aw-fleet add`
+
+**Phase**: 1 (contracts)
+**Feature**: `specs/001-add-subcommand`
+
+This document is the authoritative reference for the CLI surface
+introduced by this feature. Anything an operator (or a script, or a
+skill) sees at the command line is covered here.
+
+## Synopsis
+
+```text
+gh-aw-fleet add <owner/repo>
+    --profile <name>[,<name>...]      (required, repeatable)
+    [--engine <name>]                 (optional, single-value)
+    [--exclude <workflow-name>]       (optional, repeatable)
+    [--extra-workflow <spec>]         (optional, repeatable)
+    [--apply]                         (default: dry-run)
+    [--yes]                           (required with --apply in non-TTY)
+    [--dir <path>]                    (inherited from root; working dir)
+```
+
+## Arguments
+
+### Positional: `<owner/repo>`
+
+- **Required.** Exactly one argument.
+- Must be in `owner/repo` form: two non-empty `[a-z0-9._-]+` halves
+  separated by a single `/`.
+- Normalized to lowercase before any comparison or write.
+- Examples (valid): `rshade/gh-aw-fleet`, `acme/foo.bar`,
+  `Owner/Repo` (normalized to `owner/repo`).
+- Examples (invalid): `` (empty), `justaword` (no slash),
+  `owner/` (empty half), `/repo` (empty half),
+  `owner/repo/extra` (too many slashes), `owner with space/repo`.
+
+## Flags
+
+### `--profile <name>` (required, repeatable or comma-separated)
+
+- At least one profile **must** be specified.
+- May be passed multiple times (`--profile a --profile b`) or as a
+  single comma-separated value (`--profile a,b`). Both forms
+  produce identical behavior (see `research.md §1`).
+- Every name must exist in the merged `cfg.Profiles` map. A name
+  that does not exist causes a non-zero exit with a message listing
+  available profile names.
+
+### `--engine <name>` (optional, single-value)
+
+- Default: absent (repo inherits `cfg.Defaults.Engine`).
+- Accepted values: the keys of `EngineSecrets` in
+  `internal/fleet/deploy.go`. Current values at time of writing:
+  `copilot`, `claude`, `codex`, `gemini`.
+- Unknown value causes a non-zero exit with a message listing
+  accepted engine names.
+
+### `--exclude <workflow-name>` (optional, repeatable)
+
+- Each occurrence adds one name to `RepoSpec.ExcludeFromProfiles`.
+- No validation against the selected profiles' workflow lists; a
+  name that matches nothing triggers a **warning** on stderr but
+  does NOT fail (see `research.md §3`).
+
+### `--extra-workflow <spec>` (optional, repeatable)
+
+- Each occurrence adds one entry to `RepoSpec.ExtraWorkflows`.
+- Accepted forms (FR-008):
+  - `name` → local workflow (`Source: "local"`, no `Ref`, no `Path`).
+  - `owner/repo/name@ref` → agentics 3-part form (`Source:
+    "owner/repo"`, `Ref: ref`, no `Path`).
+  - `owner/repo/.github/workflows/name.md@ref` → gh-aw 4-part form
+    (`Source: "owner/repo"`, `Ref: ref`, `Path:
+    ".github/workflows/name.md"`).
+- Any other form causes a non-zero exit with a message showing the
+  three valid forms.
+
+### `--apply` (boolean, default: false)
+
+- Default (false): dry-run. Validates, resolves, prints preview.
+  No file mutation.
+- `--apply`: after validation succeeds AND confirmation is
+  obtained, write `fleet.local.json`.
+
+### `--yes` (boolean, default: false)
+
+- Confirms `--apply` without an interactive prompt.
+- Required when stdin is not a TTY (CI, piped shells). Attempting
+  `--apply` in a non-TTY without `--yes` exits 1 with the message:
+  `--apply requires --yes in a non-interactive shell`.
+- Ignored in dry-run mode (log once as "ignored: --yes has no
+  effect without --apply" on stderr).
+
+### `--dir <path>` (inherited from root)
+
+- Working directory containing `fleet.json` and/or
+  `fleet.local.json`. Default: `"."`.
+
+## Stdin
+
+- Used **only** for the interactive confirmation prompt when
+  `--apply` is passed without `--yes` and stdin is a TTY.
+- Not consumed for any other purpose.
+- Prompt text: `Write fleet.local.json? [y/N] `.
+- Accepted responses (case-insensitive): `y`, `yes`.
+- Any other input (including empty / EOF) aborts with exit 1 and
+  the message `aborted: re-run with --apply --yes to confirm`.
+
+## Stdout
+
+### Dry-run mode
+
+- One line per resolved workflow, format: `- <workflow-name>`.
+- Order: profile-member workflows (in profile resolution order),
+  then extras.
+- No other output on stdout.
+
+### `--apply` success
+
+- Same workflow list as dry-run (for consistency — operators who
+  pipe stdout get the same payload regardless of mode).
+
+### Error paths
+
+- Nothing on stdout when validation fails before resolve.
+
+## Stderr
+
+### Dry-run mode
+
+1. Header: `would add <repo> with profiles [<csv>] (<N> workflows)`
+2. Engine override line (only if `--engine` passed):
+   `engine override: <name>`
+3. Zero or more warnings, each prefixed `warning: `.
+4. Final hint: `next: re-run with --apply to persist`
+
+### `--apply` success
+
+1. File-transition notice (only when synthesizing a new
+   `fleet.local.json` from a `fleet.json`-only baseline):
+   `creating fleet.local.json (minimal; profiles/defaults still resolved from fleet.json)`
+2. Header: `added <repo> with profiles [<csv>] (<N> workflows)`
+   (tense shift from "would add" to "added" signals success).
+3. Engine override line (if applicable).
+4. Zero or more warnings, same format as dry-run.
+5. Final hint: `next: gh-aw-fleet deploy <repo>`
+
+### Error paths
+
+- Single `error: <message>` line followed by any applicable
+  remediation hint (engine list, profile list, slug example, etc.).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Dry-run success OR `--apply` success |
+| 1 | Any validation or write failure |
+
+`add` never returns exit codes other than 0 or 1. Future commands
+(`remove`, `status`) MAY introduce codes 2+ for distinct outcomes;
+`add` deliberately stays binary to keep scripting trivial.
+
+## Environment variables
+
+None read or written by `add`. `LoadConfig` honors the existing
+`--dir` flag; no new env vars are introduced.
+
+## Idempotence
+
+`add` is **not** idempotent. Re-running `add owner/repo --profile X
+--apply --yes` after a successful first run returns exit 1 with
+the duplicate-repo error. This is intentional: shadowing or
+re-assigning profile membership is not a well-defined operation in
+v1 (see spec.md's "Out of Scope" and the shadowing edge case).
+
+## Example invocations
+
+```bash
+# Dry-run a simple onboarding:
+gh-aw-fleet add rshade/foo --profile default
+
+# Onboard with customization:
+gh-aw-fleet add rshade/foo \
+    --profile default \
+    --engine claude \
+    --exclude ci-doctor \
+    --extra-workflow my-local-thing \
+    --apply --yes
+
+# Onboard a repo that needs a pinned remote extra:
+gh-aw-fleet add rshade/foo \
+    --profile default \
+    --extra-workflow githubnext/agentics/security-guardian@v0.4.1 \
+    --apply --yes
+```
+
+## Changes to other commands
+
+None. `deploy`, `list`, `sync`, `upgrade`, `template` are
+unchanged by this feature.
+
+## Tests required to cover this contract
+
+See `research.md §9` for the full test matrix. Every row in every
+table above (arguments, flags, stdout, stderr, exit codes) MUST
+be exercised by a case in either `TestAdd_DryRun` or `TestAdd_Apply`
+in `internal/fleet/add_test.go`, except for:
+
+- The interactive TTY prompt path (not easily unit-testable;
+  covered by manual integration verification in `quickstart.md`).
+- The `--dir` flag (inherited unchanged from root; already tested
+  transitively by other subcommands).

--- a/specs/001-add-subcommand/data-model.md
+++ b/specs/001-add-subcommand/data-model.md
@@ -1,0 +1,187 @@
+# Data Model: `add <owner/repo>` Subcommand
+
+**Phase**: 1 (design & contracts)
+**Feature**: `specs/001-add-subcommand`
+
+This document defines the new types introduced by this feature and
+reiterates the existing types it composes with. Existing types
+(defined elsewhere) are documented here only for interface clarity;
+the authoritative definitions remain in `internal/fleet/schema.go`
+and `internal/fleet/load.go`.
+
+## New types (introduced by this feature)
+
+### `AddOptions` (in `internal/fleet/add.go`)
+
+The in-memory representation of command-line intent. Populated by
+`cmd/add.go` from cobra flags, then passed to `fleet.Add()`.
+
+```go
+type AddOptions struct {
+    Repo           string   // Normalized "owner/repo" (lowercased, trimmed).
+    Profiles       []string // Profile names to assign. Length >= 1 enforced.
+    Engine         string   // Optional engine override. "" means no override.
+    Excludes       []string // Workflow names to exclude from profile members.
+    ExtraWorkflows []string // Raw --extra-workflow flag values (parsed inside Add).
+    Apply          bool     // false = dry-run; true = write to fleet.local.json.
+    Confirmed      bool     // true if --yes OR interactive prompt accepted.
+    Dir            string   // Working dir containing fleet.json (for LoadConfig / SaveLocalConfig).
+}
+```
+
+**Validation rules** (enforced inside `Add()`, not in cobra):
+
+| Field | Rule | On violation |
+|-------|------|--------------|
+| `Repo` | Must match `validateSlug` output (two lowercase `[a-z0-9._-]+` halves separated by `/`) | Return error naming the invalid slug and the rule it violated |
+| `Profiles` | Length ≥ 1; every entry must exist in merged `cfg.Profiles` | Return error listing available profile names |
+| `Engine` | If non-empty, must be a key of `EngineSecrets` | Return error listing accepted engine names |
+| `ExtraWorkflows` | Each raw string must parse via `parseExtraWorkflowSpec` | Return error naming the offending spec with an example of the correct form |
+| `Apply` + `Confirmed` | If `Apply == true`, `Confirmed` must also be true | Return error `"--apply requires --yes or interactive confirmation"` |
+
+### `AddResult` (in `internal/fleet/add.go`)
+
+The return value from `fleet.Add()`. Carries both the preview
+payload (for rendering) and, in `--apply` mode, a record of what
+was written.
+
+```go
+type AddResult struct {
+    Repo         string             // "owner/repo" (normalized)
+    Profiles     []string           // Profile names assigned, in order
+    Engine       string             // Engine override ("" if none)
+    Resolved     []ResolvedWorkflow // Workflow list (from ResolveRepoWorkflows)
+    Warnings     []string           // Non-fatal warnings (no-op exclude, shadowed extra, zero-resolved)
+    WroteLocal   bool               // true if this invocation created or rewrote fleet.local.json
+    SynthesizedLocal bool           // true if fleet.local.json was synthesized from fleet.json-only baseline
+    LocalPath    string             // Absolute path to the written/would-be-written file (for logging)
+}
+```
+
+Notes:
+
+- `Resolved` is the same `ResolvedWorkflow` slice type the deploy
+  path uses; we deliberately do not introduce a parallel "preview
+  workflow" type. Exercising the same resolver keeps dry-run
+  preview and deploy behavior in lockstep.
+- `Warnings` is populated for stderr rendering. Empty in the happy
+  path. Never carries fatal errors — those are returned via
+  `Add()`'s `error` return.
+- `WroteLocal == false` in dry-run mode; `LocalPath` is still
+  populated so the dry-run message can reference the target file.
+
+### Supporting helper: `parseExtraWorkflowSpec(s string) (ExtraWorkflow, error)`
+
+Pure function. Converts a single `--extra-workflow` flag value into
+an `ExtraWorkflow`. See `research.md §7` for the full algorithm and
+error cases.
+
+### Supporting helper: `validateSlug(s string) (string, error)`
+
+Pure function. Returns the normalized (lowercased, trimmed)
+`owner/repo` form, or a descriptive error. See `research.md §6`.
+
+### Supporting helper: `BuildMinimalLocalConfig(repo string, spec RepoSpec) *Config`
+
+Constructs a `Config` with `Version = SchemaVersion`,
+`Repos = map[string]RepoSpec{repo: spec}`, and everything else zero-
+valued. Exists specifically to make the FR-015 "minimal local file"
+contract directly testable (unit test asserts the resulting JSON
+has exactly two top-level keys: `version` and `repos`).
+
+## Modified types
+
+None. `Config`, `RepoSpec`, `ExtraWorkflow`, `ResolvedWorkflow`,
+and `Profile` (all in `internal/fleet/schema.go`) are consumed as-is.
+
+## Existing types consumed (for reference)
+
+### `Config` (`internal/fleet/schema.go:10-16`)
+
+Already supports everything needed. `Add` mutates `Config.Repos` by
+inserting the new key.
+
+### `RepoSpec` (`internal/fleet/schema.go:56-62`)
+
+Fields populated by `Add`:
+
+| Field | Source |
+|-------|--------|
+| `Profiles` | `AddOptions.Profiles` verbatim |
+| `Engine` | `AddOptions.Engine` (empty string omitted via `omitempty`) |
+| `ExtraWorkflows` | Result of parsing each `AddOptions.ExtraWorkflows` entry |
+| `ExcludeFromProfiles` | `AddOptions.Excludes` verbatim |
+| `Overrides` | Always nil in v1 (out of scope per Assumptions) |
+
+### `ExtraWorkflow` (`internal/fleet/schema.go:66-71`)
+
+All four fields (`Name`, `Source`, `Ref`, `Path`) populated by
+`parseExtraWorkflowSpec`.
+
+## Lifecycle (dry-run → apply)
+
+```text
+cmd/add.go parses flags
+    │
+    ├── validateSlug(args[0])                          ← FR-004
+    ├── check Apply + Confirmed (TTY/--yes logic)      ← FR-003
+    └── build AddOptions
+            │
+            ▼
+    fleet.Add(cfg, opts) in internal/fleet/add.go
+            │
+            ├── parse each --extra-workflow             ← FR-008
+            ├── validate profiles exist in cfg          ← FR-011
+            ├── validate engine in EngineSecrets        ← FR-006
+            ├── check no duplicate in cfg.Repos         ← FR-010
+            ├── build candidate RepoSpec
+            ├── set cfg.Repos[repo] = candidate
+            │    (IN-MEMORY ONLY — used for resolver call)
+            ├── cfg.ResolveRepoWorkflows(repo)          ← FR-012
+            ├── collect warnings (no-op excludes,       ← research.md §3
+            │   shadowed extras, zero-resolved)
+            └── build AddResult
+                    │
+                    ▼
+            if opts.Apply:
+                BuildMinimalLocalConfig(repo, candidate) ← FR-015
+                SaveLocalConfig(opts.Dir, minimal)       ← FR-014 + FR-016
+                set WroteLocal = true
+            return result, nil
+                    │
+                    ▼
+    cmd/add.go renders AddResult
+        stderr: header + warnings + next-step hint     ← FR-013
+        stdout: workflow list (one "- <name>" per line)
+```
+
+**Important invariant**: The in-memory `cfg.Repos[repo] = candidate`
+mutation is temporary — it exists only so `ResolveRepoWorkflows`
+can treat the candidate as though it were part of the merged view.
+When `--apply` writes, it writes a **minimal** `Config` that does
+NOT carry the rest of `cfg`'s contents (FR-015). The minimal file
+is constructed fresh via `BuildMinimalLocalConfig`, not derived
+from the mutated `cfg`.
+
+## State transitions
+
+`add` is stateless per-invocation. Between invocations, the state
+machine is:
+
+```text
+(no fleet.local.json, fleet.json present)
+     │
+     │ add owner/repo --profile X --apply --yes
+     ▼
+(fleet.local.json with {version, repos:{owner/repo: ...}})
+     │
+     │ add owner2/repo2 --profile Y --apply --yes
+     ▼
+(fleet.local.json with {version, repos:{owner/repo, owner2/repo2}})
+```
+
+No intermediate "partially-written" state is possible because
+writes are atomic (temp file + rename, per FR-016).
+
+Fatal-error transitions exit non-zero before any mutation. The
+only way `fleet.local.json` changes is the successful path above.

--- a/specs/001-add-subcommand/plan.md
+++ b/specs/001-add-subcommand/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: `add <owner/repo>` Subcommand for Fleet Onboarding
+
+**Branch**: `001-add-subcommand` | **Date**: 2026-04-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/001-add-subcommand/spec.md`
+
+## Summary
+
+Implement the `add <owner/repo>` subcommand so operators can register a
+new repo in `fleet.local.json` from the CLI instead of hand-editing
+JSON. The command is dry-run by default (prints a preview of the
+resolved workflow set) and writes the file only when both `--apply` and
+confirmation (`--yes` or interactive prompt) are provided. Validation
+runs the candidate through the existing `ResolveRepoWorkflows` resolver
+before any write, so the preview shown to the operator is what `deploy`
+will actually install. Shared state (profiles, defaults) stays
+authoritative in `fleet.json`; `fleet.local.json` is written as a
+minimal delta so that `mergeConfigs` at load time produces the correct
+merged view.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.8 (from `go.mod`)
+**Primary Dependencies**: `github.com/spf13/cobra` v1.10.2 (CLI
+framework — already used by every other subcommand), `encoding/json`
+(stdlib — existing write path uses it via `writeJSON`)
+**Storage**: `fleet.local.json` (the private source of truth — target
+for all writes from this command) and `fleet.json` (public example,
+read-only from this command's perspective). Both are JSON files at the
+repo working dir, resolved by `LoadConfig(dir)`.
+**Testing**: Go stdlib `testing` package (matches the existing style in
+`internal/fleet/deploy_test.go`). Pure-logic unit tests for `Add()`,
+`parseExtraWorkflowSpec()`, `validateSlug()`; no subprocess or network
+mocks required — this command does no I/O beyond reading/writing local
+files.
+**Target Platform**: Linux / macOS developer shells (WSL2 tested by
+the repo owner; macOS supported). No Windows build target. CLI-only.
+**Project Type**: Single-project Go CLI. No frontend/backend split.
+**Performance Goals**: ≤2 s for dry-run and `--apply` (SC-006). No
+network calls. Load + resolve + write should be well under 100 ms on a
+typical fleet (≤50 repos, ≤20 workflows per profile).
+**Constraints**:
+- No mutation of `fleet.json` under any circumstance (FR-014).
+- No subprocess calls (no `gh`, no `git`, no `gh aw`) — writes stay
+  local.
+- Atomic writes via temp-file + rename (existing `writeJSON`
+  pattern).
+- `--apply` without `--yes` in a non-TTY MUST fail; never silently
+  write (FR-003).
+
+**Scale/Scope**: Single-operator, single-repo-per-invocation. Fleets
+observed in this project top out at ~10 repos × ~20 workflows; 100×
+that is still fine in memory.
+
+All NEEDS CLARIFICATION from earlier drafts resolved via
+`/speckit.clarify` sessions — see `## Clarifications` in `spec.md`
+(FR-006, FR-008, FR-013, FR-015).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.0.0
+(2026-04-18). Each principle's applicability and compliance stance
+for this feature:
+
+### I. Thin-Orchestrator Code Quality — PASS
+
+- `add` does not wrap any upstream tool; it is pure local config
+  manipulation. This is an intentional carve-out: the principle says
+  the tool orchestrates `gh aw` / `gh` / `git` rather than
+  reimplementing them; it does NOT forbid local config logic. `add`
+  sits at the same layer as `LoadConfig`, which is also pure Go.
+- The command delegates workflow resolution to the existing
+  `ResolveRepoWorkflows` function — no re-implementation of profile
+  merging, source layout handling, or exclusion logic.
+- `go build ./...` and `go vet ./...` clean is a shipping requirement
+  (enforced by the existing CLAUDE.md hook into every task's
+  definition-of-done).
+- File size: the new `internal/fleet/add.go` and `cmd/add.go` will
+  each stay well under the 300-line soft ceiling. Estimated ~150 LOC
+  and ~80 LOC respectively.
+
+### II. Testing Standards (Build-Green + Real-World Dry-Run) — PASS
+
+- `go build ./...` and `go vet ./...` clean: enforced.
+- The "real-world dry-run" clause applies to **mutating commands that
+  touch external state** (`deploy`, `sync`, `upgrade`). `add` mutates
+  only a local file; its equivalent of "real-world dry-run" is the
+  dry-run preview it prints before any write, which exercises the
+  exact `ResolveRepoWorkflows` code path `deploy` will use. This
+  satisfies the spirit of the rule (dry-run exercises real logic
+  against real state) without requiring a scratch clone.
+- Unit tests are appropriate here because the logic is pure: config in
+  → config out. Tests land in `internal/fleet/add_test.go` following
+  the table-driven style already used in `deploy_test.go`.
+- No skills need to be re-exercised in subagents beyond the
+  `fleet-onboard-repo` update called out in FR-019.
+
+### III. User Experience Consistency (Three-Turn Mutation Pattern) — PASS
+
+- Dry-run by default (FR-002): Turn 1.
+- `--apply` requires `--yes` or interactive approval (FR-003): Turn 2
+  is the confirmation step; non-TTY enforces explicit `--yes`, which
+  matches `deploy`/`sync`/`upgrade`'s convention.
+- Mutation (write to `fleet.local.json`) happens only on Turn 3
+  (FR-014, FR-016).
+- Error messages route through a per-error-class remediation hint
+  pattern consistent with `fleet.CollectHints` (we do NOT need new
+  `CollectHints` entries — `add`'s errors are parse/validation errors,
+  not network/auth errors that require tooling remediation).
+- Commit signing / commit messages: N/A. `add` does not run `git`.
+
+### IV. Performance Requirements — PASS
+
+- No network, no `exec.Command`, no parallelism required. Single
+  load, single resolve, single write.
+- Well under the 5-minute ceiling and the 2-second spec target
+  (SC-006).
+
+**Constitution Check outcome**: All principles PASS. No violations;
+Complexity Tracking section below remains empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-add-subcommand/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (resolves deferred clarify items)
+├── data-model.md        # Phase 1 output (AddOptions, AddPreview)
+├── quickstart.md        # Phase 1 output (operator-facing walkthrough)
+├── contracts/
+│   └── cli.md           # Phase 1 output (CLI surface contract)
+├── checklists/
+│   └── requirements.md  # From /speckit.specify
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── add.go               # NEW: cobra command wiring, flag parsing, TTY detection,
+│                        #      calls into fleet.Add(), renders AddPreview/AddResult
+├── stubs.go             # MODIFIED: remove newAddCmd stub (keep newStatusCmd)
+├── deploy.go            # UNCHANGED
+├── list.go              # UNCHANGED
+├── root.go              # UNCHANGED (already wires newAddCmd into root)
+├── sync.go              # UNCHANGED
+├── template.go          # UNCHANGED
+└── upgrade.go           # UNCHANGED
+
+internal/fleet/
+├── add.go               # NEW: Add(cfg, opts) → (*AddResult, error)
+│                        #      parseExtraWorkflowSpec, validateSlug, buildRepoSpec
+├── add_test.go          # NEW: table-driven unit tests for Add() + helpers
+├── load.go              # MODIFIED: replace SaveConfig (dead code today) with
+│                        #           SaveLocalConfig targeting fleet.local.json
+├── schema.go            # UNCHANGED (RepoSpec/Config/ExtraWorkflow already fit)
+├── deploy.go            # UNCHANGED (EngineSecrets map consumed as-is)
+├── deploy_test.go       # UNCHANGED
+├── diagnostics.go       # UNCHANGED (no new hint classes needed)
+├── fetch.go             # UNCHANGED
+├── frontmatter.go       # UNCHANGED
+├── sync.go              # UNCHANGED
+└── upgrade.go           # UNCHANGED
+
+skills/fleet-onboard-repo/
+└── SKILL.md             # MODIFIED: replace JSON-edit step with gh-aw-fleet add
+
+README.md                # MODIFIED: add `add` to the CLI surface list;
+                         #          update Quickstart to show onboarding via add
+```
+
+**Structure Decision**: Single-project Go CLI — matches the existing
+`cmd/` + `internal/fleet/` split. No new packages. No new top-level
+directories. The `cmd/add.go` / `internal/fleet/add.go` pairing
+mirrors the existing `cmd/deploy.go` / `internal/fleet/deploy.go`
+pairing exactly, preserving the one-concept-per-file organization the
+rest of the codebase uses.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.

--- a/specs/001-add-subcommand/quickstart.md
+++ b/specs/001-add-subcommand/quickstart.md
@@ -1,0 +1,198 @@
+# Quickstart: `gh-aw-fleet add <owner/repo>`
+
+**Audience**: operators onboarding a repo into the fleet for the
+first time, or adding a second/third/Nth repo.
+**Time**: ~30 seconds for a standard onboarding.
+
+This is the operator-facing walkthrough. For the full command
+contract, see `contracts/cli.md`. For implementation details, see
+`plan.md`.
+
+## Prerequisites
+
+- `gh-aw-fleet` built and on your `PATH` (or run via `go run .`).
+- A working directory with at least `fleet.json` present (a
+  `fleet.local.json` is optional — if it's absent, `add` will
+  create a minimal one on your first `--apply`).
+- You know which profile you want the repo to use (`default` is
+  the standard starting point).
+
+## Step 1 — Dry-run
+
+Preview what `add` would write, without touching anything on disk:
+
+```bash
+gh-aw-fleet add rshade/my-new-repo --profile default
+```
+
+Expected output (example):
+
+```text
+# stderr:
+would add rshade/my-new-repo with profiles [default] (12 workflows)
+next: re-run with --apply to persist
+
+# stdout:
+- ci-doctor
+- security-guardian
+- perf-guardian
+- ... (9 more)
+```
+
+If the header shows an unexpected profile list, workflow count, or
+missing workflows, **stop** — you have a flag wrong. Re-run with
+corrected flags. Nothing has been written.
+
+## Step 2 — Apply
+
+When the dry-run preview looks right:
+
+```bash
+gh-aw-fleet add rshade/my-new-repo --profile default --apply --yes
+```
+
+Expected output:
+
+```text
+# stderr:
+added rshade/my-new-repo with profiles [default] (12 workflows)
+next: gh-aw-fleet deploy rshade/my-new-repo
+```
+
+If `fleet.local.json` did not exist before this run, you will also
+see (on stderr):
+
+```text
+creating fleet.local.json (minimal; profiles/defaults still resolved from fleet.json)
+```
+
+This is expected and correct. See the FAQ below for what that
+minimal file looks like.
+
+## Step 3 — Verify
+
+```bash
+gh-aw-fleet list
+```
+
+Your new repo should appear alongside any others, with the
+resolved workflow count matching what Step 1 / Step 2 reported.
+
+## Step 4 — Deploy (optional, separate command)
+
+`add` only writes the declarative state. To actually install the
+workflows onto the target repo, follow up with:
+
+```bash
+gh-aw-fleet deploy rshade/my-new-repo         # dry-run
+gh-aw-fleet deploy rshade/my-new-repo --apply # opens PR
+```
+
+## Customizing at onboarding time
+
+### Override the engine
+
+```bash
+gh-aw-fleet add rshade/my-new-repo --profile default --engine claude --apply --yes
+```
+
+Accepted engines: `copilot`, `claude`, `codex`, `gemini`. (Whatever
+`EngineSecrets` declares is the authoritative list; any other value
+is rejected up front.)
+
+### Exclude a workflow the profile includes
+
+```bash
+gh-aw-fleet add rshade/my-new-repo \
+    --profile default \
+    --exclude perf-guardian \
+    --apply --yes
+```
+
+If `perf-guardian` isn't actually in `default`, you'll see a
+warning — but the add still succeeds (the exclusion is a no-op).
+
+### Add an extra workflow the profile doesn't include
+
+Three forms, depending on where the workflow comes from:
+
+```bash
+# Local workflow (lives in the target repo):
+--extra-workflow my-repo-specific-thing
+
+# Agentics 3-part form:
+--extra-workflow githubnext/agentics/security-guardian@v0.4.1
+
+# gh-aw 4-part form:
+--extra-workflow github/gh-aw/.github/workflows/custom.md@v0.68.3
+```
+
+## Duplicate-repo error — what it means
+
+```text
+error: rshade/my-new-repo already exists in fleet.json + fleet.local.json
+```
+
+The repo is already tracked (in either file). `add` refuses to
+overwrite. Options:
+
+1. Hand-edit `fleet.local.json` if you intend to shadow a
+   `fleet.json` entry.
+2. Run `gh-aw-fleet list` to confirm you didn't already add this
+   repo.
+3. Use a different slug (double-check casing — `Foo/Bar` normalizes
+   to `foo/bar`).
+
+## Manual integration test (for reviewers of PR #9)
+
+Steps to verify this feature end-to-end after merging:
+
+1. In a fresh worktree, delete `fleet.local.json` if it exists.
+2. Run `gh-aw-fleet list` and confirm the pre-existing repo set.
+3. Run `gh-aw-fleet add testowner/testrepo --profile default`.
+   Confirm dry-run preview lists the expected workflow set; no
+   file changes.
+4. Run `gh-aw-fleet add testowner/testrepo --profile default
+   --apply --yes`. Confirm:
+   - `fleet.local.json` now exists.
+   - Its contents are **minimal**: exactly
+     `{"version": 1, "repos": {"testowner/testrepo": {"profiles": ["default"]}}}`.
+   - `fleet.json` is byte-identical to before.
+5. Run `gh-aw-fleet list` again. Confirm `testowner/testrepo`
+   appears with a resolved workflow count.
+6. Run `gh-aw-fleet add testowner/testrepo --profile default`.
+   Confirm it fails with the duplicate-repo error.
+7. Clean up: `git checkout -- .` (the test repo entry is in
+   `fleet.local.json` which is gitignored, so it stays; delete it
+   manually if you want a clean state).
+
+## FAQ
+
+### Why is `fleet.local.json` so small after the first `add`?
+
+By design. `add` writes a minimal delta: only `version` and the
+new `repos` entry. Profiles, defaults, and peer repos continue to
+resolve from `fleet.json` via `LoadConfig`'s merge logic. This
+keeps `fleet.json` authoritative for shared state; your
+`fleet.local.json` stays a focused "what I changed locally" file.
+
+### Why can't I just re-run `add` to change a repo's profile?
+
+v1 scope. `add` is strictly additive: it refuses if the repo
+already exists. Editing an existing entry requires hand-editing
+`fleet.local.json`. A future `edit` command may lift this.
+
+### Can I `add` without a profile?
+
+No. `--profile` is required in v1. A repo with zero profiles is
+not meaningfully tracked by the fleet — `deploy` wouldn't know
+what to install. If you want a repo tracked but deployed with only
+`--extra-workflow` entries, that's out of scope for v1.
+
+### What happens if two operators run `add --apply` at the same time?
+
+One will win, the other's entry will be lost. `add` doesn't take a
+lock. The atomic-rename write pattern guarantees the file is never
+partially written, but last-write-wins applies. This is acceptable
+for a local single-operator CLI; documented as an assumption in
+the spec.

--- a/specs/001-add-subcommand/research.md
+++ b/specs/001-add-subcommand/research.md
@@ -1,0 +1,310 @@
+# Research: `add <owner/repo>` Subcommand
+
+**Phase**: 0 (outline + research)
+**Feature**: `specs/001-add-subcommand`
+
+All items from `spec.md`'s `## Clarifications` section are resolved
+upstream. This document resolves the items `/speckit.clarify`
+deferred to the planning phase, plus a small number of questions
+that surfaced only once we started enumerating the implementation.
+
+Each entry follows: **Decision** / **Rationale** / **Alternatives
+considered**.
+
+---
+
+## 1. `--profile` flag mechanics (cobra `StringSliceVar` vs `StringArrayVar`)
+
+**Decision**: Use `cmd.Flags().StringSliceVar(&flagProfiles, "profile", ...)`.
+
+**Rationale**: `StringSliceVar` accepts both repeated flags
+(`--profile a --profile b`) and comma-separated values
+(`--profile a,b`). Operators using this from interactive shells will
+prefer the comma form; operators using it from scripts will prefer
+the repeated form. `StringSliceVar` gives both for free. No other
+subcommand in this repo takes a multi-value flag yet, so there is no
+project convention to match — this decision establishes the
+convention.
+
+**Alternatives considered**:
+
+- `StringArrayVar`: forces repetition (`--profile a --profile b`);
+  rejects commas. Fine for programmatic callers, unfriendly for
+  interactive use. Rejected because comma-separated is a universal
+  CLI idiom.
+- Custom parsing of a single `StringVar`: would re-implement what
+  cobra gives us for free. Rejected per Principle I (don't
+  re-implement upstream behavior).
+
+## 2. `SaveConfig` → `SaveLocalConfig` rename
+
+**Decision**: Delete the existing `SaveConfig(dir, c *Config) error`
+function in `internal/fleet/load.go:96-99` and replace it with
+`SaveLocalConfig(dir string, c *Config) error`, which writes
+unconditionally to `fleet.local.json` (not `fleet.json`). Also
+export a small `BuildMinimalLocalConfig(repo string, spec RepoSpec)
+*Config` helper for the FR-015 synthesis path.
+
+**Rationale**:
+
+- `SaveConfig` has zero callers today (`grep -r SaveConfig` finds
+  only its own definition in the source tree — all other hits are in
+  the spec docs). Deleting it is safe.
+- Renaming the function (instead of adding a new one alongside)
+  satisfies FR-021's "impossible by construction" constraint: after
+  the rename, no function in the package can write to `fleet.json`.
+  If a future caller wants that ability, they must consciously add
+  it and justify it — which is exactly the friction FR-021 asks for.
+- The small synthesis helper keeps `cmd/add.go` free of schema
+  construction logic. It also makes the "minimal file" contract
+  (from the 4th clarification) easy to unit-test in isolation.
+
+**Alternatives considered**:
+
+- Keep `SaveConfig` and add `SaveLocalConfig` alongside. Rejected
+  because `SaveConfig`'s continued existence contradicts FR-021 —
+  the impossibility must be structural, not merely "no current
+  caller uses the dangerous function."
+- Make `SaveLocalConfig` unexported. Rejected because unit tests in
+  `internal/fleet/add_test.go` want to exercise it; same-package
+  tests would still have access, but exporting it leaves the door
+  open for reuse by a future `remove`/`edit` command without needing
+  a refactor.
+
+## 3. Warning emission rules for FR-013
+
+**Decision**: Emit warnings on stderr (between the header line and
+the `next step` hint) in exactly three cases:
+
+1. `--exclude <name>` where `<name>` does not appear in any workflow
+   list of any selected profile.
+2. `--extra-workflow <spec>` whose resolved `Name` already appears
+   in one of the selected profiles' workflow lists (the existing
+   `ResolveRepoWorkflows` dedup at `internal/fleet/load.go:183-185`
+   will silently drop it; operators need to know).
+3. The resolved workflow count is zero. This almost always indicates
+   a typoed `--profile` name whose resolution succeeded but yielded
+   nothing, or an overly aggressive `--exclude`. Exit remains zero
+   but the warning is loud.
+
+**Rationale**:
+
+- These are the only cases where the user's command-line intent
+  silently differs from the written config. Every other class of
+  error (unknown profile, malformed slug, duplicate repo, unknown
+  engine) is a hard error that exits non-zero.
+- No warning for `--engine` overriding a fleet default — that's an
+  intentional user gesture, not a silent divergence.
+- Warnings on stderr keep stdout pristine for the workflow-list
+  output (relevant if an operator pipes stdout through `grep` /
+  `wc -l`).
+
+**Alternatives considered**:
+
+- Also warn for `--extra-workflow` with a non-"local" source that
+  lacks a corresponding profile source pin. Rejected because
+  `ExtraWorkflow.Ref` is set inline from the flag value — extras
+  don't depend on profile pins.
+- Error (not warn) on zero resolved workflows. Rejected because a
+  profile could legitimately be defined with zero workflows during
+  onboarding of a new profile; forcing `add` to fail would block
+  that workflow.
+
+## 4. TTY detection for `--apply` confirmation
+
+**Decision**: Use `term.IsTerminal(int(os.Stdin.Fd()))` from
+`golang.org/x/term`. Add the dependency only if not already
+present; prefer an existing dep if one provides the same primitive.
+
+**Rationale**:
+
+- This is the standard Go idiom for "am I attached to a terminal."
+  `os.Stdin.Stat()` + `Mode()&os.ModeCharDevice` also works but is
+  less readable and has subtle portability footguns.
+- `golang.org/x/term` is a common indirect transitive dependency in
+  Go projects that use cobra; we should confirm it isn't already in
+  the indirect-requires section before adding it explicitly.
+- If we do add it, it is a tiny, well-maintained package from the
+  Go team — low dependency risk.
+
+**Alternatives considered**:
+
+- `github.com/mattn/go-isatty`: larger dep, vestigial from older Go
+  versions that lacked `x/term`. Rejected.
+- Skip TTY detection entirely; always require `--yes`. Rejected
+  because the spec's FR-003 explicitly allows interactive prompt in
+  TTY mode, and removing that would break the "friendly CLI" UX
+  this feature is built to deliver.
+
+**Verification step**: Before adding `golang.org/x/term` to
+`go.mod`'s `require` block, run `go mod graph | grep 'golang.org/x/term'`
+to check if cobra or another direct dep already pulls it in as a
+transitive. If so, promote it to a direct require (no new dep) rather
+than adding a new one.
+
+## 5. Interactive prompt wording and response parsing
+
+**Decision**: Prompt text: `Write fleet.local.json? [y/N] `.
+Accept responses: `y`, `Y`, `yes`, `YES` → proceed; anything else →
+abort with exit 1 and the message
+`aborted: re-run with --apply --yes to confirm`.
+
+**Rationale**:
+
+- Single-char default `N` is the standard Unix CLI convention for
+  "destructive operation confirmation."
+- Case-insensitive y/yes keeps the prompt forgiving without
+  accepting ambiguous input like `maybe`.
+- The abort message tells the operator exactly what to type to
+  re-run non-interactively, closing the UX loop.
+
+**Alternatives considered**:
+
+- Full-word-only prompt (`yes`/`no`, no single-letter). Rejected as
+  unidiomatic for Unix CLIs.
+- Abort silently on anything-not-`y`. Rejected because the operator
+  might have hit Enter by accident; the error message points them
+  at the remedy.
+
+## 6. Slug normalization rules (FR-004)
+
+**Decision**: `validateSlug(s string) (string, error)` implements:
+
+- Trim leading/trailing whitespace.
+- Reject empty string.
+- Split on `/`. Require exactly 2 parts, both non-empty and
+  non-whitespace.
+- Lowercase both halves.
+- Allowed character set: `[a-z0-9._-]+` for each half (matches
+  GitHub's slug rules — no spaces, no `/` inside a half after
+  the split).
+- Return the lowercased `owner/repo` form.
+
+**Rationale**: These are GitHub's repo-slug rules. Using a stricter
+superset than GitHub allows (e.g., forbidding `.`) would reject
+valid repo names like `owner/foo.bar`.
+
+**Alternatives considered**:
+
+- Validate against the exact GitHub regex (which requires owner
+  name to start with an alphanumeric and not end with a hyphen).
+  Rejected as over-engineering — this is local validation to catch
+  typos, not a security boundary. If the slug slips past
+  `validateSlug` but is later rejected by GitHub, `deploy` will
+  surface that.
+
+## 7. `--extra-workflow` parse implementation (elaborates FR-008)
+
+**Decision**: `parseExtraWorkflowSpec(s string) (ExtraWorkflow, error)`
+with the following algorithm:
+
+```text
+1. If s contains no "/", treat as bare name:
+     return ExtraWorkflow{Name: s, Source: "local"}
+2. Otherwise split on "@":
+     lhs is everything before the first "@" (required)
+     ref is everything after the first "@" (required; empty ref → error)
+3. Split lhs on "/":
+     a. len == 2 (unexpected — looks like "owner/repo" with no path):
+        → error, suggest 3-part or 4-part form
+     b. len == 3: treat as "owner/repo/name"
+        → ExtraWorkflow{Name: parts[2], Source: "parts[0]/parts[1]", Ref: ref}
+     c. len >= 4 AND parts[2] == ".github" AND parts[3] == "workflows":
+        path = ".github/workflows/" + parts[4:].join("/")
+        name = basename of parts[-1] with ".md" suffix stripped
+        → ExtraWorkflow{Name: name, Source: parts[0]+"/"+parts[1],
+                        Ref: ref, Path: path}
+     d. otherwise: → error with example
+```
+
+**Rationale**: Mirrors the layout distinctions encoded in
+`SourceLayout` (from `internal/fleet/fetch.go`, referenced in
+CLAUDE.md). The 4-part form must specifically start with
+`.github/workflows/` to match how `gh-aw`-layout sources are
+addressed everywhere else in the project.
+
+**Alternatives considered**:
+
+- Auto-detect based on whether the `Source` is a known key in any
+  loaded profile's `Sources` map. Rejected: the operator might be
+  adding an extra from a source not yet referenced by any profile,
+  and the parse should work without loading the config.
+- Accept both `@ref` and a ref-less form. Rejected for remote
+  sources: a pin is mandatory to be reproducible (matches how
+  `profile.Sources[source].Ref` is mandatory). Bare-name local
+  extras legitimately have no ref.
+
+## 8. Preview output formatting details (elaborates FR-013)
+
+**Decision**:
+
+- Header line on stderr, format:
+  `would add <repo> with profiles [<csv>] (<N> workflows)`
+  e.g., `would add rshade/foo with profiles [default] (12 workflows)`
+- Workflow list on stdout, one per line, format: `- <name>`.
+  Workflows appear in resolution order: profile membership order
+  (from `ResolveRepoWorkflows`), then extras.
+- Engine override line (only if `--engine` was passed): on stderr
+  after the header, format: `engine override: <name>`.
+- Warnings on stderr after any engine override line, format:
+  `warning: <message>`.
+- Final line on stderr (dry-run only): `next: re-run with --apply to persist`.
+- Final line on stderr (`--apply` success): `next: gh-aw-fleet deploy <repo>`.
+
+**Rationale**: Matches the cadence of `cmd/deploy.go`'s
+`printDeploy` function (see `cmd/deploy.go:57-80`) — a header
+summary followed by indented detail lines. Keeping stdout limited
+to the workflow list is what enables pipe-friendliness without a
+`--output` flag.
+
+**Alternatives considered**:
+
+- Put everything on stdout for simplicity. Rejected because
+  operators who pipe stdout to `wc -l` expect it to equal the
+  workflow count, not the count plus 3 status lines.
+
+## 9. Test matrix (elaborates Testing Strategy in spec.md)
+
+**Decision**: `internal/fleet/add_test.go` has four table-driven
+test functions:
+
+- `TestValidateSlug(t *testing.T)` — parsing/casing/invalid-form
+  cases.
+- `TestParseExtraWorkflowSpec(t *testing.T)` — all four branches
+  of FR-008 syntax plus error cases.
+- `TestAdd_DryRun(t *testing.T)` — happy path, duplicate-repo,
+  unknown-profile, unknown-engine, no-op exclude, zero-workflow
+  warning.
+- `TestAdd_Apply(t *testing.T)` — actually writes to `t.TempDir()`;
+  asserts file contents exactly (minimal file per FR-015), and
+  confirms `fleet.json` at the temp dir is untouched.
+- `TestBuildMinimalLocalConfig(t *testing.T)` — direct test of the
+  synthesis helper to anchor the FR-015 contract.
+
+Integration test (documented in `quickstart.md`, not automated in
+this PR):
+
+- Fresh checkout scenario, no `fleet.local.json` → `add --apply
+  --yes` → inspect written file, run `gh-aw-fleet list`, confirm
+  new entry appears with resolved workflow count.
+
+**Rationale**: Unit tests cover all decision branches; the
+integration test covers the one thing unit tests can't — that
+`list` correctly surfaces a newly-added repo after round-tripping
+through the file system. Matches the constitutional carve-out for
+build-green + real-world dry-run: `add` exercises its own real
+dry-run via the preview, and integration verifies round-trip.
+
+**Alternatives considered**:
+
+- Add a separate `cmd/add_integration_test.go` that shells out to
+  the built binary. Rejected because the test adds a build
+  dependency and duplicates what the `TestAdd_Apply` temp-dir test
+  already covers. The integration scenario stays in the PR's
+  manual-verification checklist.
+
+---
+
+**Research outcome**: No NEEDS CLARIFICATION remain. All deferred
+items resolved with decisions justified against the constitution.
+Ready for Phase 1 design.

--- a/specs/001-add-subcommand/spec.md
+++ b/specs/001-add-subcommand/spec.md
@@ -1,0 +1,360 @@
+# Feature Specification: `add <owner/repo>` Subcommand for Fleet Onboarding
+
+**Feature Branch**: `001-add-subcommand`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: GitHub issue #9 — "feat(cmd): implement add <owner/repo> subcommand for fleet onboarding"
+
+## Clarifications
+
+### Session 2026-04-19
+
+- Q: What format should `--extra-workflow` accept on the command line? → A: Reuse the existing `gh aw`-style spec syntax — `name` for local extras, `owner/repo/name@ref` (3-part agentics), or `owner/repo/.github/workflows/name.md@ref` (4-part gh-aw). A single parser extracts `Name`, `Source`, `Ref`, and `Path` from one string.
+- Q: How should `--engine` be validated, given that `deploy` does not currently reject unknown engines? → A: Validate in `add` only, against the existing `EngineSecrets` map in `internal/fleet/deploy.go`. No changes to `deploy`'s current behavior; `add` becomes the stricter onboarding gate.
+- Q: What shape should the dry-run preview output take? → A: Plain prose + indented workflow list, matching the style of `deploy`'s dry-run and `list`'s summary. Header line on stderr ("would add rshade/foo with profiles [default] (N workflows)"), then the workflow names as a bulleted list on stdout. No JSON output mode in v1.
+- Q: When `fleet.local.json` does not yet exist and must be synthesized on `--apply`, what should it contain? → A: Rely on the existing merge code — write a minimal `fleet.local.json` containing only `version` and a `repos` map with the single new entry. Do not copy profiles, defaults, or peer repos from `fleet.json`. `LoadConfig`/`mergeConfigs` will continue to produce a correct merged view on every load, and `fleet.json` remains authoritative for shared state.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Onboard a new repo declaratively with a profile (Priority: P1)
+
+An operator wants to add a repository to their private fleet state
+(`fleet.local.json`) and assign it the `default` profile so the next
+`deploy` run installs the standard workflow bundle. Today they must
+hand-edit JSON and guess at the exact schema.
+
+**Why this priority**: This is the entire motivation for the feature.
+Without it, onboarding remains schema-fragile and blocks the
+`fleet-onboard-repo` skill from being a one-command operation. This
+single story, shipped alone, replaces a manual 10-minute procedure with
+a single command and delivers the full MVP value of issue #9.
+
+**Independent Test**: On a fresh checkout with only `fleet.json`
+present, run `gh-aw-fleet add rshade/new-example --profile default`
+(no `--apply`) and confirm the dry-run preview lists the resolved
+workflow set. Then run the same command with `--apply --yes`, confirm
+`fleet.local.json` exists with the new entry, and confirm
+`gh-aw-fleet list` now surfaces the new repo with its resolved
+workflows.
+
+**Acceptance Scenarios**:
+
+1. **Given** `fleet.local.json` already exists with no entry for
+   `owner/repo`, **When** the operator runs `gh-aw-fleet add owner/repo
+   --profile default --apply --yes`, **Then** the file is rewritten with
+   the new `repos.owner/repo` entry containing `profiles: ["default"]`,
+   and the command prints a "next step: run `gh-aw-fleet deploy
+   owner/repo`" hint.
+2. **Given** only `fleet.json` exists (no `fleet.local.json`), **When**
+   the operator runs `gh-aw-fleet add owner/repo --profile default
+   --apply --yes`, **Then** `fleet.local.json` is created as a minimal
+   file containing only `version` and a `repos` map with the new entry
+   (profiles, defaults, and peer repos are NOT copied — they remain in
+   `fleet.json` and are picked up by `LoadConfig`'s merge), and the
+   public `fleet.json` is left unchanged.
+3. **Given** any fleet config, **When** the operator runs
+   `gh-aw-fleet add owner/repo --profile default` (no `--apply`),
+   **Then** no file on disk changes and the command prints a preview
+   showing the count and names of workflows that would be deployed,
+   plus the profile list.
+
+---
+
+### User Story 2 — Validate before writing (Priority: P1)
+
+The operator wants the tool to refuse unsafe or incoherent additions —
+duplicate repos, unknown profiles, malformed slugs — with clear
+actionable errors, not silent overwrite or cryptic JSON decoder
+messages. This is the guardrail that makes story 1 trustworthy.
+
+**Why this priority**: Hand-editing JSON is error-prone; replacing that
+with a command that silently overwrites or produces subtly-broken
+configs would be worse than the current workflow. Validation must ship
+with the happy path.
+
+**Independent Test**: Invoke the command with each of the failure
+conditions below; verify each exits non-zero and prints an operator-
+readable error that names the offending input.
+
+**Acceptance Scenarios**:
+
+1. **Given** `owner/repo` already exists in the merged fleet config
+   (whether from `fleet.json`, `fleet.local.json`, or both), **When**
+   the operator runs `gh-aw-fleet add owner/repo --profile default`,
+   **Then** the command exits non-zero with an error naming the repo
+   and the source file, and no preview is printed.
+2. **Given** the operator passes `--profile nonexistent`, **When** the
+   command resolves profiles, **Then** it exits non-zero listing the
+   profiles available in the merged config.
+3. **Given** the operator passes an argument that is not in
+   `owner/repo` slug form (e.g., `just-a-name`, `owner/`, `/repo`, an
+   empty string), **When** the command parses positional arguments,
+   **Then** it exits non-zero with a validation error.
+
+> **Note**: Two additional failure conditions — unknown `--engine`
+> value and no-op `--exclude` — are intrinsically tied to flags
+> introduced in User Story 3 and are therefore specified as part of
+> US3's acceptance scenarios. US2 covers only the failure conditions
+> testable with the US1 flag surface (`--profile`, positional slug).
+
+---
+
+### User Story 3 — Express per-repo customization at onboarding time (Priority: P2)
+
+The operator sometimes needs a new repo to diverge from pure profile
+membership on day one — excluding a workflow the profile includes,
+adding one the profile doesn't, or overriding the default engine. They
+want to express all of that on the `add` command line rather than
+running `add` and then hand-editing.
+
+**Why this priority**: Most onboardings will use the `--profile
+default` case only (story 1). Per-repo divergence is common enough to
+require command-line flags but not so dominant that story 1 is blocked
+on it.
+
+**Independent Test**: Add a repo with `--profile default --exclude
+ci-doctor --extra-workflow custom-thing --engine claude`; inspect the
+written `fleet.local.json` and confirm all four fields are populated.
+
+**Acceptance Scenarios**:
+
+1. **Given** `--exclude` is passed one or more times, **When** the
+   repo is written, **Then** each excluded workflow name appears once
+   in the `exclude` array under the new `repos.owner/repo` entry.
+2. **Given** `--extra-workflow` is passed one or more times, **When**
+   the repo is written, **Then** each extra workflow name appears as
+   an entry in the `extra` array. Default source for an extra workflow
+   is `local` unless a `name@source` (or `name@source@ref`) form is
+   used.
+3. **Given** `--engine claude`, **When** the repo is written, **Then**
+   the `engine` field is set on the new repo entry (overriding the
+   fleet default).
+4. **Given** none of `--exclude`, `--extra-workflow`, `--engine` are
+   passed, **When** the repo is written, **Then** those JSON fields are
+   omitted (they have `omitempty`) so the entry is minimal.
+5. **Given** the operator passes `--engine unknown-engine-xyz`,
+   **When** the command validates the engine override, **Then** it
+   exits non-zero with an error naming the unsupported engine and
+   listing the accepted values (the keys of `EngineSecrets`).
+6. **Given** the operator passes `--exclude workflow-x` where
+   `workflow-x` is not a member of any of the selected profiles,
+   **When** the command resolves workflows, **Then** it emits a
+   warning on stderr naming the offending exclusion but exits zero
+   (the exclusion is a no-op; the operation still proceeds).
+
+---
+
+### Edge Cases
+
+- **Neither `fleet.json` nor `fleet.local.json` exists.** The command
+  should exit non-zero with the same "no config found" error
+  `LoadConfig` already emits. Bootstrapping an empty fleet from the
+  `add` command is out of scope for this issue.
+- **`fleet.json` and `fleet.local.json` disagree on a profile
+  definition.** The merged view (local wins) is what gets validated
+  against. The operator's `--profile` must resolve in the merged view.
+- **`--apply` is passed without `--yes` in a non-interactive shell.**
+  The command must either prompt (when stdin is a TTY) or fail with an
+  actionable "re-run with `--yes` to confirm" message (when stdin is
+  not a TTY). Silent non-interactive writes are forbidden.
+- **Concurrent invocations.** Two `add --apply` calls racing on the
+  same file could lose one entry. The tool already uses atomic rename
+  in `writeJSON`, so the loser gets clobbered but no partial file is
+  produced. Acceptable for a local single-operator CLI; documented in
+  assumptions.
+- **Slug casing.** `Owner/Repo` and `owner/repo` are treated as
+  distinct keys by Go's `map[string]RepoSpec`. The command should
+  normalize to lowercase at parse time (GitHub URLs are
+  case-insensitive) to avoid silent duplicates.
+- **Repo already exists in `fleet.json` (public example) but not in
+  `fleet.local.json`.** This is NOT a duplicate from the operator's
+  perspective — they may legitimately want to shadow the public
+  example with a local entry. The command should treat presence in the
+  merged view as a duplicate, however, because overriding via `add`
+  without an explicit gesture is surprising. Exit non-zero; document
+  the workaround ("hand-edit `fleet.local.json` if you want to shadow
+  a `fleet.json` entry").
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST expose `gh-aw-fleet add <owner/repo>` as a
+  top-level subcommand, replacing the existing stub in `cmd/stubs.go`.
+- **FR-002**: The command MUST be dry-run by default, matching the
+  `deploy` / `sync` / `upgrade` convention, and MUST require an explicit
+  `--apply` flag to write to disk.
+- **FR-003**: When `--apply` is passed, the command MUST additionally
+  require confirmation via either a `--yes` flag or an interactive
+  stdin prompt; it MUST exit non-zero if neither is available.
+- **FR-004**: The command MUST accept a single positional argument in
+  `owner/repo` form. It MUST normalize casing to lowercase before
+  comparing or writing. It MUST reject malformed slugs (missing slash,
+  empty halves, whitespace).
+- **FR-005**: The command MUST accept `--profile <name>` (repeatable or
+  comma-separated, matching how `RepoSpec.Profiles` is modeled as a
+  list). At least one profile MUST be specified unless the operator
+  explicitly passes `--no-profile` (out of scope for v1 — v1 requires
+  `--profile`).
+- **FR-006**: The command MUST accept `--engine <name>` (zero or one);
+  if provided, it MUST validate the name against the keys of the
+  existing `EngineSecrets` map in `internal/fleet/deploy.go`, rejecting
+  unknown values with an error that lists the accepted names. The
+  `deploy` path's current permissive behavior (skip secret check on
+  unknown engine) is unchanged; `add` is deliberately stricter so that
+  onboarding-time typos never reach `deploy`.
+- **FR-007**: The command MUST accept `--exclude <workflow-name>` as a
+  repeatable flag and populate `RepoSpec.ExcludeFromProfiles`.
+- **FR-008**: The command MUST accept `--extra-workflow <spec>` as a
+  repeatable flag and populate `RepoSpec.ExtraWorkflows`. The flag
+  value MUST accept the existing `gh aw`-style spec syntax operators
+  already use in `fleet.json`:
+  - Bare `name` → `Name=name`, `Source="local"`, `Ref=""`, `Path=""`.
+  - `owner/repo/name@ref` (3-part agentics layout) →
+    `Name=name`, `Source="owner/repo"`, `Ref=ref`, `Path=""`.
+  - `owner/repo/.github/workflows/name.md@ref` (4-part gh-aw layout) →
+    `Name=name` (derived from the basename), `Source="owner/repo"`,
+    `Ref=ref`, `Path=".github/workflows/name.md"`.
+  A single parser MUST populate all four `ExtraWorkflow` fields from
+  one flag value; invalid forms MUST be rejected with an error that
+  shows an example of the correct syntax.
+- **FR-009**: Before any validation, the command MUST load the fleet
+  config via the existing `LoadConfig` routine (base + local merge
+  semantics).
+- **FR-010**: The command MUST reject adding a repo that already exists
+  in the merged fleet view, naming the source file (`fleet.json`
+  and/or `fleet.local.json`) in the error message.
+- **FR-011**: The command MUST validate that every `--profile` name
+  exists in the merged `Profiles` map; on failure, it MUST list the
+  available profiles in the error output.
+- **FR-012**: The command MUST resolve the candidate `RepoSpec` through
+  the existing `ResolveRepoWorkflows` logic to produce the workflow set
+  used in the preview, exercising the same code path `deploy` will use.
+- **FR-013**: In dry-run mode, the command MUST print a preview in
+  plain text using the same style as `deploy`'s dry-run and `list`'s
+  summary. The preview MUST contain:
+  - A header line on **stderr** naming the target repo slug, the
+    profile list, and the resolved workflow count, e.g.:
+    `would add rshade/foo with profiles [default] (12 workflows)`.
+  - A bulleted list of the resolved workflow names on **stdout**, one
+    per line, in resolution order (profile membership first, then
+    extras), with each line prefixed by a visual marker (e.g., `- `).
+  - Any resolution warnings (e.g., an `--exclude` that didn't match
+    anything in the selected profiles) printed on **stderr** after the
+    header.
+  - A final "next step" hint on stderr telling the operator to re-run
+    with `--apply` to persist.
+  No machine-readable (JSON) output mode is provided in v1; the
+  stdout/stderr split is the only structure acceptance tests should
+  rely on.
+- **FR-014**: In `--apply` mode, after confirmation, the command MUST
+  write the updated config exclusively to `fleet.local.json` — never
+  to `fleet.json`. It MUST NOT modify the public `fleet.json` under any
+  circumstance, including when `fleet.local.json` did not previously
+  exist.
+- **FR-015**: When `fleet.local.json` does not exist and only
+  `fleet.json` is present, the command on `--apply` MUST synthesize a
+  **minimal** `fleet.local.json` containing exactly:
+  - `version` set to the current `SchemaVersion`.
+  - `repos` populated with a single entry for the new repo.
+  It MUST NOT copy `defaults`, `profiles`, or peer `repos` entries
+  from `fleet.json` into the new local file. The existing
+  `mergeConfigs` helper in `internal/fleet/load.go` supplies those
+  fields at load time by merging `fleet.json` underneath, so the
+  minimal local file remains correct for all downstream commands and
+  `fleet.json` stays authoritative for shared state. The command MUST
+  surface this transition in the output ("creating fleet.local.json
+  (minimal; profiles/defaults still resolved from fleet.json)").
+- **FR-016**: The command MUST write `fleet.local.json` atomically
+  (temp file + rename), matching the existing `writeJSON` pattern, so a
+  crash mid-write cannot leave a partial file.
+- **FR-017**: After a successful `--apply`, the command MUST print the
+  next step: `gh-aw-fleet deploy <owner/repo>`.
+- **FR-018**: On any error, the command MUST exit non-zero; on dry-run
+  success it MUST exit zero; on `--apply` success it MUST exit zero.
+- **FR-019**: The `fleet-onboard-repo` skill at
+  `skills/fleet-onboard-repo/SKILL.md` MUST be updated so the JSON-
+  editing step is replaced with a `gh-aw-fleet add` invocation.
+- **FR-020**: The README's CLI / Quickstart section MUST be updated to
+  document the `add` command alongside `deploy`, `sync`, and `upgrade`.
+- **FR-021**: The existing `SaveConfig` helper at
+  `internal/fleet/load.go` MUST be adjusted or supplemented so that
+  saving via the `add` path always targets `fleet.local.json`. Calling
+  `SaveConfig` with intent to modify `fleet.json` from the `add` flow
+  MUST be impossible by construction, not just by convention.
+
+### Key Entities
+
+- **RepoSpec (existing)**: The per-repo desired state in
+  `internal/fleet/schema.go` — profiles, engine override, extra
+  workflows, exclusions, overrides. `add` constructs a new instance and
+  inserts it into `Config.Repos`.
+- **Config (existing)**: The top-level declarative state. `add` reads
+  it via `LoadConfig` and writes a modified version to
+  `fleet.local.json`.
+- **AddResult (new)**: Return value from `fleet.Add()`. Carries the
+  target repo, selected profiles, resolved workflow list, engine
+  override (if any), non-fatal warnings, and — in `--apply` mode —
+  flags recording whether and where `fleet.local.json` was written
+  (including whether the file had to be synthesized from a
+  `fleet.json`-only baseline). Used to render the dry-run preview
+  AND as the test-assertion surface. See `data-model.md` for the
+  exact field list.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can onboard a new repo with the default
+  profile in a single command (no text editor, no JSON hand-typing).
+  Measured by: the documented quickstart procedure reduces from
+  ≥6 manual steps (edit file, re-read schema, save, run list, etc.) to
+  1 command.
+- **SC-002**: 100% of invocations that would produce an invalid
+  `fleet.local.json` (duplicate key, unknown profile, malformed slug,
+  unknown engine) are rejected before any file write occurs.
+- **SC-003**: 0 invocations of `add` modify `fleet.json`. Verifiable by
+  inspection of the command's file-write call sites and by integration
+  test.
+- **SC-004**: The `fleet-onboard-repo` skill's post-update instructions
+  fit in ≤5 lines and contain no JSON editing guidance.
+- **SC-005**: Dry-run preview output is understandable on first read:
+  the repo slug, profile list, and workflow count are all visible
+  without scrolling on an 80-column terminal for profiles with ≤20
+  workflows.
+- **SC-006**: The command completes (dry-run or `--apply`) in under 2
+  seconds on a warm cache, with no network calls required beyond what
+  `LoadConfig` and `ResolveRepoWorkflows` already perform (which today
+  is zero).
+
+## Assumptions
+
+- The operator already has a valid `fleet.json` or
+  `fleet.local.json` checked out. Bootstrapping an empty fleet
+  (`fleet init`) is out of scope and tracked separately.
+- The set of valid engine names comes from the keys of the
+  `EngineSecrets` map declared in `internal/fleet/deploy.go`. `add`
+  validates against that map; `deploy` continues its current permissive
+  behavior (unknown engine → skip secret check, no rejection). Keeping
+  the allowlist in one place (`EngineSecrets`) means adding a new
+  supported engine still only requires one edit.
+- The operator onboards one repo per `add` invocation. Bulk add (e.g.,
+  reading a list of slugs from stdin) is out of scope.
+- `Overrides` (the per-workflow `map[string]string` field on
+  `RepoSpec`) is not exposed via `add` flags in v1 — it is rarely set
+  at onboarding time, and the few operators who need it can hand-edit
+  `fleet.local.json` after running `add`.
+- Because `LoadConfig` merges local over base, duplicate detection
+  uses the merged view: if the repo exists anywhere (base or local),
+  `add` treats it as a duplicate and refuses. Shadowing a public
+  `fleet.json` entry with a private local override is an intentionally-
+  restricted workflow that still requires hand-editing.
+- `--apply` confirmation in non-TTY environments (CI, hooks, piped
+  shells) requires `--yes`. This is intentionally stricter than the
+  interactive flow because automated use of `add` is unusual and the
+  write target is a source-of-truth file.
+- The JSON output format of `fleet.local.json` after `add --apply`
+  uses the same `MarshalIndent("", "  ")` style that `writeJSON`
+  already produces; key ordering follows Go's struct field order for
+  `Config` (stable) and alphabetical order for the `Repos` /
+  `Profiles` maps (from `encoding/json`'s map handling).

--- a/specs/001-add-subcommand/tasks.md
+++ b/specs/001-add-subcommand/tasks.md
@@ -1,0 +1,271 @@
+---
+
+description: "Task list for implementing the add <owner/repo> subcommand"
+---
+
+# Tasks: `add <owner/repo>` Subcommand for Fleet Onboarding
+
+**Input**: Design documents from `specs/001-add-subcommand/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cli.md, quickstart.md
+
+**Tests**: INCLUDED. spec.md §"Testing Strategy" explicitly requests
+unit tests for `Add()`, `SaveConfig` round-trip, duplicate-repo error
+path, and unknown-profile error path. A manual integration test is
+documented in quickstart.md §"Manual integration test."
+
+**Organization**: Tasks are grouped by user story so each can be
+implemented, tested, and delivered independently. US1 = happy-path
+onboarding (MVP), US2 = actionable validation errors, US3 = per-repo
+customization flags.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on
+  incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- All file paths are relative to the repository root:
+  `/mnt/c/GitHub/go/src/github.com/rshade/gh-aw/`
+
+## Path Conventions
+
+Single-project Go CLI. Key locations:
+
+- `cmd/` — cobra command definitions (one file per subcommand)
+- `internal/fleet/` — core logic, no cobra dependencies
+- `skills/` — operator workflow documentation
+- Tests live alongside source in the same package (`_test.go`)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the build environment is clean and verify the
+one optional dependency called for in research.md §4.
+
+- [X] T001 Verify baseline build by running `go build ./...` and `go vet ./...` on the current branch; both must exit 0 before any implementation begins. If `golang.org/x/term` is not already a transitive dependency (`go mod graph | grep 'golang.org/x/term'`), record that T011 will need to add it to `go.mod`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the pure helpers and types that every user
+story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is
+complete.
+
+- [X] T002 Create `internal/fleet/add.go` with package docs, `AddOptions` struct, and `AddResult` struct per data-model.md §"New types"
+- [X] T003 Implement `validateSlug(s string) (string, error)` in `internal/fleet/add.go` per research.md §6 (trim, reject empty, split on `/`, require exactly 2 non-empty halves, lowercase, enforce `[a-z0-9._-]+` character class)
+- [X] T004 Implement `BuildMinimalLocalConfig(repo string, spec RepoSpec) *Config` in `internal/fleet/add.go` per data-model.md §"Supporting helper: BuildMinimalLocalConfig" (returns Config with only `Version` and `Repos` set)
+- [X] T005 [P] Rename `SaveConfig` → `SaveLocalConfig` in `internal/fleet/load.go:95-99`; change target from `ConfigFile` to `LocalConfigFile`; delete the old `SaveConfig` declaration entirely so no function in the package can write to `fleet.json` (satisfies FR-021)
+- [X] T006 Create `internal/fleet/add_test.go` with `TestValidateSlug` table-driven test covering: valid slugs (incl. case normalization, allowed chars `.`, `_`, `-`), empty string, missing slash, empty halves, whitespace, too many slashes, invalid characters
+- [X] T007 Add `TestBuildMinimalLocalConfig` to `internal/fleet/add_test.go` asserting the produced `*Config` JSON-marshals to a blob with exactly top-level keys `version` and `repos` (no `defaults`, no `profiles`)
+- [X] T008 Add `TestSaveLocalConfig_WritesLocalFile` to `internal/fleet/add_test.go` using `t.TempDir()`: call `SaveLocalConfig`, assert `fleet.local.json` exists with expected content, assert `fleet.json` was NOT created
+
+**Checkpoint**: Foundation ready — all helpers are implemented and
+unit-tested. User story phases can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Onboard a new repo declaratively with a profile (Priority: P1) 🎯 MVP
+
+**Goal**: Operator runs `gh-aw-fleet add rshade/new-repo --profile default [--apply --yes]` and gets either (a) a dry-run preview or (b) a written `fleet.local.json` and a "next: gh-aw-fleet deploy" hint. Default-profile case only; customization flags come in US3.
+
+**Independent Test**: On a fresh checkout with only `fleet.json`
+present (no `fleet.local.json`), run the command in dry-run mode,
+confirm preview on stderr + workflow list on stdout, no file
+changes. Re-run with `--apply --yes`, confirm `fleet.local.json` is
+written as a minimal file and `gh-aw-fleet list` now surfaces the
+new repo.
+
+### Tests for User Story 1
+
+> **NOTE**: Write each test and confirm it FAILS before implementing the corresponding behavior.
+
+- [X] T009 [US1] Add `TestAdd_DryRun_HappyPath` to `internal/fleet/add_test.go` — given a Config with a `default` profile and no repo entry, call `Add()` with `Apply=false`; assert returned `AddResult` has correct `Repo`, `Profiles`, non-empty `Resolved`, `WroteLocal == false`, and no file is written to the temp dir
+- [X] T010 [US1] Add `TestAdd_Apply_HappyPath` to `internal/fleet/add_test.go` — same Config as T009, but `Apply=true, Confirmed=true`; assert `fleet.local.json` is written to `t.TempDir()`, its content matches `BuildMinimalLocalConfig` output exactly, and `fleet.json` in the temp dir is byte-identical before and after
+- [X] T011 [US1] Add `TestAdd_Apply_SynthesizesLocalFromJSON` to `internal/fleet/add_test.go` — temp dir has only `fleet.json` (no `fleet.local.json`); after `Add()` with `Apply=true, Confirmed=true`, assert `fleet.local.json` exists and is minimal, `fleet.json` unchanged, and the returned `AddResult.SynthesizedLocal == true`
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement `Add(cfg *Config, opts AddOptions) (*AddResult, error)` skeleton in `internal/fleet/add.go`: (1) validate `opts.Repo` (already normalized by caller), (2) reject if `cfg.Repos[opts.Repo]` already exists (basic error — US2 upgrades messaging), (3) reject if any `opts.Profiles` entry is not in `cfg.Profiles` (basic error — US2 upgrades messaging), (4) build candidate `RepoSpec{Profiles: opts.Profiles}` (engine/exclude/extra stay zero — US3 wires those), (5) transiently set `cfg.Repos[opts.Repo] = candidate`, (6) call `cfg.ResolveRepoWorkflows(opts.Repo)`, (7) populate and return `AddResult`
+- [X] T013 [US1] Extend `Add()` with the `--apply` branch: detect whether `fleet.local.json` exists (via `os.Stat` on `filepath.Join(opts.Dir, LocalConfigFile)`), call `BuildMinimalLocalConfig(opts.Repo, candidate)`, call `SaveLocalConfig(opts.Dir, minimal)`, set `WroteLocal=true` and `SynthesizedLocal` accordingly, populate `LocalPath`
+- [X] T014 [P] [US1] Create `cmd/add.go` with `newAddCmd(flagDir *string)` function: cobra command with `Use: "add <owner/repo>"`, `Args: cobra.ExactArgs(1)`, flags `--profile` (`StringSliceVar`, required, repeatable or comma-separated per research.md §1), `--apply` (bool), `--yes` (bool); `RunE` calls `validateSlug`, detects TTY via `term.IsTerminal(int(os.Stdin.Fd()))` from `golang.org/x/term` (add to `go.mod` if absent), prompts with `Write fleet.local.json? [y/N]` in TTY mode when `--apply` without `--yes`, errors otherwise, calls `fleet.LoadConfig` then `fleet.Add`, calls a new `printAdd` helper to render output
+- [X] T015 [US1] Implement `printAdd(cmd *cobra.Command, res *fleet.AddResult, apply bool)` in `cmd/add.go` rendering per contracts/cli.md "Stdout" and "Stderr" sections: header line on stderr (tense varies by apply flag), workflow list on stdout (one `- <name>` per line, resolution order), next-step hint on stderr
+- [X] T016 [US1] Remove `newAddCmd` stub from `cmd/stubs.go` (keep `newStatusCmd`). Root command in `cmd/root.go` already wires `newAddCmd` — verify no changes needed there by reading `cmd/root.go`
+- [X] T017 [US1] Run `go build ./...` and `go vet ./...`; fix any errors. Run `go test ./internal/fleet/ -run TestAdd -v`; confirm T009, T010, T011 all pass.
+
+**Checkpoint**: MVP complete. `gh-aw-fleet add <owner/repo> --profile default [--apply --yes]` is fully functional for the default-profile happy path. Error messages are minimal but errors exit non-zero. Duplicate-repo, unknown-profile, slug-validation paths work but lack actionable detail.
+
+---
+
+## Phase 4: User Story 2 — Validate before writing (Priority: P1)
+
+**Goal**: Every error path produces an actionable, operator-readable
+message: duplicate-repo names the source file, unknown-profile lists
+available profiles, malformed-slug shows a valid example. This story
+upgrades US1's error messaging; the happy path is unchanged.
+
+**Independent Test**: Invoke the command with each failure condition
+(duplicate, unknown profile, malformed slug); verify each exits
+non-zero AND the stderr message names the offending input along with
+a remediation hint (source file, profile list, example slug).
+
+### Tests for User Story 2
+
+- [X] T018 [US2] Add `TestAdd_DuplicateRepo_NamesSourceFile` to `internal/fleet/add_test.go` — three subtests: repo exists in `fleet.json` only, `fleet.local.json` only, both; assert error string contains the correct file name(s) in each case
+- [X] T019 [US2] Add `TestAdd_UnknownProfile_ListsAvailable` to `internal/fleet/add_test.go` — Config has profiles `[default, experimental]`; call `Add()` with `Profiles: ["nonexistent"]`; assert error contains both available profile names alphabetically
+- [X] T020 [US2] Extend `TestValidateSlug` (from T006) with malformed-slug subtests asserting error messages contain an example of valid form (e.g., `"owner/repo"`)
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Upgrade duplicate-repo error in `Add()` (from T012): determine source by checking `base.Repos` vs `local.Repos` — requires exposing which file contains the entry. Use the `Config.LoadedFrom` field (already populated by `LoadConfig`) to derive the phrasing. Error format: `repo %q already exists in %s` where `%s` is the relevant file(s).
+- [X] T022 [US2] Upgrade unknown-profile error in `Add()` (from T012): on mismatch, collect sorted keys of `cfg.Profiles` and include in error. Format: `profile %q not defined; available profiles: [%s]`
+- [X] T023 [US2] Upgrade `validateSlug` error in `internal/fleet/add.go` (from T003) to include a valid example in every failure message. Format: `invalid repo slug %q: %s; expected form: owner/repo`
+- [X] T024 [US2] Run `go build ./...`, `go vet ./...`, and `go test ./internal/fleet/ -run TestAdd -v`; confirm T018, T019, T020 pass along with US1 tests.
+
+**Checkpoint**: US1 + US2 complete. All error paths produce actionable
+messages. Happy path unchanged. The MVP is now also "safe to use
+without consulting docs."
+
+---
+
+## Phase 5: User Story 3 — Per-repo customization at onboarding time (Priority: P2)
+
+**Goal**: Add `--engine`, `--exclude`, `--extra-workflow` flags and
+their validation / warning behavior. `--extra-workflow` uses the
+`gh aw`-style spec syntax per FR-008.
+
+**Independent Test**: Run `add rshade/foo --profile default --engine claude --exclude ci-doctor --extra-workflow githubnext/agentics/security-guardian@v0.4.1 --apply --yes`; inspect `fleet.local.json` and confirm all four fields (`profiles`, `engine`, `exclude`, `extra`) are populated in the single new repo entry. Test each flag in isolation too.
+
+### Tests for User Story 3
+
+- [X] T025 [US3] Add `TestParseExtraWorkflowSpec` to `internal/fleet/add_test.go` — table-driven; subtests for: bare `name` → local; `owner/repo/name@ref` (3-part agentics) → remote with source/ref; `owner/repo/.github/workflows/name.md@ref` (4-part gh-aw) → remote with source/ref/path; error cases (no `@ref`, `owner/repo` alone, malformed path prefix)
+- [X] T026 [US3] Add `TestAdd_UnknownEngine` to `internal/fleet/add_test.go` — call `Add()` with `Engine: "fictional-engine"`; assert error names rejected value and lists accepted engines (from `EngineSecrets` keys, sorted)
+- [X] T027 [US3] Add `TestAdd_CustomizationFlags_WriteCorrectSpec` to `internal/fleet/add_test.go` — `Apply=true, Confirmed=true` with all three flags populated; assert written `fleet.local.json` contains a `RepoSpec` with correct `Engine`, `ExcludeFromProfiles`, and `ExtraWorkflows` (parsed) entries
+- [X] T028 [US3] Add `TestAdd_Warnings` to `internal/fleet/add_test.go` — three subtests per research.md §3: (a) `--exclude` name not in any selected profile → warning includes name, exit 0; (b) `--extra-workflow` with a name that's also in a selected profile → warning about shadowing, exit 0; (c) profile resolves to zero workflows (e.g., all excluded) → warning about zero-resolved, exit 0
+
+### Implementation for User Story 3
+
+- [X] T029 [US3] Implement `parseExtraWorkflowSpec(s string) (ExtraWorkflow, error)` in `internal/fleet/add.go` per research.md §7: no slash → local; with `@`, split lhs on `/` → 3-part (agentics) or 4+ part starting with `.github/workflows/` (gh-aw 4-part); every other shape errors with an example
+- [X] T030 [US3] Extend `Add()` in `internal/fleet/add.go` to call `parseExtraWorkflowSpec` for each `opts.ExtraWorkflows` entry, propagate parse errors early (before any mutation), and populate `candidate.ExtraWorkflows`
+- [X] T031 [US3] Extend `Add()` with engine validation: if `opts.Engine != ""`, check `_, ok := EngineSecrets[opts.Engine]`; on miss, error with sorted list of accepted keys. Then set `candidate.Engine = opts.Engine`.
+- [X] T032 [US3] Extend `Add()` to populate `candidate.ExcludeFromProfiles = opts.Excludes`
+- [X] T033 [US3] Implement warning collection in `Add()` per research.md §3: after resolution, (a) for each `opts.Excludes` entry that didn't match any workflow in the selected profiles, append warning; (b) for each parsed extra whose Name also appears in a selected profile's workflow list, append warning; (c) if `len(result.Resolved) == 0`, append a loud warning. All warnings go into `AddResult.Warnings`.
+- [X] T034 [US3] Add `--engine` (`StringVar`), `--exclude` (`StringArrayVar`, repeatable), `--extra-workflow` (`StringArrayVar`, repeatable) flags to `cmd/add.go` (from T014). Wire them into `AddOptions.Engine`, `.Excludes`, `.ExtraWorkflows` respectively.
+- [X] T035 [US3] Update `printAdd` in `cmd/add.go` (from T015) to render the engine-override line (`engine override: <name>` on stderr, only when set) between the header and any warnings, and render warnings as `warning: <message>` on stderr after the header/engine line and before the next-step hint
+- [X] T036 [US3] Run `go build ./...`, `go vet ./...`, and `go test ./internal/fleet/ -run TestAdd -v` and `-run TestParseExtraWorkflowSpec -v`; confirm T025, T026, T027, T028 pass along with all US1 + US2 tests.
+
+**Checkpoint**: All three user stories complete. Full flag surface
+matches contracts/cli.md. All unit tests pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update operator-facing documentation and the skill that
+advertises the now-obsolete JSON-editing workflow. Perform the manual
+integration test from quickstart.md.
+
+- [X] T037 [P] Update `skills/fleet-onboard-repo/SKILL.md` (FR-019): replace the "edit `fleet.local.json` by hand" step with a `gh-aw-fleet add <owner/repo> --profile <name>` invocation (dry-run then `--apply --yes`). Preserve the three-turn pattern structure. Verify the final skill instructions fit in ≤5 lines and contain no JSON editing guidance (SC-004).
+- [X] T038 [P] Update `README.md` (FR-020): add `add` to the CLI surface list (wherever `deploy`, `sync`, `upgrade` are already enumerated); add a Quickstart section showing `gh-aw-fleet add <owner/repo> --profile default --apply --yes` before `gh-aw-fleet deploy <owner/repo>`
+- [X] T039 Run full build + vet + test sweep: `go build ./... && go vet ./... && go test ./...`; all must exit 0
+- [X] T040 Run `markdownlint specs/001-add-subcommand/*.md skills/fleet-onboard-repo/SKILL.md README.md`; fix any issues surfaced
+- [X] T041 Execute the manual integration test documented in `specs/001-add-subcommand/quickstart.md` §"Manual integration test (for reviewers of PR #9)" — fresh working dir, run `add` dry-run then `--apply --yes`, verify file contents exactly (`{"version": 1, "repos": {...}}`), confirm `fleet.json` byte-identical, confirm `list` surfaces the new entry, confirm re-run produces duplicate error. Record pass/fail in the PR description.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies. T001 runs first.
+- **Phase 2 (Foundational)**: Depends on T001 passing. BLOCKS all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2 complete. Independently shippable as MVP.
+- **Phase 4 (US2)**: Depends on Phase 3 complete (it upgrades US1's error messaging in-place).
+- **Phase 5 (US3)**: Depends on Phase 2 complete. Can technically run in parallel with Phase 3 if staffed, but shares `cmd/add.go` and `internal/fleet/add.go` with US1 — prefer sequential.
+- **Phase 6 (Polish)**: Depends on desired user stories complete. Run before opening the PR.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2. Self-contained.
+- **US2 (P1)**: Depends on US1 — T021/T022/T023 modify code introduced in US1.
+- **US3 (P2)**: Can start after Phase 2 (the helpers); T025/T029 are independent of US1. T030–T035 modify code introduced in US1; in practice, run US3 after US2.
+
+### Within Each User Story
+
+- Tests written BEFORE the implementation that makes them pass (TDD per spec.md's "Testing Strategy").
+- Within `internal/fleet/add.go`: types → helpers → `Add()` body. Within `cmd/add.go`: command scaffold → flag wiring → print rendering.
+- Story's final task is a verification run (`go build`, `go vet`, `go test ./internal/fleet/ -run TestAdd -v`).
+
+### Parallel Opportunities
+
+- **Phase 2**: T005 (`internal/fleet/load.go`) runs in parallel with T002–T004 (`internal/fleet/add.go`) — different files.
+- **Phase 3**: T014 (`cmd/add.go` scaffold, new file) can run in parallel with T009–T011 (`internal/fleet/add_test.go`, different file) once the `Add` signature exists (after T012).
+- **Phase 6**: T037 and T038 modify different files (SKILL.md and README.md) — can run in parallel.
+- **Within a single `_test.go` file**: test additions are SEQUENTIAL (same-file edits conflict). Do not parallelize test-case additions within `internal/fleet/add_test.go`.
+
+---
+
+## Parallel Example: Phase 2 Foundational
+
+```bash
+# After T001 passes, these three can run in parallel:
+Task: "T002 Create internal/fleet/add.go with AddOptions and AddResult types"
+Task: "T005 Rename SaveConfig → SaveLocalConfig in internal/fleet/load.go"
+# (T003/T004 must wait for T002, since they add functions to the same new file.)
+```
+
+## Parallel Example: Phase 3 User Story 1
+
+```bash
+# After T012 + T013 complete:
+Task: "T014 Create cmd/add.go with cobra command (different file)"
+Task: "T009/T010/T011 Add tests to internal/fleet/add_test.go (different file)"
+# Note: T009, T010, T011 themselves are SEQUENTIAL because they share add_test.go.
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (T001)
+2. Complete Phase 2 (T002–T008)
+3. Complete Phase 3 / US1 (T009–T017)
+4. **STOP and VALIDATE**: run quickstart.md §"Step 1" through §"Step 4" manually. Confirm: dry-run preview readable, `--apply --yes` writes minimal file, `fleet.json` untouched, `gh-aw-fleet list` surfaces new entry.
+5. If the MVP holds, open a draft PR with the US1 scope for early review.
+
+### Incremental Delivery
+
+1. Complete Phase 1 + 2 → foundation ready
+2. Add US1 → MVP → demo
+3. Add US2 → error messaging is now production-quality
+4. Add US3 → full flag surface
+5. Phase 6 → documentation + skill update + manual integration test → merge-ready PR
+
+### Parallel Team Strategy (if staffed)
+
+1. Developer A: Phase 1 + 2 (T001–T008)
+2. After Phase 2 completes:
+   - Developer A: US1 (T009–T017)
+   - Developer B: US3 helpers ONLY (T025 + T029) — they don't touch US1 code
+3. After US1 completes:
+   - Developer A: US2 (T018–T024)
+   - Developer B: rest of US3 (T026–T036)
+4. Either developer: Phase 6 (T037–T041)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- Setup (Phase 1) and Foundational (Phase 2) tasks have NO [Story] label
+- Polish (Phase 6) tasks have NO [Story] label
+- Commit after each user-story phase is recommended but not required (spec.md Out of Scope: "Pushing the change to a remote git repo (this is local config only)" applies to the `add` command — this note is about the implementing PR's git hygiene)
+- All commit messages for this work follow the project convention: `ci(workflows)` scope, Conventional Commits format, subject ≤72 chars (per CLAUDE.md and plan.md Constitution Check §III)
+- Verify every test FAILS before implementing the behavior it asserts (TDD per spec.md §"Testing Strategy")
+- Stop at any checkpoint to validate the current story independently against quickstart.md
+- Avoid: modifying files outside the "Files Likely Affected" list in spec.md without a written rationale; same-file parallelization; cross-story coupling that breaks US1's independent shippability


### PR DESCRIPTION
## Summary

- Operators can register a new repo in `fleet.local.json` via CLI instead of hand-editing JSON, eliminating the error-prone step in the `fleet-onboard-repo` skill.
- Dry-run by default; `--apply --yes` performs an atomic write of a minimal local config (only `version` + the new repo entry), leaving `fleet.json` byte-identical.
- Runs the candidate spec through the production `ResolveRepoWorkflows` resolver before any write, so the preview matches what `deploy` will actually install.
- Supports per-repo customization at onboarding: `--profile` (required, repeatable), `--engine`, `--exclude`, `--extra-workflow` (accepts bare-name, 3-part agentics, or 4-part gh-aw specs).
- Produces actionable error messages: duplicate-repo names the source file, unknown-profile lists available profiles alphabetically, malformed slugs show a valid-form example.
- Emits non-fatal warnings for no-op `--exclude` values, shadowed extras, and zero-resolved workflow sets.
- `SaveConfig` is removed in favor of `SaveLocalConfig` so no code path in the package can overwrite the public `fleet.json` (FR-014 / FR-021).

## Test plan

- [x] `go build ./...` passes clean
- [x] `go vet ./...` passes clean
- [x] `go test ./...` passes (35+ new subtests across `TestAdd*`, `TestValidateSlug`, `TestParseExtraWorkflowSpec`, `TestBuildMinimalLocalConfig`, `TestSaveLocalConfig`)
- [x] Manual integration smoke test from `quickstart.md`: dry-run → `--apply --yes` → `list` verification → duplicate-repo error, with SHA-256 check confirming `fleet.json` is byte-identical across the run
- [x] `markdownlint` clean on updated `README.md`, `SKILL.md`, and spec docs

## Changes

### New files

- `cmd/add.go` — cobra command, flag parsing, TTY detection, `resolveConfirmation` (FR-003), `printAdd` renderer
- `internal/fleet/add.go` — `AddOptions`, `AddResult`, `Add`, `ValidateSlug`, `parseExtraWorkflowSpec`, `BuildMinimalLocalConfig`, `collectAddWarnings`, `duplicateRepoError`
- `internal/fleet/add_test.go` — table-driven unit tests for all of the above
- `specs/001-add-subcommand/` — spec, plan, research, data-model, contracts, quickstart, tasks, checklists

### Modified files

- `cmd/root.go` — wires `newAddCmd` into the root command
- `cmd/stubs.go` — removes `newAddCmd` stub (keeps `newStatusCmd`)
- `internal/fleet/load.go` — replaces `SaveConfig` with `SaveLocalConfig` targeting `fleet.local.json` only
- `internal/fleet/schema.go` — minor field exposure for the add path
- `skills/fleet-onboard-repo/SKILL.md` — replaces the hand-edit step with `gh-aw-fleet add` (dry-run then `--apply --yes`)
- `README.md` — documents the `add` subcommand in the CLI surface table and Quickstart
- `go.mod` / `go.sum` — adds `golang.org/x/term` for TTY detection

Closes #9