### PR TITLE
feat(cli): add --output json mode for list/deploy/sync/upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -433,16 +433,6 @@ linters:
     rules:
       - source: 'TODO'
         linters: [ godot ]
-      - text: 'should have a package comment'
-        linters: [ revive ]
-      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
-        linters: [ revive ]
-      - text: 'package comment should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive ]
-      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive, staticcheck ]
       - path: 'pkg/version/'
         text: 'var-naming: avoid package names that conflict with Go standard library package names'
         linters: [ revive ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ make ci          # runs: fmt-check vet lint test  (this is the CI gate)
 
 **Do not claim a task complete until `make ci` passes locally.** `go build` passing means nothing — prior commits have landed lint/fmt failures that CI rejected because only build+vet were run. When in doubt, run `make ci`.
 
-The CLI has two config files: `fleet.local.json` (private, gitignored, real fleet state) and `fleet.json` (public, committed, example tracking only `rshade/gh-aw-fleet`). `LoadConfig` tries `fleet.local.json` first and falls back. `go run . list` prints `(loaded fleet.local.json)` or `(loaded fleet.json)` to stderr so you know which is active.
+The CLI has two config files: `fleet.json` (public, committed, example tracking only `rshade/gh-aw-fleet`) and `fleet.local.json` (private, gitignored, real fleet state). `LoadConfig` reads `fleet.json` as the **base** and overlays `fleet.local.json` on top — when both exist they are merged (local profiles/repos/defaults add to or override base entries); when only one exists it is used directly. `go run . list` prints `(loaded fleet.json + fleet.local.json)`, `(loaded fleet.json)`, or `(loaded fleet.local.json)` to stderr so you know which mode is active.
 
 ## Architecture big-picture
 
@@ -51,8 +51,17 @@ The CLI has two config files: `fleet.local.json` (private, gitignored, real flee
 - **Never bypass gpg signing.** Don't add `--no-gpg-sign`, `-c commit.gpgsign=false`, or `git config commit.gpgsign false` to any command. The tool lets gpg fail; the user finishes manually in their shell. `.claude/settings.json` denies these at the allowlist level.
 - **Never run `git add`, `git commit`, `git push` from the Bash tool.** The Go tool invokes these via `exec.Command` inside `Deploy`/`Upgrade`/`Sync` — that's the one legitimate path. Claude never invokes git directly. `.claude/settings.json` deny list enforces this.
 - **Commit messages and PR titles use Conventional Commits with `ci(workflows)` scope.** See `commitMessage()` / `upgradeTitle()` in `internal/fleet/`. Subject ≤72 chars, no trailing period, type is always `ci` (these ARE CI configuration changes).
+- **Never hand-edit `CHANGELOG.md`.** Release-please manages it: on every push to `main`, the action in `.github/workflows/release-please.yml` opens a release PR that prepends a `## [version]` section generated from conventional commits. The type→section map lives in `release-please-config.json` (`feat:` → Added, `fix:` → Fixed, `refactor:` → Changed, `perf:` → Performance, `docs:` → Documentation; `chore:`/`ci:`/`build:`/`test:`/`style:` are hidden). The **commit message IS the changelog entry** — write the subject accordingly. Manual edits to version sections will be overwritten. This overrides the global CLAUDE.md rule "always update CHANGELOG.md." (The stale `## Unreleased` block at the top is a pre-automation artifact, not a pattern to extend.)
 - **Clone dirs at `/tmp/gh-aw-fleet-*` are breadcrumbs after failure** — the tool preserves them when `--apply` fails mid-pipeline. Don't delete them; the user inspects / resumes from them.
 - **`--work-dir` resumes a prior run.** Deploy's commit gate checks `hasStagedOrUnstagedWorkflowChanges` so a previously-interrupted `--apply` completes correctly when re-invoked with `--work-dir <clone>`.
+
+## Code self-documentation
+
+- **Every exported identifier gets a godoc comment.** Package, type, function, method, const, var, and exported struct field. Format: one complete sentence starting with the identifier name and ending with a period (`// Config is the declarative desired state for the fleet.`). For `Opts` / `Result` structs, document field meaning inline (`Force bool // pass --force to gh aw add`) — mirror the `DeployOpts` / `DeployResult` pattern in `internal/fleet/deploy.go`.
+- **One `// Package foo` comment per package** on any file. Keep it short (1–3 sentences describing scope, not a feature tour).
+- **Prefer expressive names over comments for unexported code.** If an internal helper needs a comment to explain *what* it does, rename it. Comments on unexported code should explain *why* — constraints, invariants, non-obvious tradeoffs — not restate the code.
+- **`make lint` enforces this** via `revive` and `staticcheck`. Do **not** re-add the `should have a package comment` / `exported X should have comment` suppressions to `.golangci.yml` — they were removed deliberately. If a check fires against a legitimate exception, narrow the suppression to that path, don't blanket-disable the rule.
+- **Two `SchemaVersion` constants live in this codebase.** `cmd.SchemaVersion` versions the JSON output envelope (wire contract); `fleet.SchemaVersion` versions the on-disk fleet.json format. They bump independently. Godoc on both must state which they are — the linter won't catch that they mean different things.
 
 ## Testing deploys requires care
 
@@ -60,7 +69,7 @@ The CLI has two config files: `fleet.local.json` (private, gitignored, real flee
 
 ## Skills
 
-The `skills/` directory contains four SKILL.md files codifying recurring operator workflows: `fleet-deploy`, `fleet-eval-templates`, `fleet-upgrade-review`, `fleet-onboard-repo`. Each skill encodes the three-turn pattern (dry-run → user approval → apply) and the gpg-failure manual-finish paste template. When adding features that affect these flows, update the relevant SKILL.md alongside the code.
+The `skills/` directory contains five SKILL.md files codifying recurring operator workflows: `fleet-deploy`, `fleet-eval-templates`, `fleet-upgrade-review`, `fleet-onboard-repo`, and `fleet-build-profile`. Each skill encodes the three-turn pattern (dry-run → user approval → apply) and the gpg-failure manual-finish paste template. `fleet-build-profile` picks up where `fleet-eval-templates` stops — the latter evaluates which upstream workflows deserve inclusion, the former materializes a chosen set as a `profiles.<name>` entry in `fleet.json` (and, for the `default` profile, the mirrored `profiles/default.json`). When adding features that affect these flows, update the relevant SKILL.md alongside the code.
 
 ## .claude/settings.json
 
@@ -70,6 +79,8 @@ Committed at repo root; shared with collaborators and subagents. Allows `go buil
 - Go 1.25.8 (from `go.mod`), using `github.com/spf13/cobra` v1.10.2 for CLI wiring and `github.com/rs/zerolog` v1.x for structured logging on stderr.
 - `fleet.local.json` is the private, gitignored source of truth; `fleet.json` is the committed public example.
 - Structured logging: `internal/log.Configure(level, format)` wires a zerolog global logger in root's `PersistentPreRunE`; warnings/errors/subprocess summaries emit on stderr, tabwriter status stays on stdout.
+- Go 1.25.8 (from `go.mod`). + `encoding/json` (stdlib, new usage site); `github.com/spf13/cobra` v1.10.2 (existing); `github.com/rs/zerolog` v1.35.1 (existing, landed in #34). No new third-party dependencies — constitution Principle I. (main)
+- N/A (no persistent state; envelope writes are transient to stdout). (main)
 
 ## Recent Changes
 - 002-add-zerolog-logging: added `--log-level` / `--log-format` persistent flags; `⚠ WARNING:` lines in `deploy`/`sync` moved to stderr as structured `warn` events; subprocess summaries at `debug`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All commands accept these persistent flags:
 | `--dir <path>` | `.` | Directory containing `fleet.json` / `fleet.local.json`. |
 | `--log-level <level>` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. Use `debug` to see every subprocess invocation, timing, and exit code. |
 | `--log-format <format>` | `console` | Log format: `console` (human-readable on stderr) or `json` (structured logs for `jq` / aggregators). |
-| `-o`, `--output <format>` | `text` | Output format for list/status commands: `text` (tabular human view) or `json` (machine-readable envelopes for scripting). Currently being rolled out command by command — check `gh-aw-fleet <command> --help`. |
+| `-o`, `--output <format>` | `text` | Output format: `text` (tabular human view, default) or `json` (machine-readable envelopes for scripting). Supported on `list`, `deploy`, `sync`, and `upgrade` (`upgrade --all` emits NDJSON). Rejected with a clear error on `template fetch`, `add`, and `status`. |
 
 For multi-repo failure debugging, [`skills/fleet-deploy/SKILL.md`](skills/fleet-deploy/SKILL.md) recommends `--log-level=debug --log-format=json 2>/tmp/log.json` and traversing subprocess events with `jq`.
 

--- a/README.md
+++ b/README.md
@@ -2,81 +2,156 @@
 
 Declarative fleet manager for GitHub Agentic Workflows.
 
+[![Latest release](https://img.shields.io/github/v/release/rshade/gh-aw-fleet)](https://github.com/rshade/gh-aw-fleet/releases/latest)
+[![License](https://img.shields.io/github/license/rshade/gh-aw-fleet)](LICENSE)
+[![Go version](https://img.shields.io/github/go-mod/go-version/rshade/gh-aw-fleet)](go.mod)
+
 ## Status
 
-Early work-in-progress. The core reconcile loop (`deploy`, `sync`, `upgrade`) is functional, along with `add` for onboarding repos into `fleet.local.json`. The `status` command is still a stub; `template fetch` works but is incomplete. Architecture and APIs are actively evolving.
+Released as **v0.1.0** (April 2026). Pre-1.0: public surfaces (CLI flags, `fleet.json` schema) may still change before v1.0. The core reconcile loop (`deploy`, `sync`, `upgrade`, `add`) is functional. `template fetch` works but is still being extended; the `status` command is not yet implemented.
 
 ## Why
 
 When you manage 3+ repositories that deploy agentic workflows—markdown-authored workflows that compile to GitHub Actions and run AI agents—keeping them consistent becomes tedious. Each repo independently pins a version of `gh-aw`, drifts on its own, and requires manual sync cycles. `gh-aw-fleet` centralizes that: a single `fleet.json` declares the desired state (which repos get which workflows), and `deploy`, `sync`, and `upgrade` commands bring each repo in line via `gh aw add/update/upgrade` under the hood.
 
+## Who is this for?
+
+**You'll get value if:**
+
+- You operate **3 or more repositories** that use (or want to use) [`gh-aw`](https://github.com/github/gh-aw)-compiled agentic workflows.
+- You want one place to declare *which workflows belong on which repos*, pinned to specific upstream refs, and a way to bring drifted repos back in line.
+- You're comfortable with PR-based change flow — every fleet operation that touches a repo opens a PR there; nothing force-pushes or commits directly to `main`.
+
+**You probably don't need this if:**
+
+- You operate **one repo** — use `gh aw` directly; there's no fleet to manage.
+- You want to **author** new workflows — that's `gh aw`'s job. This tool only deploys what already exists upstream.
+- You want a **hosted SaaS or daemon** — this is a CLI you run on your laptop or in CI; no server, no webhook, no background reconciler.
+
 ## How It Works
 
 **1. gh-aw ships the compiler; `githubnext/agentics` ships the library.** `gh-aw` is the markdown→GitHub Actions compiler and an internal dogfooding testbed. The curated, reusable workflows live in the `githubnext/agentics` repository. The `default` profile sources workflows from agentics whenever an equivalent exists, falling back to gh-aw only for workflows that don't exist elsewhere (currently: `audit-workflows`, `docs-noob-tester`, `mergefest`).
 
-**2. The tool is a thin orchestrator.** It never rewrites workflow markdown. It only invokes `gh aw add` (which writes the `source:` frontmatter pin), `gh aw upgrade` (bumps actions + recompiles), `gh aw update` (pulls upstream + 3-way merge), and git/gh for branching, commits, and PRs. All value comes from answering *who gets what workflow, when, and from which profile*—not from file manipulation.
+**2. The tool is a thin orchestrator.** It never rewrites workflow markdown. It only invokes `gh aw init` (initializes the dispatcher agent in target repos that don't yet have one), `gh aw add` (writes the `source:` frontmatter pin), `gh aw upgrade` (bumps action SHAs + recompiles), `gh aw update` (pulls upstream workflow source + 3-way merge), and `git`/`gh` for branching, commits, and PRs. All value comes from answering *who gets what workflow, when, and from which profile*—not from file manipulation.
 
-**3. Pin-per-profile.** Each profile declares a `sources` map keyed by upstream repository (e.g., `github/gh-aw`, `githubnext/agentics`), each with its own ref. `default` pins `github/gh-aw@v0.68.3` (a tagged release for stability) and `githubnext/agentics@main` (the library's default branch). A profile advances atomically: bumping one source ref re-pins every workflow in that profile sourced from that repo.
+**3. Pin-per-profile.** Each profile declares a `sources` map keyed by upstream repository (e.g., `github/gh-aw`, `githubnext/agentics`), each with its own ref. The shipped `default` profile pins `github/gh-aw` to a tagged release (e.g. `v0.68.3`) and `githubnext/agentics` to a specific commit SHA — never `main`, since moving refs are forbidden by the [project constitution](CONTEXT.md). A profile advances atomically: bumping one source ref re-pins every workflow in that profile sourced from that repo.
 
 **4. Declarative reconcile.** `fleet.json` is the source of truth. Commands like `deploy`, `sync`, and `upgrade` compute diffs between desired and actual state, then apply them. Edits to `fleet.json` become commits; the tool brings reality in line.
+
+### The reconcile loop at a glance
+
+```mermaid
+flowchart LR
+    A["fleet.json<br/>fleet.local.json<br/><i>(desired state)</i>"] --> B["gh-aw-fleet<br/><i>(diff + dispatch)</i>"]
+    B -->|"workflow changes"| C["gh aw<br/>init / add / upgrade / update"]
+    B -->|"branch + commit"| D["git"]
+    B -->|"open PR"| E["gh"]
+    C --> F["Target repo<br/>.github/workflows/"]
+    D --> F
+    E --> G[("PR on target repo<br/><i>review → merge</i>")]
+```
+
+`gh-aw-fleet` itself never touches workflow markdown — it only computes *what* should change and dispatches the actual work to `gh aw`, `git`, and `gh`.
+
+### Concepts
+
+- **Profile** — a named bundle of workflows (`default`, `quality-plus`, etc.) that can be applied to one or more repos. Defined in `fleet.json` under `profiles.<name>`.
+- **Source** — the upstream repository a workflow comes from. Currently either `github/gh-aw` (compiler + dogfooding workflows) or `githubnext/agentics` (the curated library). Each profile pins each source to a specific ref.
+- **Pin** — a fixed reference (tag like `v0.68.3` or commit SHA) that locks a source to a known-good version. Moving refs like `main` are forbidden by the [project constitution](CONTEXT.md).
+- **Spec** — an `owner/repo/path@ref` string (e.g., `github/gh-aw/.github/workflows/audit-workflows.md@v0.68.3`) that uniquely identifies one workflow at one version. The tool resolves profile + source + workflow name → spec, then passes it to `gh aw add`.
+- **Reconcile** — compute the diff between desired state (`fleet.json`) and actual state (the target repo's `.github/workflows/` directory), then apply just enough commands to bring them into agreement.
+- **Dry-run gate** — `deploy`, `sync`, and `upgrade` print what they would do but make no changes unless `--apply` is passed. This is the default safety mechanism for any operation that touches an external repo.
+
+## Why not just…?
+
+- **Hand-rolled bash loop over `gh aw add`?** Works for 1-2 repos. Past that, you re-derive the loop, the dry-run flag, the profile-to-workflow expansion, and the diagnostic hint patterns each time. This tool packages all of that.
+- **Renovate or Dependabot?** They bump dependency manifests; they don't speak agentic-workflow source pinning, profile composition, or `gh aw`'s 3-way merge semantics. Different abstraction.
+- **Terraform / Pulumi for workflow files?** Overkill — there's no infrastructure here, just markdown files and PRs. And the actual compilation and pin management lives in `gh aw`; wrapping it in HCL or TypeScript would re-implement what `gh aw` already does.
+- **A `gh aw` extension that adds fleet semantics?** Plausible alternative — listed as a possible future direction in [CONTEXT.md](CONTEXT.md). For now, this lives outside `gh aw` to evolve independently of the upstream tool's release cadence.
 
 ## Quick Start
 
 ### Prerequisites
 
-- Go 1.25+
-- `gh` CLI authed to your GitHub instance
-- `gh aw` extension installed: `gh extension install github/gh-aw`
+- `gh` CLI authed to your GitHub instance (`gh auth login`) with `repo` and `workflow` scopes
+- `gh aw` extension installed: `gh extension install github/gh-aw` — install a tagged release matching the `github/gh-aw` ref in your `fleet.json` (the shipped `default` profile uses `v0.68.3`). Avoid `main`: it often contains unreleased features that break this tool. To upgrade later, `gh extension upgrade gh-aw` and verify the new tag still matches your fleet pin.
+- Go 1.25.8+ **only if** installing via `go install` or building from source
 
-### Build
+### Install
+
+**Option 1 — Download a release binary (recommended).** Pre-built binaries are published for Linux, macOS, and Windows on amd64 and arm64:
 
 ```bash
+# Example: Linux amd64
+gh release download --repo rshade/gh-aw-fleet --pattern '*linux_amd64.tar.gz'
+tar -xzf gh-aw-fleet_*_linux_amd64.tar.gz
+sudo mv gh-aw-fleet /usr/local/bin/
+```
+
+See the [latest release](https://github.com/rshade/gh-aw-fleet/releases/latest) for all available platform archives and checksums.
+
+**Option 2 — `go install`.** Installs into `$(go env GOPATH)/bin`:
+
+```bash
+go install github.com/rshade/gh-aw-fleet@latest
+```
+
+**Option 3 — Build from source.** For contributors and anyone working off `main`:
+
+```bash
+git clone https://github.com/rshade/gh-aw-fleet.git
+cd gh-aw-fleet
 go build -o gh-aw-fleet .
 ```
+
+> **Note on examples below:** all command examples use bare `gh-aw-fleet` (assumes the binary is on your `PATH`, which is the case for Options 1 and 2). If you built from source via Option 3 and didn't install the binary, prefix every `gh-aw-fleet` command with `./` to run it from the build directory.
 
 ### Example Workflow
 
 List tracked repos and their resolved workflow sets:
 
 ```bash
-./gh-aw-fleet list
+gh-aw-fleet list
 ```
 
 Fetch the upstream catalog (templates.json) so you can review new workflows:
 
 ```bash
-./gh-aw-fleet template fetch
+gh-aw-fleet template fetch
 ```
 
-Onboard a new repo into `fleet.local.json` with a profile (dry-run first, then `--apply`):
+Onboard a new repo into `fleet.local.json` with a profile (`acme/widgets` is a placeholder — substitute your `<owner>/<repo>`). Dry-run first, then `--apply`:
 
 ```bash
-./gh-aw-fleet add acme/widgets --profile default
-./gh-aw-fleet add acme/widgets --profile default --apply --yes
+gh-aw-fleet add acme/widgets --profile default              # dry-run; prints planned change
+gh-aw-fleet add acme/widgets --profile default --apply      # interactive: prompts for confirmation
+gh-aw-fleet add acme/widgets --profile default --apply --yes # non-interactive (CI / scripts): skips prompt
 ```
+
+The repo entry is written to **`fleet.local.json`** (the private, gitignored config), not `fleet.json` (the committed example). See [Two config files](#two-config-files) below.
 
 Dry-run a deploy to one repo (shows what would be added, no changes made):
 
 ```bash
-./gh-aw-fleet deploy acme/widgets
+gh-aw-fleet deploy acme/widgets
 ```
 
 Apply the deploy (commits, pushes, opens a PR in the target repo):
 
 ```bash
-./gh-aw-fleet deploy acme/widgets --apply
+gh-aw-fleet deploy acme/widgets --apply
 ```
 
 Reconcile a repo (add missing workflows, flag unexpected ones):
 
 ```bash
-./gh-aw-fleet sync HavenTrack/goa-service-shared --apply
+gh-aw-fleet sync HavenTrack/goa-service-shared --apply
 ```
 
 Upgrade all repos to the latest gh-aw and agentics versions:
 
 ```bash
-./gh-aw-fleet upgrade --all --apply
+gh-aw-fleet upgrade --all --apply
 ```
 
 ## Commands
@@ -93,13 +168,37 @@ Upgrade all repos to the latest gh-aw and agentics versions:
 
 ## Configuration
 
-### fleet.json
+### Global flags
+
+All commands accept these persistent flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--dir <path>` | `.` | Directory containing `fleet.json` / `fleet.local.json`. |
+| `--log-level <level>` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. Use `debug` to see every subprocess invocation, timing, and exit code. |
+| `--log-format <format>` | `console` | Log format: `console` (human-readable on stderr) or `json` (structured logs for `jq` / aggregators). |
+| `-o`, `--output <format>` | `text` | Output format for list/status commands: `text` (tabular human view) or `json` (machine-readable envelopes for scripting). Currently being rolled out command by command — check `gh-aw-fleet <command> --help`. |
+
+For multi-repo failure debugging, [`skills/fleet-deploy/SKILL.md`](skills/fleet-deploy/SKILL.md) recommends `--log-level=debug --log-format=json 2>/tmp/log.json` and traversing subprocess events with `jq`.
+
+### Two config files
+
+`gh-aw-fleet` reads from up to two files in the working directory:
+
+1. **`fleet.json`** — the committed base config. The repo ships one tracking only `rshade/gh-aw-fleet` itself (the dogfood case); use it as a reference for schema, or replace it with your own committed fleet if you want shared state across collaborators.
+2. **`fleet.local.json`** — a private, gitignored *overlay* on top of `fleet.json`. This is where the `add` command writes by default, and where you can keep entries that shouldn't be committed (private repos, in-flight changes, personal overrides).
+
+When both files exist, they are **merged** — `fleet.local.json` profiles, repos, and defaults add to or override matching entries in `fleet.json`. When only one exists, that one is used directly. The stderr line `(loaded fleet.json + fleet.local.json)` (or `(loaded fleet.json)` / `(loaded fleet.local.json)` when only one is present) printed at the start of every command tells you which mode is active.
+
+To start from scratch, copy `fleet.example.json` to `fleet.local.json` (or to `fleet.json` if you want it committed) and edit, or use `gh-aw-fleet add` to generate entries.
+
+### fleet.json schema
 
 The declarative desired state. Top-level keys:
 
 - **`version`**: Schema version (currently `1`).
 - **`defaults`**: Fleet-wide defaults. Currently: `engine` (e.g., `"copilot"` for all repos unless overridden).
-- **`profiles`**: Named bundles of workflows. See "Profiles Bundled" below.
+- **`profiles`**: Named bundles of workflows. See [Bundled Profiles](#bundled-profiles) below.
 - **`repos`**: Per-repo desired state (profiles, excludes, extras, overrides).
 
 Example fragment:
@@ -115,7 +214,7 @@ Example fragment:
       "description": "Baseline every tracked repo gets.",
       "sources": {
         "github/gh-aw": { "ref": "v0.68.3" },
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "audit-workflows", "source": "github/gh-aw" },
@@ -144,27 +243,26 @@ Per-repo configuration. Keys:
 - **`exclude`** (optional): List of workflow names to skip (useful when a profile mostly fits but one or two workflows don't).
 - **`overrides`** (optional): Map of workflow name → custom path (if the upstream path doesn't match convention).
 
-## Profiles Bundled
+## Bundled Profiles
 
-### default
+| Profile | Purpose | Adds | Best for |
+|---|---|---|---|
+| `default` | Baseline — low-noise, broadly useful | 12 workflows (3 gh-aw + 9 agentics) | Every tracked repo |
+| `quality-plus` | PR-generating quality agents — noisier | 3 agentics workflows | Actively-developed repos |
+| `security-plus` | SAST, secret scanning, outbound-traffic audits | 3 gh-aw workflows | Repos handling sensitive data |
+| `docs-plus` | Heavier docs maintenance | 6 agentics workflows | Repos with a `docs/` directory or published docs site |
+| `community-plus` | Contributor-facing helpers — command-triggered, dormant when idle | 4 agentics workflows | Public repos with external contributors |
 
-Baseline every tracked repo gets. Low-noise, broadly useful. Pulls 12 workflows: 3 from gh-aw (`audit-workflows`, `docs-noob-tester`, `mergefest`) and 9 from agentics (`ci-doctor`, `code-simplifier`, `daily-doc-updater`, `daily-malicious-code-scan`, `pr-fix`, `weekly-issue-summary`, `issue-arborist`, `sub-issue-closer`, `dependabot-pr-bundler`).
+<details>
+<summary>Workflow lists per profile</summary>
 
-### quality-plus
+- **`default`** — gh-aw: `audit-workflows`, `docs-noob-tester`, `mergefest`. agentics: `ci-doctor`, `code-simplifier`, `daily-doc-updater`, `daily-malicious-code-scan`, `pr-fix`, `weekly-issue-summary`, `issue-arborist`, `sub-issue-closer`, `dependabot-pr-bundler`.
+- **`quality-plus`** — agentics: `daily-test-improver`, `daily-perf-improver`, `repository-quality-improver`.
+- **`security-plus`** — gh-aw: `daily-semgrep-scan`, `daily-secrets-analysis`, `daily-firewall-report`. Layers on top of `default`'s `daily-malicious-code-scan`.
+- **`docs-plus`** — agentics: `glossary-maintainer`, `unbloat-docs`, `update-docs`, `link-checker`, `markdown-linter`, `daily-multi-device-docs-tester`.
+- **`community-plus`** — agentics: `grumpy-reviewer`, `pr-nitpick-reviewer`, `archie`, `repo-ask`.
 
-PR-generating quality agents. Noisier—opt in for actively-developed repos. Adds 3 agentics workflows: `daily-test-improver`, `daily-perf-improver`, `repository-quality-improver`.
-
-### security-plus
-
-SAST, secret scanning, and outbound-traffic audits. Layered on top of `default`'s `daily-malicious-code-scan`. Adds 3 gh-aw workflows: `daily-semgrep-scan`, `daily-secrets-analysis`, `daily-firewall-report`.
-
-### docs-plus
-
-Heavier docs maintenance. Assumes the repo has a real docs site. Adds 6 agentics workflows: `glossary-maintainer`, `unbloat-docs`, `update-docs`, `link-checker`, `markdown-linter`, `daily-multi-device-docs-tester`.
-
-### community-plus
-
-Contributor-facing helpers. All command-triggered or event-scoped, dormant when idle. Adds 4 agentics workflows: `grumpy-reviewer`, `pr-nitpick-reviewer`, `archie`, `repo-ask`.
+</details>
 
 ## templates.json
 
@@ -174,7 +272,7 @@ Upstream catalog cache. Populated by `template fetch`. Lists every workflow avai
 
 **Thin orchestrator, not re-implementation.** The tool delegates workflow compilation to `gh aw`, not a homegrown parser. This means improvements to `gh aw` flow through automatically; there's no separate maintenance burden.
 
-**Asymmetry in deploy vs upgrade.** `deploy` uses the pins from `fleet.json`. `upgrade` follows the workflow's own frontmatter pin (the `source:` field written by `gh aw add`), then bumps that. This is intentional—it allows independent per-workflow decisions while `deploy` enforces fleet-wide consistency. Document this.
+**Asymmetry in deploy vs upgrade.** `deploy` uses the pins from `fleet.json`. `upgrade` follows the workflow's own frontmatter pin (the `source:` field written by `gh aw add`), then bumps that. This is intentional: it allows independent per-workflow decisions while `deploy` enforces fleet-wide consistency. To force a re-pin from `fleet.json` after editing it, run `gh-aw-fleet sync --apply --force <repo>` rather than `upgrade` — `upgrade` will not pick up `fleet.json` changes on its own.
 
 **Dry-run by default.** `deploy`, `sync`, and `upgrade` default to dry-run mode. Pass `--apply` to commit, push, and open PRs. This prevents surprises.
 
@@ -186,25 +284,72 @@ When a command fails (e.g., `gh aw add` returns an error), the tool scans output
 
 - `Unknown property: mount-as-clis` → "This workflow uses an unreleased gh-aw feature. Upgrade your CLI or pin to a tagged release."
 - `HTTP 404` → "Check the spec—github/gh-aw workflows live under `.github/workflows/`; githubnext/agentics workflows live under `workflows/`."
-- `gpg failed to sign` → "Unlock gpg-agent in your shell and re-run."
+- `gpg failed to sign` → "Unlock gpg-agent in your shell and re-run." See [Troubleshooting](#troubleshooting) below for the manual-finish recipe.
+
+## Troubleshooting
+
+### gpg signing failed during `--apply`
+
+This is the most common `--apply` failure mode. The tool runs `git commit` non-interactively, so a signing-required git config that needs a passphrase prompt has nowhere to surface it. **The tool never bypasses signing** (no `--no-gpg-sign`, no `commit.gpgsign=false`) — it preserves the in-progress clone so you can finish the commit in your own shell where gpg-agent can prompt you.
+
+When `--apply` fails on gpg signing:
+
+1. The clone directory is preserved at `/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>/` with all files staged on the deploy branch.
+2. `cd` into that directory and finish manually:
+
+   ```bash
+   cd /tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>
+   git commit -m 'ci(workflows): add <N> agentic workflows via gh-aw-fleet'
+   git push -u origin <branch-name>   # branch is fleet/deploy-<timestamp>
+   gh pr create --title "ci(workflows): add <N> agentic workflows via gh-aw-fleet" --body "..."
+   ```
+
+3. The full template (with body, conventional-commits validation rules, and edge-case handling for `gh aw init` and skipped workflows) is in [`skills/fleet-deploy/SKILL.md`](skills/fleet-deploy/SKILL.md).
+
+### `Unknown property: mount-as-clis` and similar pre-flight failures
+
+A workflow uses a feature that is in upstream `gh-aw` `main` but not yet in your installed CLI. Either upgrade the CLI (`gh extension upgrade gh-aw`), or — preferably — pin the source ref in `fleet.json` to a tagged release and run `gh-aw-fleet sync --apply --force <repo>` to re-pin.
+
+### Resuming after a partial failure
+
+The `--work-dir <path>` flag points `deploy` / `upgrade` / `sync` at an existing clone instead of cloning fresh. Use it with the `/tmp/gh-aw-fleet-*` directory preserved from a failed run to re-attempt without re-cloning. Note: `--work-dir` does not yet *resume* mid-pipeline state (see Known Limitations).
 
 ## Known Limitations & Roadmap
 
-- **No `--work-dir` persistence.** The `--work-dir` flag exists but doesn't resume from a previous state. A full retry re-clones and re-starts.
+- **`status` command not yet implemented.** Planned. Will diff desired (`fleet.json`) vs actual repo state.
+- **No `--work-dir` mid-pipeline resume.** The `--work-dir` flag re-uses an existing clone but doesn't resume from arbitrary mid-pipeline state. A full retry re-runs the pipeline from the start.
 - **Sync dry-run doesn't do deploy preflight.** `sync --dry-run` computes the diff but doesn't pre-validate that the workflows would deploy successfully.
-- **No GitHub extension packaging yet.** `gh-aw-fleet` is not yet installable as a `gh` extension. Build and invoke directly for now.
-- **`status` is still a stub.** Planned but not yet implemented.
+- **No GitHub extension packaging yet.** `gh-aw-fleet` is distributed as a standalone CLI (release binary, `go install`, or build from source — see [Install](#install)), not as a `gh` extension. Extension packaging is planned.
+
+## Further reading
+
+- **[CONTEXT.md](CONTEXT.md)** — the project constitution. Architectural identity, hard scope boundaries, and what this tool deliberately does *not* do. Read before proposing features.
+- **[ROADMAP.md](ROADMAP.md)** — what's actively being built within those boundaries.
+- **[CHANGELOG.md](CHANGELOG.md)** — release history (managed via [release-please](https://github.com/googleapis/release-please)).
+- **`skills/`** — operator playbooks codifying recurring workflows. Each is a complete runbook with the three-turn dry-run → approval → apply pattern:
+  - [`fleet-deploy`](skills/fleet-deploy/SKILL.md) — deploy a profile to one repo (includes the gpg manual-finish recipe).
+  - [`fleet-upgrade-review`](skills/fleet-upgrade-review/SKILL.md) — bump source pins and review the resulting PR.
+  - [`fleet-onboard-repo`](skills/fleet-onboard-repo/SKILL.md) — add a brand-new repo to the fleet.
+  - [`fleet-eval-templates`](skills/fleet-eval-templates/SKILL.md) — evaluate upstream template catalog for new workflows.
+  - [`fleet-build-profile`](skills/fleet-build-profile/SKILL.md) — materialize a chosen workflow set as a `fleet.json` profile.
+- **[CLAUDE.md](CLAUDE.md)** — invariants for AI coding agents working in this repo. Useful for human contributors too as a quick reference.
 
 ## Contributing & Development
 
-Development requires `go build`, `go vet`, `go test`, and `gh aw` commands to work without prompting. The repo's `.claude/settings.json` allows these automatically. Deny rules block destructive git operations (`git add`, `git commit`, `git rebase --continue`, `git reset --hard`, `git push --force`).
-
-To build and verify:
+See [ROADMAP.md](ROADMAP.md) for what's actively in flight, and the [issue tracker](https://github.com/rshade/gh-aw-fleet/issues) for places to start. Before opening a PR, run the full local gate:
 
 ```bash
-go build ./...
-go vet ./...
-go test ./...
+make ci         # fmt-check + vet + lint + test (the same gate CI runs)
 ```
 
-All tests must pass before submitting changes.
+Or step by step:
+
+```bash
+make fmt        # apply gofmt
+make lint       # golangci-lint — can take 5+ minutes; do not skip
+make test       # full test suite
+```
+
+If `make ci` passes locally, CI will pass.
+
+**For AI coding agents** working in this repo, see [CLAUDE.md](CLAUDE.md) for the invariants (no bypassing gpg signing, no direct git invocations, etc.) and `.claude/settings.json` for the shell-command allowlist that lets subagents run without prompting.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,11 +20,11 @@ The project is at **v0.1** — initial bootstrap landed in commit `8543956`
 
 ## Immediate Focus (v0.2 — CLI completeness + deploy UX)
 
-The CLI surface advertises seven subcommands but two are stubs (#9, #10).
-Closing that gap removes user surprise and unblocks the `fleet-onboard-repo`
-skill from leaning on manual `fleet.local.json` edits. Bundled in this
-milestone: a small set of deploy-time UX fixes (#6, #7) that operators feel
-on every run.
+The CLI surface advertises seven subcommands but one remains a stub (#10) —
+`add` (#9) shipped in 2026-Q2. Closing the remaining gap removes user
+surprise. Bundled in this milestone: a set of deploy-time UX fixes
+(#7, #11, #12) operators feel on every run, plus three recently-discovered
+correctness bugs (#30, #31, #32) that affect CLI error UX.
 
 ### CLI completeness
 
@@ -35,12 +35,6 @@ on every run.
   clone/init/add when staged changes exist, and re-enter at the commit gate
   (the `hasStagedOrUnstagedWorkflowChanges` check is already there). Tested
   by interrupting `--apply` after gpg failure.*
-- [ ] [#9](https://github.com/rshade/gh-aw-fleet/issues/9) Implement
-  `add <owner/repo>` subcommand `[M]`
-  *Register a repo in `fleet.local.json` with profile selection, optional
-  exclusions, and post-add validation. Dry-run by default; only `--apply`
-  writes the file. Replaces the manual JSON-edit step in the
-  `fleet-onboard-repo` skill.*
 - [ ] [#10](https://github.com/rshade/gh-aw-fleet/issues/10) Implement
   `status [repo]` subcommand `[M]`
   *Diff desired (`fleet.json`) vs actual (per-repo workflow set + pins)
@@ -74,27 +68,53 @@ in 2026-Q2; #7 and #11 continue the work.
   issue lays out three options (SHA pin, push upstream for tags, document
   exception) and requires an explicit decision before a fix lands.*
 
+### Correctness fixes
+
+Post-release bugs surfaced by real use of `v0.1.0`. All `[S]`; can be
+batched into a single `fix:` PR series.
+
+- [ ] [#30](https://github.com/rshade/gh-aw-fleet/issues/30) Errors
+  double-print to stderr (cobra + `main` both print) `[S]`
+  *Cobra's default error rendering and `main`'s zerolog `fatal:` handler
+  both fire on the same error. Silence one — likely `RootCmd.SilenceErrors`
+  is already true but one error path writes directly.*
+- [ ] [#31](https://github.com/rshade/gh-aw-fleet/issues/31) `not tracked
+  in fleet.json` error ignores `fleet.local.json` `[S]`
+  *Error message lies: the lookup goes through `LoadConfig` which merges
+  both files, but the error string only names `fleet.json`. Fix the message
+  to reflect merged-config semantics.*
+- [ ] [#32](https://github.com/rshade/gh-aw-fleet/issues/32) `upgrade`
+  first changed-file missing leading dot (TrimSpace eats porcelain status
+  char) `[S]`
+  *`git status --porcelain` emits a fixed-width status column followed by
+  the path starting at column 4. The parser `TrimSpace`s the line, which
+  eats the leading status char and then eats the first char of the path
+  when it's a dot (e.g. `.github/workflows/...`). Parse by column offset,
+  not by trim.*
+
 ## Near-Term Vision (v0.3 — operator quality of life)
 
 Once the CLI is complete, the next layer is making it pleasant under load —
 preflight before destructive ops, faster sanity checks, packaging, and
-making the tool legible to LLM agents piping its output.
+making the tool legible to LLM agents piping its output. The zerolog
+foundation (#24) shipped in 2026-Q2 and unblocks #25.
 
-- [ ] [#24](https://github.com/rshade/gh-aw-fleet/issues/24) Introduce
-  zerolog for errors, warnings, and diagnostics `[M]`
-  *Foundational: add a thin `internal/log` package over zerolog. Configure
-  once from cobra `PersistentPreRunE` with `--log-level` / `--log-format`.
-  User-facing tabwriter output stays; errors, warnings, and subprocess
-  diagnostics become structured. Prerequisite for #25's stderr warning
-  emission.*
 - [ ] [#25](https://github.com/rshade/gh-aw-fleet/issues/25) Add
   `--output json` to `list`/`deploy`/`sync`/`upgrade` for LLM consumption
   `[M]`
   *No new data — just marshal the existing `DeployResult` / `SyncResult` /
   `UpgradeResult` structs as a versioned JSON envelope
   (`schema_version: 1`) when `-o json` is set. Unlocks agentic consumers
-  without regex-scraping tabwriter tables. Depends on #24 for stderr
-  warning emission.*
+  without regex-scraping tabwriter tables. Spec lives in
+  `specs/003-cli-output-json/`; foundation (#24) is in place.*
+- [ ] [#43](https://github.com/rshade/gh-aw-fleet/issues/43) Add
+  `install.sh` and `install.ps1` one-liner installers `[M]` `community`
+  *Replace the four-step manual `gh release download` flow with curl/iwr
+  one-liners. Ship both scripts as release assets (via
+  `.goreleaser.yml` `extra_files`) and on `main` for a fallback URL.
+  Acceptance: checksum-verified install of `v0.1.0` on
+  ubuntu/macos/windows CI runners. Complements, does not replace, the
+  `gh extension` packaging item below.*
 - [ ] `sync --dry-run` runs deploy preflight `[M]`
   *Today `sync --dry-run` computes the diff but doesn't validate that the
   resolved workflows would actually `gh aw add` cleanly (404s on bad pins,
@@ -104,7 +124,8 @@ making the tool legible to LLM agents piping its output.
   *Move from `go run .` / built binary to `gh extension install rshade/gh-aw-fleet`.
   Requires renaming the binary (`gh-aw-fleet`), adding the extension manifest,
   and updating `goreleaser` to publish the right artifact shape. Lowers install
-  friction for external contributors significantly.*
+  friction for external contributors significantly. Related to #43 but a
+  distinct distribution channel.*
 - [ ] Expand `CollectHints` diagnostic catalog `[S]`
   *`internal/fleet/diagnostics.go` already scans for unknown-property, HTTP 404,
   and gpg failures. Add hints for: rate-limit (HTTP 403/429), unsigned-commit
@@ -130,12 +151,28 @@ at machine speed (prt-scan campaign, April 2026). `gh-aw-fleet` sits at the
 chokepoint where every workflow is pinned and deployed — it's the natural
 layer to enforce fleet-wide policy that per-repo tools cannot.
 
+- [ ] [#36](https://github.com/rshade/gh-aw-fleet/issues/36) **[EPIC]**
+  Add security scanning to `upgrade`/`sync`/`deploy` pipeline `[L]`
+  *Umbrella: insert a scanner layer that catches secrets, dangerous
+  compiled-YAML patterns, and fleet-structural violations before PRs merge.
+  Scoped into four sub-issues (#37–#40) that ship independently; promote
+  to Near-Term once #37 has a landing PR.*
+  - [ ] [#37](https://github.com/rshade/gh-aw-fleet/issues/37) Layer 1
+    scanner: secrets + compiled-YAML + fleet-structural rules `[L]`
+  - [ ] [#38](https://github.com/rshade/gh-aw-fleet/issues/38) `--strict`
+    flag: promote HIGH Layer 1 findings from advisory to blocking `[S]`
+  - [ ] [#39](https://github.com/rshade/gh-aw-fleet/issues/39)
+    `--deep-scan` flag: prompt-injection regex signatures + optional
+    classifier `[L]`
+  - [ ] [#40](https://github.com/rshade/gh-aw-fleet/issues/40)
+    Defense-in-depth UX: stderr + interactive prompt + PR body Security
+    Findings section `[M]`
 - [ ] Pin hygiene validator `[S]`
   *New `fleet validate` command: scan `fleet.json` and every resolved
   `SourceRef` for floating refs (`main`, `latest`, branch names) and fail on
   violations. Configurable severity per source so exceptions get documented
   explicitly instead of living silently in profiles. Pure parse, no
-  subprocess.*
+  subprocess. Complements #37's rule set; could ship as a Layer 0 scanner.*
 - [ ] Source attestation check `[M]` `spec-first`
   *When GitHub's 2026 workflow-dep SHA-locking API ships, cross-check each
   fleet pin against the published attestation. Warn on mismatch. Blocked on
@@ -144,8 +181,8 @@ layer to enforce fleet-wide policy that per-repo tools cannot.
   *Scan installed workflows for known-risky trigger shapes
   (`pull_request_target` without fork guards, `issue_comment` without
   `author_association` filter). Zero-clone via `gh api`; shares plumbing with
-  the proposed `status` subcommand (#10). Direct operator-facing response to
-  prt-scan-class attacks.*
+  the proposed `status` subcommand (#10). Natural Layer 2 rule for #37's
+  scanner framework once that lands.*
 
 ### Community / ecosystem
 
@@ -224,6 +261,18 @@ ideas close the loop without becoming a daemon.
 
 ### 2026-Q2
 
+- [x] [#24](https://github.com/rshade/gh-aw-fleet/issues/24) Introduce
+  zerolog for errors, warnings, and diagnostics `[M]`
+  *Added `internal/log` over zerolog, wired via cobra `PersistentPreRunE`
+  with `--log-level` / `--log-format`. Warnings and subprocess summaries
+  now emit as structured events on stderr; user-facing tabwriter output
+  stays on stdout. Unblocks #25.*
+- [x] [#9](https://github.com/rshade/gh-aw-fleet/issues/9) Implement
+  `add <owner/repo>` subcommand for fleet onboarding `[M]`
+  *New `gh-aw-fleet add <owner/repo>` cobra subcommand onboards repos into
+  `fleet.local.json` with profile selection and post-add validation.
+  Dry-run by default; `--apply` is the explicit gate. Replaces the manual
+  JSON-edit step in the `fleet-onboard-repo` skill.*
 - [x] [#6](https://github.com/rshade/gh-aw-fleet/issues/6) Check org-level
   secrets to avoid false-positive missing-secret warnings `[S]`
   *`checkEngineSecret` now queries repo secrets first, then falls back to
@@ -254,7 +303,8 @@ Any roadmap item that violates these is rejected, not negotiated.
 - **Effort labels**: `effort/small`, `effort/medium`, `effort/large`
 - **Contribution flags**: `community`, `cross-repo`, `spec-first`
 
-> Immediate Focus items (#7, #8, #9, #10, #11, #12) and the two Near-Term
-> infrastructure items (#24, #25) are tracked as GitHub issues. The remaining
-> Near-Term and Future items don't have issues yet — open them as work picks
-> up, then run `/roadmap sync` to keep this file aligned.
+> Immediate Focus items (#7, #8, #10, #11, #12, #30, #31, #32), Near-Term
+> items (#25, #43), and the Future Vision security epic (#36 with children
+> #37–#40) are tracked as GitHub issues. The remaining Near-Term and Future
+> items don't have issues yet — open them as work picks up, then run
+> `/roadmap sync` to keep this file aligned.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,6 +28,9 @@ func newAddCmd(flagDir *string) *cobra.Command {
 		Short: "Register a repo in fleet.local.json with a profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := rejectJSONMode(cmd, "add"); err != nil {
+				return err
+			}
 			slug, err := fleet.ValidateSlug(args[0])
 			if err != nil {
 				return err

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -33,7 +33,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
 				if jsonMode {
 					return preResultFailureEnvelope(cmd, "deploy", repo, flagApply, notTrackedErr)
 				}
@@ -168,10 +168,7 @@ func emitDeployEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet.
 		emitHints(res.Repo, fleet.CollectHints(errs...))
 		hints = fleet.CollectHintDiagnostics(errs...)
 	}
-
-	if res == nil && deployErr != nil {
-		hints = []fleet.Diagnostic{fleet.HintFromError(deployErr)}
-	}
+	hints = ensureFailureHint(hints, deployErr)
 
 	if writeErr := writeEnvelope(cmd, "deploy", repo, apply, res, warnings, hints); writeErr != nil {
 		return writeErr

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -24,12 +24,20 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			repo := args[0]
+			jsonMode := outputMode(cmd) == outputJSON
 			cfg, err := fleet.LoadConfig(*flagDir)
 			if err != nil {
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "deploy", repo, flagApply, err)
+				}
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				return fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "deploy", repo, flagApply, notTrackedErr)
+				}
+				return notTrackedErr
 			}
 			opts := fleet.DeployOpts{
 				Apply:   flagApply,
@@ -39,6 +47,9 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 				WorkDir: flagWorkDir,
 			}
 			res, deployErr := fleet.Deploy(cmd.Context(), cfg, repo, opts)
+			if jsonMode {
+				return emitDeployEnvelope(cmd, repo, flagApply, res, deployErr)
+			}
 			printDeploy(cmd, res, flagApply)
 			return deployErr
 		},
@@ -110,6 +121,17 @@ func emitDeployWarnings(res *fleet.DeployResult) {
 	if res == nil || res.MissingSecret == "" {
 		return
 	}
+	msg := buildMissingSecretMessage(res)
+	zlog.Warn().
+		Str("repo", res.Repo).
+		Str("secret", res.MissingSecret).
+		Msg(msg)
+}
+
+// buildMissingSecretMessage produces the same human-readable text for both
+// the stderr zerolog warning and the JSON envelope's warnings[] entry.
+// Factored out so the two emission paths can never drift apart.
+func buildMissingSecretMessage(res *fleet.DeployResult) string {
 	msg := fmt.Sprintf(
 		"Actions secret %q is not set on %s; workflows will fail until added (gh secret set %s --repo %s)",
 		res.MissingSecret, res.Repo, res.MissingSecret, res.Repo,
@@ -117,8 +139,42 @@ func emitDeployWarnings(res *fleet.DeployResult) {
 	if res.SecretKeyURL != "" {
 		msg = fmt.Sprintf("%s — obtain the key at %s", msg, res.SecretKeyURL)
 	}
-	zlog.Warn().
-		Str("repo", res.Repo).
-		Str("secret", res.MissingSecret).
-		Msg(msg)
+	return msg
+}
+
+// emitDeployEnvelope writes the JSON envelope for a deploy invocation,
+// dual-emitting warnings/hints to stderr (zerolog) per FR-011/FR-012 and
+// embedding the structured equivalents in the envelope per FR-006/FR-009.
+func emitDeployEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet.DeployResult, deployErr error) error {
+	var warnings []fleet.Diagnostic
+	var hints []fleet.Diagnostic
+
+	if res != nil && res.MissingSecret != "" {
+		emitDeployWarnings(res)
+		warnings = append(warnings, fleet.Diagnostic{
+			Code:    fleet.DiagMissingSecret,
+			Message: buildMissingSecretMessage(res),
+			Fields: map[string]any{
+				"secret": res.MissingSecret,
+				"url":    res.SecretKeyURL,
+			},
+		})
+	}
+	if res != nil && len(res.Failed) > 0 {
+		errs := make([]string, 0, len(res.Failed))
+		for _, f := range res.Failed {
+			errs = append(errs, f.Error)
+		}
+		emitHints(res.Repo, fleet.CollectHints(errs...))
+		hints = fleet.CollectHintDiagnostics(errs...)
+	}
+
+	if res == nil && deployErr != nil {
+		hints = []fleet.Diagnostic{fleet.HintFromError(deployErr)}
+	}
+
+	if writeErr := writeEnvelope(cmd, "deploy", repo, apply, res, warnings, hints); writeErr != nil {
+		return writeErr
+	}
+	return deployErr
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,11 +17,26 @@ func newListCmd(flagDir *string) *cobra.Command {
 		Use:   "list",
 		Short: "List tracked repos and their resolved workflow sets",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			jsonMode := outputMode(cmd) == outputJSON
 			cfg, err := fleet.LoadConfig(*flagDir)
 			if err != nil {
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "list", "", false, err)
+				}
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStderr(), "  (loaded %s)\n", cfg.LoadedFrom)
+			// Breadcrumb stays on stderr in both modes — text consumers expect it,
+			// JSON consumers redirect stderr.
+			fmt.Fprintf(cmd.ErrOrStderr(), "  (loaded %s)\n", cfg.LoadedFrom)
+
+			if jsonMode {
+				res, buildErr := fleet.BuildListResult(cfg)
+				if buildErr != nil {
+					return preResultFailureEnvelope(cmd, "list", "", false, buildErr)
+				}
+				return writeEnvelope(cmd, "list", "", false, res, nil, nil)
+			}
+
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, tabPadding, ' ', 0)
 			fmt.Fprintln(tw, "REPO\tPROFILES\tENGINE\tWORKFLOWS\tEXCLUDED\tEXTRA")
 			repos := make([]string, 0, len(cfg.Repos))

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
+)
+
+// SchemaVersion is the JSON envelope wire-contract version. Bumped only on
+// breaking changes to envelope or result struct field shapes (FR-005).
+// Additive changes (new optional fields, new diagnostic codes) do not bump.
+const SchemaVersion = 1
+
+// outputJSON is the --output value that selects the JSON envelope serializer.
+// outputText is the default. Centralized so subcommand mode-checks share one source.
+const (
+	outputJSON = "json"
+	outputText = "text"
+)
+
+// Envelope is the top-level JSON object emitted on stdout in --output json mode.
+// Field order is the JSON-key emission order; consumers MUST NOT depend on it.
+// All seven keys are always present (FR-004) — no omitempty.
+type Envelope struct {
+	SchemaVersion int                `json:"schema_version"`
+	Command       string             `json:"command"`
+	Repo          string             `json:"repo"`
+	Apply         bool               `json:"apply"`
+	Result        any                `json:"result"`
+	Warnings      []fleet.Diagnostic `json:"warnings"`
+	Hints         []fleet.Diagnostic `json:"hints"`
+}
+
+// writeEnvelope emits one envelope on the cobra command's stdout writer.
+// Thin wrapper over writeEnvelopeTo for production callers.
+func writeEnvelope(
+	cmd *cobra.Command,
+	commandName, repo string,
+	apply bool,
+	result any,
+	warnings, hints []fleet.Diagnostic,
+) error {
+	return writeEnvelopeTo(cmd.OutOrStdout(), commandName, repo, apply, result, warnings, hints)
+}
+
+// writeEnvelopeTo is the test-friendly entry point. Normalizes nil slices to
+// non-nil empty (FR-009), walks the result struct via initSlices to do the
+// same recursively, then emits compact JSON + trailing newline via
+// json.NewEncoder.Encode (research.md R4: per-call flush enables NDJSON
+// streaming for upgrade --all).
+//
+// For future parallelization of upgrade --all, callers MUST serialize Encode
+// calls behind a mutex to prevent interleaved partial lines (contracts/ndjson.md).
+func writeEnvelopeTo(
+	w io.Writer,
+	commandName, repo string,
+	apply bool,
+	result any,
+	warnings, hints []fleet.Diagnostic,
+) error {
+	if result != nil {
+		initSlices(result)
+	}
+	if warnings == nil {
+		warnings = []fleet.Diagnostic{}
+	}
+	if hints == nil {
+		hints = []fleet.Diagnostic{}
+	}
+	env := Envelope{
+		SchemaVersion: SchemaVersion,
+		Command:       commandName,
+		Repo:          repo,
+		Apply:         apply,
+		Result:        result,
+		Warnings:      warnings,
+		Hints:         hints,
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(env)
+}
+
+// outputMode reads the resolved --output value. PersistentPreRunE has already
+// validated, so this is a defensive read; empty resolves to outputText.
+func outputMode(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("output")
+	if v == "" {
+		return outputText
+	}
+	return v
+}
+
+// validateOutputMode enforces the closed-set policy from contracts/cli-flags.md.
+// Called from root's PersistentPreRunE; rejects yaml/JSON/empty/etc with an
+// error message naming the accepted values.
+func validateOutputMode(mode string) error {
+	switch mode {
+	case outputText, outputJSON:
+		return nil
+	default:
+		return fmt.Errorf("unsupported output mode %q: expected one of: text, json", mode)
+	}
+}
+
+// rejectJSONMode is invoked at the top of subcommand RunE for commands that
+// don't honor --output json (template fetch, add, status). Returns nil when
+// the active mode is text; returns an explicit error when json is requested
+// (FR-013 — silent fallback would surprise jq consumers).
+func rejectJSONMode(cmd *cobra.Command, subcommand string) error {
+	if outputMode(cmd) == outputJSON {
+		return fmt.Errorf(
+			"command %q does not support --output json; use --output text or omit the flag",
+			subcommand,
+		)
+	}
+	return nil
+}
+
+// preResultFailureEnvelope writes a result:null envelope wrapping err as a
+// hint diagnostic, then returns err so the caller can propagate the non-zero
+// exit code. Used by every subcommand's JSON path when an error blocks result
+// construction (config parse, repo not in fleet, missing tool).
+func preResultFailureEnvelope(
+	cmd *cobra.Command,
+	command, repo string,
+	apply bool,
+	err error,
+) error {
+	hints := []fleet.Diagnostic{fleet.HintFromError(err)}
+	if writeErr := writeEnvelope(cmd, command, repo, apply, nil, nil, hints); writeErr != nil {
+		return writeErr
+	}
+	return err
+}
+
+// initSlices replaces every nil slice field in v with a non-nil empty slice,
+// recursing into nested structs and pointer-to-struct fields.
+//
+// Why this exists: stdlib encoding/json marshals nil slices as JSON null but
+// non-nil empty slices as []. FR-009 requires [] for downstream consumer
+// iteration without nil-guards. Initializing the business-logic structs at
+// construction time would scatter this concern; running the helper at the
+// envelope-writer boundary keeps the JSON contract isolated.
+//
+// Assumes v is acyclic — it's called only on the known-finite result types
+// (ListResult, DeployResult, SyncResult, UpgradeResult), which have no
+// back-edges. No cycle guard is installed.
+func initSlices(v any) {
+	if v == nil {
+		return
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return
+	}
+	walkInitSlices(rv)
+}
+
+// walkInitSlices is intentionally a switch on three relevant Kinds; other
+// kinds (numeric, bool, string, map, etc.) need no normalization.
+//
+//nolint:gocognit,exhaustive // exhaustive: only the three kinds matter for FR-009; gocognit: shape mirrors the kind switch by design
+func walkInitSlices(rv reflect.Value) {
+	for i := range rv.NumField() {
+		field := rv.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		switch field.Kind() {
+		case reflect.Slice:
+			// Skip []byte (incl. json.RawMessage) — these have custom MarshalJSON
+			// that expects nil → null, valid JSON bytes → nested object, and empty
+			// non-nil []byte → marshal error. Don't normalize them.
+			if field.Type().Elem().Kind() == reflect.Uint8 {
+				continue
+			}
+			if field.IsNil() {
+				field.Set(reflect.MakeSlice(field.Type(), 0, 0))
+			}
+			// Recurse into struct elements so nested struct slice-fields normalize too.
+			if field.Type().Elem().Kind() == reflect.Struct {
+				for j := range field.Len() {
+					walkInitSlices(field.Index(j))
+				}
+			}
+		case reflect.Pointer:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				walkInitSlices(field.Elem())
+			}
+		case reflect.Struct:
+			walkInitSlices(field)
+		}
+	}
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -85,6 +85,15 @@ func writeEnvelopeTo(
 	return enc.Encode(env)
 }
 
+// ensureFailureHint preserves a machine-readable failure reason on stdout when
+// a command returns a partial result but the diagnostics layer finds no hint.
+func ensureFailureHint(hints []fleet.Diagnostic, err error) []fleet.Diagnostic {
+	if err == nil || len(hints) > 0 {
+		return hints
+	}
+	return append(hints, fleet.HintFromError(err))
+}
+
 // outputMode reads the resolved --output value. PersistentPreRunE has already
 // validated, so this is a defensive read; empty resolves to outputText.
 func outputMode(cmd *cobra.Command) string {
@@ -131,7 +140,7 @@ func preResultFailureEnvelope(
 	apply bool,
 	err error,
 ) error {
-	hints := []fleet.Diagnostic{fleet.HintFromError(err)}
+	hints := ensureFailureHint(nil, err)
 	if writeErr := writeEnvelope(cmd, command, repo, apply, nil, nil, hints); writeErr != nil {
 		return writeErr
 	}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,652 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
+)
+
+// listResultStub mirrors the JSON shape of internal/fleet.ListResult, kept
+// local here to pin the envelope contract independent of the fleet package.
+type listResultStub struct {
+	LoadedFrom string   `json:"loaded_from"`
+	Repos      []string `json:"repos"`
+}
+
+func TestEnvelope_TopLevelKeysPinned(t *testing.T) {
+	var buf bytes.Buffer
+	res := listResultStub{LoadedFrom: "", Repos: nil}
+	if err := writeEnvelopeTo(&buf, "list", "", false, &res, nil, nil); err != nil {
+		t.Fatalf("writeEnvelopeTo: %v", err)
+	}
+	want := `{"schema_version":1,"command":"list","repo":"","apply":false,"result":{"loaded_from":"","repos":[]},"warnings":[],"hints":[]}` + "\n"
+	if buf.String() != want {
+		t.Errorf("envelope =\n  %q\nwant\n  %q", buf.String(), want)
+	}
+}
+
+func TestEnvelope_SchemaVersionConstant(t *testing.T) {
+	if SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d; want 1 (pinned by FR-005)", SchemaVersion)
+	}
+}
+
+func TestEnvelope_SchemaVersionIs1(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "list", "", false, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := env["schema_version"].(float64)
+	if !ok {
+		t.Fatalf("schema_version not numeric: %v", env["schema_version"])
+	}
+	if int(v) != 1 {
+		t.Errorf("schema_version = %v; want 1", v)
+	}
+}
+
+func TestEnvelope_ResultNullOnPreFailure(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "deploy", "x/y", false, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"result":null`) {
+		t.Errorf("missing result:null in %s", out)
+	}
+	for _, key := range []string{
+		`"schema_version":1`, `"command":"deploy"`, `"repo":"x/y"`,
+		`"apply":false`, `"warnings":[]`, `"hints":[]`,
+	} {
+		if !strings.Contains(out, key) {
+			t.Errorf("missing %s in %s", key, out)
+		}
+	}
+}
+
+func TestInitSlices_NilToEmpty(t *testing.T) {
+	r := fleet.DeployResult{Repo: "x/y"}
+	initSlices(&r)
+	if r.Added == nil {
+		t.Error("Added still nil after initSlices")
+	}
+	if r.Skipped == nil {
+		t.Error("Skipped still nil after initSlices")
+	}
+	if r.Failed == nil {
+		t.Error("Failed still nil after initSlices")
+	}
+	if len(r.Added) != 0 || len(r.Skipped) != 0 || len(r.Failed) != 0 {
+		t.Errorf("non-empty slices after init: %+v", r)
+	}
+}
+
+// outputFlagFixture builds a stub root with a no-op subcommand for flag-validation tests.
+func outputFlagFixture() (*cobra.Command, *bool) {
+	ran := false
+	root := NewRootCmd()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	probe := &cobra.Command{
+		Use:  "probe",
+		RunE: func(_ *cobra.Command, _ []string) error { ran = true; return nil },
+	}
+	root.AddCommand(probe)
+	return root, &ran
+}
+
+func TestOutputFlag_AcceptsText(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe", "-o", "text"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !*ran {
+		t.Error("subcommand did not run")
+	}
+}
+
+func TestOutputFlag_AcceptsJSON(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe", "-o", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !*ran {
+		t.Error("subcommand did not run")
+	}
+}
+
+func TestOutputFlag_DefaultText(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !*ran {
+		t.Error("subcommand did not run")
+	}
+}
+
+func TestOutputFlag_RejectsYAML(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe", "-o", "yaml"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute = nil; want error for -o yaml")
+	}
+	if !strings.Contains(err.Error(), `unsupported output mode "yaml"`) {
+		t.Errorf("error = %q; want contains 'unsupported output mode \"yaml\"'", err.Error())
+	}
+	if *ran {
+		t.Error("subcommand RunE ran despite invalid --output")
+	}
+}
+
+func TestOutputFlag_RejectsUpperCase(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe", "-o", "JSON"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute = nil; want error for -o JSON")
+	}
+	if *ran {
+		t.Error("subcommand RunE ran despite invalid --output")
+	}
+}
+
+func TestOutputFlag_RejectsEmpty(t *testing.T) {
+	root, ran := outputFlagFixture()
+	root.SetArgs([]string{"probe", "-o", ""})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute = nil; want error for empty -o")
+	}
+	if *ran {
+		t.Error("subcommand RunE ran despite invalid --output")
+	}
+}
+
+func TestListEnvelope_EmptyFleet(t *testing.T) {
+	res, err := fleet.BuildListResult(&fleet.Config{})
+	if err != nil {
+		t.Fatalf("BuildListResult: %v", err)
+	}
+	var buf bytes.Buffer
+	if writeErr := writeEnvelopeTo(&buf, "list", "", false, res, nil, nil); writeErr != nil {
+		t.Fatalf("writeEnvelopeTo: %v", writeErr)
+	}
+	want := `{"schema_version":1,"command":"list","repo":"","apply":false,"result":{"loaded_from":"","repos":[]},"warnings":[],"hints":[]}` + "\n"
+	if buf.String() != want {
+		t.Errorf("envelope =\n  %q\nwant\n  %q", buf.String(), want)
+	}
+}
+
+func TestListEnvelope_Populated(t *testing.T) {
+	cfg := &fleet.Config{
+		LoadedFrom: "fleet.local.json",
+		Profiles: map[string]fleet.Profile{
+			"empty": {Sources: map[string]fleet.SourcePin{}, Workflows: []fleet.ProfileWorkflow{}},
+		},
+		Repos: map[string]fleet.RepoSpec{
+			"a/b": {Profiles: []string{"empty"}, Engine: "claude"},
+		},
+	}
+	res, err := fleet.BuildListResult(cfg)
+	if err != nil {
+		t.Fatalf("BuildListResult: %v", err)
+	}
+	var buf bytes.Buffer
+	if writeErr := writeEnvelopeTo(&buf, "list", "", false, res, nil, nil); writeErr != nil {
+		t.Fatalf("writeEnvelopeTo: %v", writeErr)
+	}
+	want := `{"schema_version":1,"command":"list","repo":"","apply":false,` +
+		`"result":{"loaded_from":"fleet.local.json","repos":[` +
+		`{"repo":"a/b","profiles":["empty"],"engine":"claude","workflows":[],"excluded":[],"extra":[]}` +
+		`]},"warnings":[],"hints":[]}` + "\n"
+	if buf.String() != want {
+		t.Errorf("envelope =\n  %s\nwant\n  %s", buf.String(), want)
+	}
+}
+
+func TestListCmd_JSONMode(t *testing.T) {
+	dir := t.TempDir()
+	fleetJSON := `{
+  "version": 1,
+  "defaults": {"engine": "copilot"},
+  "profiles": {
+    "p": {"sources": {}, "workflows": []}
+  },
+  "repos": {
+    "x/y": {"profiles": ["p"]}
+  }
+}`
+	if err := writeFile(t, dir+"/fleet.json", fleetJSON); err != nil {
+		t.Fatal(err)
+	}
+	root := NewRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"list", "--dir", dir, "-o", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var env Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, stdout.String())
+	}
+	if env.Command != "list" {
+		t.Errorf("Command = %q; want list", env.Command)
+	}
+	if env.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion = %d; want 1", env.SchemaVersion)
+	}
+	if env.Apply {
+		t.Error("Apply = true; want false for list")
+	}
+}
+
+func TestJSONModeRejected_TemplateFetch(t *testing.T) {
+	root := NewRootCmd()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"template", "fetch", "-o", "json"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute = nil; want error for template fetch -o json")
+	}
+	if !strings.Contains(err.Error(), `command "template fetch" does not support --output json`) {
+		t.Errorf("error = %q; want contains template-fetch rejection message", err.Error())
+	}
+}
+
+func writeFile(t *testing.T, path, content string) error {
+	t.Helper()
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func TestDeployEnvelope_EmptyArrays(t *testing.T) {
+	res := &fleet.DeployResult{Repo: "x/y"}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "deploy", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Result fleet.DeployResult `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	if env.Result.Added == nil {
+		t.Error("Added is nil; want []")
+	}
+	for _, key := range []string{`"added":[]`, `"skipped":[]`, `"failed":[]`} {
+		if !strings.Contains(buf.String(), key) {
+			t.Errorf("missing %s in %s", key, buf.String())
+		}
+	}
+}
+
+func TestDeployEnvelope_MissingSecretWarning(t *testing.T) {
+	res := &fleet.DeployResult{
+		Repo:          "x/y",
+		MissingSecret: "ANTHROPIC_API_KEY",
+		SecretKeyURL:  "https://example.com/key",
+	}
+	warnings := []fleet.Diagnostic{{
+		Code:    fleet.DiagMissingSecret,
+		Message: "Actions secret \"ANTHROPIC_API_KEY\" is missing on x/y",
+		Fields:  map[string]any{"secret": "ANTHROPIC_API_KEY", "url": "https://example.com/key"},
+	}}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "deploy", "x/y", true, res, warnings, nil); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Apply    bool               `json:"apply"`
+		Warnings []fleet.Diagnostic `json:"warnings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !env.Apply {
+		t.Error("apply = false; want true")
+	}
+	if len(env.Warnings) != 1 {
+		t.Fatalf("len(warnings) = %d; want 1", len(env.Warnings))
+	}
+	if env.Warnings[0].Code != fleet.DiagMissingSecret {
+		t.Errorf("warning code = %q; want missing_secret", env.Warnings[0].Code)
+	}
+	if env.Warnings[0].Fields["secret"] != "ANTHROPIC_API_KEY" {
+		t.Errorf(
+			"warning fields.secret = %v; want ANTHROPIC_API_KEY",
+			env.Warnings[0].Fields["secret"],
+		)
+	}
+}
+
+func TestDeployEnvelope_ApplyFlag(t *testing.T) {
+	for _, apply := range []bool{true, false} {
+		var buf bytes.Buffer
+		res := &fleet.DeployResult{Repo: "x/y"}
+		if err := writeEnvelopeTo(&buf, "deploy", "x/y", apply, res, nil, nil); err != nil {
+			t.Fatal(err)
+		}
+		want := `"apply":true`
+		if !apply {
+			want = `"apply":false`
+		}
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("apply=%v: missing %s in %s", apply, want, buf.String())
+		}
+	}
+}
+
+func TestSyncEnvelope_EmptyArrays(t *testing.T) {
+	res := &fleet.SyncResult{Repo: "x/y"}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "sync", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"missing":[]`, `"drift":[]`, `"expected":[]`, `"pruned":[]`} {
+		if !strings.Contains(buf.String(), key) {
+			t.Errorf("missing %s in %s", key, buf.String())
+		}
+	}
+}
+
+func TestSyncEnvelope_NilDeployFields(t *testing.T) {
+	res := &fleet.SyncResult{Repo: "x/y", Deploy: nil, DeployPreflight: nil}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "sync", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"deploy":null`, `"deploy_preflight":null`} {
+		if !strings.Contains(buf.String(), key) {
+			t.Errorf("missing %s in %s", key, buf.String())
+		}
+	}
+}
+
+func TestSyncEnvelope_NestedDeployPreflight(t *testing.T) {
+	res := &fleet.SyncResult{
+		Repo: "x/y",
+		DeployPreflight: &fleet.DeployResult{
+			Repo:  "x/y",
+			Added: []fleet.WorkflowOutcome{{Name: "foo", Spec: "owner/repo/foo@v1"}},
+		},
+	}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "sync", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Result fleet.SyncResult `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	if env.Result.DeployPreflight == nil {
+		t.Fatal("DeployPreflight is nil after round-trip")
+	}
+	if len(env.Result.DeployPreflight.Added) != 1 ||
+		env.Result.DeployPreflight.Added[0].Name != "foo" {
+		t.Errorf(
+			"DeployPreflight.Added = %v; want [{Name: foo, ...}]",
+			env.Result.DeployPreflight.Added,
+		)
+	}
+}
+
+func TestSyncEnvelope_DriftDiagnostic(t *testing.T) {
+	warnings := []fleet.Diagnostic{{
+		Code:    fleet.DiagDriftDetected,
+		Message: syncDriftMessage,
+		Fields:  map[string]any{"drift": []string{"orphan"}},
+	}}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "sync", "x/y", false, &fleet.SyncResult{Repo: "x/y"}, warnings, nil); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Warnings []struct {
+			Fields struct {
+				Drift []string `json:"drift"`
+			} `json:"fields"`
+		} `json:"warnings"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Warnings) != 1 {
+		t.Fatalf("len(warnings) = %d; want 1", len(env.Warnings))
+	}
+	got := env.Warnings[0].Fields.Drift
+	if len(got) != 1 || got[0] != "orphan" {
+		t.Errorf("warnings[0].fields.drift = %v; want [orphan]", got)
+	}
+}
+
+func TestUpgradeEnvelope_EmptyArrays(t *testing.T) {
+	res := &fleet.UpgradeResult{Repo: "x/y"}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "upgrade", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"changed_files":[]`, `"conflicts":[]`} {
+		if !strings.Contains(buf.String(), key) {
+			t.Errorf("missing %s in %s", key, buf.String())
+		}
+	}
+}
+
+func TestEnvelope_AuditJSONNests(t *testing.T) {
+	res := &fleet.UpgradeResult{
+		Repo:      "x/y",
+		AuditJSON: json.RawMessage(`{"version":"1","findings":[]}`),
+	}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "upgrade", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Use a destination that captures audit_json as a re-parseable RawMessage.
+	var env struct {
+		Result struct {
+			AuditJSON json.RawMessage `json:"audit_json"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	var audit map[string]any
+	if err := json.Unmarshal(env.Result.AuditJSON, &audit); err != nil {
+		t.Fatalf("audit_json not native object; got %s; err=%v", env.Result.AuditJSON, err)
+	}
+	if audit["version"] != "1" {
+		t.Errorf("audit.version = %v; want 1", audit["version"])
+	}
+	// Negative pin: ensure the byte form is the literal object, NOT a quoted string.
+	if !strings.Contains(buf.String(), `"audit_json":{"version":"1","findings":[]}`) {
+		t.Errorf("audit_json not nested as object: %s", buf.String())
+	}
+}
+
+func TestUpgradeEnvelope_AuditJSONNil(t *testing.T) {
+	res := &fleet.UpgradeResult{Repo: "x/y", AuditJSON: nil}
+	var buf bytes.Buffer
+	if err := writeEnvelopeTo(&buf, "upgrade", "x/y", false, res, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"audit_json":null`) {
+		t.Errorf("audit_json not null when AuditJSON is nil: %s", buf.String())
+	}
+}
+
+func TestNDJSON_LineCountAndSelfContained(t *testing.T) {
+	results := []*fleet.UpgradeResult{
+		{Repo: "a/b", NoChanges: true},
+		{Repo: "c/d", ChangedFiles: []string{"x"}},
+		{Repo: "e/f", Conflicts: []string{"y"}},
+	}
+	var buf bytes.Buffer
+	for _, r := range results {
+		if err := writeEnvelopeTo(&buf, "upgrade", r.Repo, false, r, nil, nil); err != nil {
+			t.Fatalf("writeEnvelopeTo: %v", err)
+		}
+	}
+	got := buf.String()
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("len(lines) = %d; want 3; raw=%s", len(lines), got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Error("NDJSON stream missing trailing newline on last line")
+	}
+	for i, line := range lines {
+		var env Envelope
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			t.Errorf("line %d: not valid JSON: %v; raw=%s", i, err, line)
+			continue
+		}
+		if env.Command != "upgrade" {
+			t.Errorf("line %d: command = %q; want upgrade", i, env.Command)
+		}
+	}
+}
+
+func TestNDJSON_ErrorRepoIncluded(t *testing.T) {
+	// Simulate a 3-repo loop where the middle repo failed before producing a result.
+	repos := []struct {
+		name string
+		res  *fleet.UpgradeResult
+		err  error
+	}{
+		{"a/b", &fleet.UpgradeResult{Repo: "a/b", NoChanges: true}, nil},
+		{"c/d", nil, errors.New("simulated failure")},
+		{"e/f", &fleet.UpgradeResult{Repo: "e/f", NoChanges: true}, nil},
+	}
+	var buf bytes.Buffer
+	for _, r := range repos {
+		var hints []fleet.Diagnostic
+		if r.res == nil && r.err != nil {
+			hints = []fleet.Diagnostic{{
+				Code:    fleet.DiagHint,
+				Message: r.err.Error(),
+				Fields:  map[string]any{"hint": r.err.Error()},
+			}}
+		}
+		if err := writeEnvelopeTo(&buf, "upgrade", r.name, false, r.res, nil, hints); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("len(lines) = %d; want 3", len(lines))
+	}
+	// Middle line must have result: null and a hint.
+	if !strings.Contains(lines[1], `"result":null`) {
+		t.Errorf("middle line missing result:null: %s", lines[1])
+	}
+	if !strings.Contains(lines[1], `"code":"hint"`) {
+		t.Errorf("middle line missing hint diagnostic: %s", lines[1])
+	}
+	// Other lines must have result objects.
+	if strings.Contains(lines[0], `"result":null`) {
+		t.Errorf("first line should have non-null result: %s", lines[0])
+	}
+	if strings.Contains(lines[2], `"result":null`) {
+		t.Errorf("last line should have non-null result: %s", lines[2])
+	}
+}
+
+func TestNDJSON_EmptyFleet(t *testing.T) {
+	var buf bytes.Buffer
+	// Loop over zero repos — buf stays empty.
+	got := buf.String()
+	if got != "" {
+		t.Errorf("empty fleet stdout = %q; want empty", got)
+	}
+}
+
+// TestEnvelope_NoNullSlices_AllResultTypes pins FR-009 across every result
+// type so a future-added slice field doesn't sneak in as null. Walks the
+// struct via reflection and asserts each Slice (excluding json.RawMessage
+// []byte) renders as a JSON array.
+func TestEnvelope_NoNullSlices_AllResultTypes(t *testing.T) {
+	cases := []struct {
+		name   string
+		result any
+	}{
+		{"ListResult", &fleet.ListResult{}},
+		{"DeployResult", &fleet.DeployResult{Repo: "x/y"}},
+		{"SyncResult", &fleet.SyncResult{Repo: "x/y"}},
+		{"UpgradeResult", &fleet.UpgradeResult{Repo: "x/y"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := writeEnvelopeTo(&buf, "x", "x/y", false, tc.result, nil, nil); err != nil {
+				t.Fatalf("writeEnvelopeTo: %v", err)
+			}
+			var env struct {
+				Result map[string]any `json:"result"`
+			}
+			if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+				t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+			}
+			rt := reflect.TypeOf(tc.result).Elem()
+			for i := 0; i < rt.NumField(); i++ {
+				f := rt.Field(i)
+				if f.Type.Kind() != reflect.Slice {
+					continue
+				}
+				if f.Type.Elem().Kind() == reflect.Uint8 {
+					continue // json.RawMessage / []byte — null is correct when nil
+				}
+				tag := f.Tag.Get("json")
+				jsonKey, _, _ := strings.Cut(tag, ",")
+				if jsonKey == "" {
+					jsonKey = f.Name
+				}
+				v, present := env.Result[jsonKey]
+				if !present {
+					t.Errorf("%s: field %q missing from result", tc.name, jsonKey)
+					continue
+				}
+				if v == nil {
+					t.Errorf("%s: field %q is null; want [] (FR-009)", tc.name, jsonKey)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildMissingSecretMessage(t *testing.T) {
+	res := &fleet.DeployResult{
+		Repo:          "x/y",
+		MissingSecret: "FOO",
+		SecretKeyURL:  "https://example.com",
+	}
+	got := buildMissingSecretMessage(res)
+	if !strings.Contains(got, "FOO") || !strings.Contains(got, "x/y") {
+		t.Errorf("message %q missing secret/repo", got)
+	}
+	if !strings.Contains(got, "https://example.com") {
+		t.Errorf("message %q missing key URL", got)
+	}
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -279,6 +279,91 @@ func writeFile(t *testing.T, path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 
+func envelopeCommand(buf *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+	cmd.SetErr(io.Discard)
+	return cmd
+}
+
+func TestUpgradeCmd_JSONArgErrorsEmitEnvelope(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantRepo string
+		wantHint string
+	}{
+		{
+			name:     "missing repo and all",
+			args:     []string{"upgrade", "-o", "json"},
+			wantRepo: "",
+			wantHint: "upgrade: specify either a repo name or --all",
+		},
+		{
+			name:     "repo with all",
+			args:     []string{"upgrade", "x/y", "--all", "-o", "json"},
+			wantRepo: "x/y",
+			wantHint: "upgrade: cannot specify both --all and a repo name",
+		},
+		{
+			name:     "work dir with all",
+			args:     []string{"upgrade", "--all", "--work-dir", "/tmp/worktree", "-o", "json"},
+			wantRepo: "",
+			wantHint: "upgrade: --work-dir cannot be used with --all",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := NewRootCmd()
+			var stdout bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(io.Discard)
+			root.SetArgs(tc.args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("Execute = nil; want validation error")
+			}
+			if err.Error() != tc.wantHint {
+				t.Fatalf("error = %q; want %q", err.Error(), tc.wantHint)
+			}
+
+			var env struct {
+				Command string             `json:"command"`
+				Repo    string             `json:"repo"`
+				Apply   bool               `json:"apply"`
+				Result  any                `json:"result"`
+				Hints   []fleet.Diagnostic `json:"hints"`
+			}
+			if unmarshalErr := json.Unmarshal(stdout.Bytes(), &env); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v; raw=%s", unmarshalErr, stdout.String())
+			}
+			if env.Command != "upgrade" {
+				t.Errorf("command = %q; want upgrade", env.Command)
+			}
+			if env.Repo != tc.wantRepo {
+				t.Errorf("repo = %q; want %q", env.Repo, tc.wantRepo)
+			}
+			if env.Apply {
+				t.Error("apply = true; want false")
+			}
+			if env.Result != nil {
+				t.Errorf("result = %#v; want nil", env.Result)
+			}
+			if len(env.Hints) != 1 {
+				t.Fatalf("len(hints) = %d; want 1", len(env.Hints))
+			}
+			if env.Hints[0].Code != fleet.DiagHint {
+				t.Errorf("hint code = %q; want %q", env.Hints[0].Code, fleet.DiagHint)
+			}
+			if env.Hints[0].Message != tc.wantHint {
+				t.Errorf("hint message = %q; want %q", env.Hints[0].Message, tc.wantHint)
+			}
+		})
+	}
+}
+
 func TestDeployEnvelope_EmptyArrays(t *testing.T) {
 	res := &fleet.DeployResult{Repo: "x/y"}
 	var buf bytes.Buffer
@@ -354,6 +439,34 @@ func TestDeployEnvelope_ApplyFlag(t *testing.T) {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("apply=%v: missing %s in %s", apply, want, buf.String())
 		}
+	}
+}
+
+func TestDeployEnvelope_PartialFailureFallsBackToErrorHint(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := envelopeCommand(&buf)
+	res := &fleet.DeployResult{Repo: "x/y"}
+	deployErr := errors.New("gh repo clone x/y: exit status 1")
+
+	if err := emitDeployEnvelope(cmd, "x/y", false, res, deployErr); !errors.Is(err, deployErr) {
+		t.Fatalf("emitDeployEnvelope error = %v; want %v", err, deployErr)
+	}
+
+	var env struct {
+		Result fleet.DeployResult `json:"result"`
+		Hints  []fleet.Diagnostic `json:"hints"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	if env.Result.Repo != "x/y" {
+		t.Errorf("result.repo = %q; want x/y", env.Result.Repo)
+	}
+	if len(env.Hints) != 1 {
+		t.Fatalf("len(hints) = %d; want 1", len(env.Hints))
+	}
+	if env.Hints[0].Message != deployErr.Error() {
+		t.Errorf("hint message = %q; want %q", env.Hints[0].Message, deployErr.Error())
 	}
 }
 
@@ -442,6 +555,34 @@ func TestSyncEnvelope_DriftDiagnostic(t *testing.T) {
 	}
 }
 
+func TestSyncEnvelope_PartialFailureFallsBackToErrorHint(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := envelopeCommand(&buf)
+	res := &fleet.SyncResult{Repo: "x/y"}
+	syncErr := errors.New("git push: exit status 1")
+
+	if err := emitSyncEnvelope(cmd, "x/y", true, res, syncErr); !errors.Is(err, syncErr) {
+		t.Fatalf("emitSyncEnvelope error = %v; want %v", err, syncErr)
+	}
+
+	var env struct {
+		Result fleet.SyncResult   `json:"result"`
+		Hints  []fleet.Diagnostic `json:"hints"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	if env.Result.Repo != "x/y" {
+		t.Errorf("result.repo = %q; want x/y", env.Result.Repo)
+	}
+	if len(env.Hints) != 1 {
+		t.Fatalf("len(hints) = %d; want 1", len(env.Hints))
+	}
+	if env.Hints[0].Message != syncErr.Error() {
+		t.Errorf("hint message = %q; want %q", env.Hints[0].Message, syncErr.Error())
+	}
+}
+
 func TestUpgradeEnvelope_EmptyArrays(t *testing.T) {
 	res := &fleet.UpgradeResult{Repo: "x/y"}
 	var buf bytes.Buffer
@@ -494,6 +635,34 @@ func TestUpgradeEnvelope_AuditJSONNil(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), `"audit_json":null`) {
 		t.Errorf("audit_json not null when AuditJSON is nil: %s", buf.String())
+	}
+}
+
+func TestUpgradeEnvelope_PartialFailureFallsBackToErrorHint(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := envelopeCommand(&buf)
+	res := &fleet.UpgradeResult{Repo: "x/y"}
+	upgradeErr := errors.New("gh aw update: exit status 1")
+
+	if err := emitUpgradeEnvelope(cmd, "x/y", false, res, upgradeErr); !errors.Is(err, upgradeErr) {
+		t.Fatalf("emitUpgradeEnvelope error = %v; want %v", err, upgradeErr)
+	}
+
+	var env struct {
+		Result fleet.UpgradeResult `json:"result"`
+		Hints  []fleet.Diagnostic  `json:"hints"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, buf.String())
+	}
+	if env.Result.Repo != "x/y" {
+		t.Errorf("result.repo = %q; want x/y", env.Result.Repo)
+	}
+	if len(env.Hints) != 1 {
+		t.Fatalf("len(hints) = %d; want 1", len(env.Hints))
+	}
+	if env.Hints[0].Message != upgradeErr.Error() {
+		t.Errorf("hint message = %q; want %q", env.Hints[0].Message, upgradeErr.Error())
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,6 @@
+// Package cmd wires the cobra command tree for gh-aw-fleet. Each subcommand
+// is a small shell that parses flags, calls into internal/fleet for the
+// actual work, and formats the result in text or JSON (see output.go).
 package cmd
 
 import (
@@ -23,12 +26,17 @@ and calling Claude when a deploy or merge needs judgment.`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			level, _ := cmd.Flags().GetString("log-level")
 			format, _ := cmd.Flags().GetString("log-format")
-			return logpkg.Configure(level, format)
+			if err := logpkg.Configure(level, format); err != nil {
+				return err
+			}
+			out, _ := cmd.Flags().GetString("output")
+			return validateOutputMode(out)
 		},
 	}
 	root.PersistentFlags().StringVar(&flagDir, "dir", ".", "Directory containing fleet.json")
 	root.PersistentFlags().String("log-level", "info", "Log verbosity: trace|debug|info|warn|error")
 	root.PersistentFlags().String("log-format", "console", "Log format: console|json")
+	root.PersistentFlags().StringP("output", "o", "text", "Output format: text|json")
 	root.AddCommand(
 		newListCmd(&flagDir),
 		newStatusCmd(),

--- a/cmd/stubs.go
+++ b/cmd/stubs.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 )
@@ -10,12 +10,11 @@ func newStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status [repo]",
 		Short: "Diff desired (fleet.json) vs actual state of a repo's workflows",
-		RunE:  notImplemented("status"),
-	}
-}
-
-func notImplemented(name string) func(*cobra.Command, []string) error {
-	return func(_ *cobra.Command, _ []string) error {
-		return fmt.Errorf("%s: not yet implemented", name)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rejectJSONMode(cmd, "status"); err != nil {
+				return err
+			}
+			return errors.New("status: not yet implemented")
+		},
 	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -41,7 +41,7 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
 				if jsonMode {
 					return preResultFailureEnvelope(cmd, "sync", repo, flagApply, notTrackedErr)
 				}
@@ -138,10 +138,7 @@ func emitSyncEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet.Sy
 		emitHints(res.Repo, fleet.CollectHints(errs...))
 		hints = fleet.CollectHintDiagnostics(errs...)
 	}
-
-	if res == nil && syncErr != nil {
-		hints = []fleet.Diagnostic{fleet.HintFromError(syncErr)}
-	}
+	hints = ensureFailureHint(hints, syncErr)
 
 	if writeErr := writeEnvelope(cmd, "sync", repo, apply, res, warnings, hints); writeErr != nil {
 		return writeErr

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,15 +25,27 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			repo := args[0]
+			jsonMode := outputMode(cmd) == outputJSON
 			if flagPrune && !flagApply {
-				return errors.New("--prune requires --apply")
+				pruneErr := errors.New("--prune requires --apply")
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "sync", repo, flagApply, pruneErr)
+				}
+				return pruneErr
 			}
 			cfg, err := fleet.LoadConfig(*flagDir)
 			if err != nil {
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "sync", repo, flagApply, err)
+				}
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				return fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+				if jsonMode {
+					return preResultFailureEnvelope(cmd, "sync", repo, flagApply, notTrackedErr)
+				}
+				return notTrackedErr
 			}
 			opts := fleet.SyncOpts{
 				Apply:   flagApply,
@@ -42,6 +54,9 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 				WorkDir: flagWorkDir,
 			}
 			res, syncErr := fleet.Sync(cmd.Context(), cfg, repo, opts)
+			if jsonMode {
+				return emitSyncEnvelope(cmd, repo, flagApply, res, syncErr)
+			}
 			printSync(cmd, res, flagApply, flagPrune)
 			return syncErr
 		},
@@ -92,7 +107,46 @@ func emitSyncWarnings(res *fleet.SyncResult) {
 	zlog.Warn().
 		Str("repo", res.Repo).
 		Strs("drift", res.Drift).
-		Msg("Drift detected: workflows on disk not declared in fleet.json")
+		Msg(syncDriftMessage)
+}
+
+const syncDriftMessage = "Drift detected: workflows on disk not declared in fleet.json"
+
+// emitSyncEnvelope writes the JSON envelope for a sync invocation, dual-emitting
+// drift warnings and pre-flight hints to stderr (FR-011/FR-012) and embedding
+// structured equivalents in the envelope.
+func emitSyncEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet.SyncResult, syncErr error) error {
+	var warnings []fleet.Diagnostic
+	var hints []fleet.Diagnostic
+
+	if res != nil && len(res.Drift) > 0 {
+		emitSyncWarnings(res)
+		warnings = append(warnings, fleet.Diagnostic{
+			Code:    fleet.DiagDriftDetected,
+			Message: syncDriftMessage,
+			Fields:  map[string]any{"drift": res.Drift},
+		})
+	}
+	// Hint source mirrors text mode: only DeployPreflight.Failed (printSyncPreflight).
+	// Deploy.Failed is intentionally NOT a hint source today — widening that surface
+	// would change text-mode behavior too and belongs in a separate feature.
+	if res != nil && res.DeployPreflight != nil && len(res.DeployPreflight.Failed) > 0 {
+		errs := make([]string, 0, len(res.DeployPreflight.Failed))
+		for _, f := range res.DeployPreflight.Failed {
+			errs = append(errs, f.Error)
+		}
+		emitHints(res.Repo, fleet.CollectHints(errs...))
+		hints = fleet.CollectHintDiagnostics(errs...)
+	}
+
+	if res == nil && syncErr != nil {
+		hints = []fleet.Diagnostic{fleet.HintFromError(syncErr)}
+	}
+
+	if writeErr := writeEnvelope(cmd, "sync", repo, apply, res, warnings, hints); writeErr != nil {
+		return writeErr
+	}
+	return syncErr
 }
 
 func printSyncDrift(w io.Writer, res *fleet.SyncResult) {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -22,6 +22,9 @@ func newTemplateFetchCmd(flagDir *string) *cobra.Command {
 		Use:   "fetch",
 		Short: "Refresh templates.json from gh-aw and agentics; Claude-classify new entries",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rejectJSONMode(cmd, "template fetch"); err != nil {
+				return err
+			}
 			return runTemplateFetch(cmd, *flagDir)
 		},
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -25,10 +25,17 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 		Use:   "upgrade [repo|--all]",
 		Short: "Bump profile pin + run gh aw upgrade + update across repos",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			jsonMode := outputMode(cmd) == outputJSON
 			if err := validateUpgradeArgs(args, flagAll, flagWorkDir); err != nil {
+				if jsonMode {
+					repo := ""
+					if len(args) > 0 {
+						repo = args[0]
+					}
+					return preResultFailureEnvelope(cmd, "upgrade", repo, flagApply, err)
+				}
 				return err
 			}
-			jsonMode := outputMode(cmd) == outputJSON
 			cfg, err := fleet.LoadConfig(*flagDir)
 			if err != nil {
 				if jsonMode {
@@ -191,7 +198,7 @@ func runUpgradeSingle(
 	cmd *cobra.Command, cfg *fleet.Config, repo string, opts fleet.UpgradeOpts, apply, jsonMode bool,
 ) error {
 	if _, ok := cfg.Repos[repo]; !ok {
-		notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+		notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
 		if jsonMode {
 			return preResultFailureEnvelope(cmd, "upgrade", repo, apply, notTrackedErr)
 		}
@@ -214,9 +221,7 @@ func emitUpgradeEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet
 		emitHints(res.Repo, fleet.CollectHints(res.OutputLog))
 		hints = fleet.CollectHintDiagnostics(res.OutputLog)
 	}
-	if res == nil && upErr != nil {
-		hints = []fleet.Diagnostic{fleet.HintFromError(upErr)}
-	}
+	hints = ensureFailureHint(hints, upErr)
 	if writeErr := writeEnvelope(cmd, "upgrade", repo, apply, res, nil, hints); writeErr != nil {
 		return writeErr
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -24,24 +25,21 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 		Use:   "upgrade [repo|--all]",
 		Short: "Bump profile pin + run gh aw upgrade + update across repos",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 1 {
-				return errors.New("upgrade: at most one positional argument (repo name)")
-			}
-			if flagAll && len(args) > 0 {
-				return errors.New("upgrade: cannot specify both --all and a repo name")
-			}
-			if !flagAll && len(args) == 0 {
-				return errors.New("upgrade: specify either a repo name or --all")
-			}
-			if flagWorkDir != "" && flagAll {
-				return errors.New("upgrade: --work-dir cannot be used with --all")
-			}
-
-			cfg, err := fleet.LoadConfig(*flagDir)
-			if err != nil {
+			if err := validateUpgradeArgs(args, flagAll, flagWorkDir); err != nil {
 				return err
 			}
-
+			jsonMode := outputMode(cmd) == outputJSON
+			cfg, err := fleet.LoadConfig(*flagDir)
+			if err != nil {
+				if jsonMode {
+					repo := ""
+					if len(args) > 0 {
+						repo = args[0]
+					}
+					return preResultFailureEnvelope(cmd, "upgrade", repo, flagApply, err)
+				}
+				return err
+			}
 			opts := fleet.UpgradeOpts{
 				Apply:   flagApply,
 				Audit:   flagAudit,
@@ -49,21 +47,10 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 				Force:   flagForce,
 				WorkDir: flagWorkDir,
 			}
-
 			if flagAll {
-				results, allErr := fleet.UpgradeAll(cmd.Context(), cfg, opts)
-				printUpgradeAll(cmd, results, flagAudit)
-				return allErr
+				return runUpgradeAll(cmd, cfg, opts, flagApply, flagAudit, jsonMode)
 			}
-
-			repo := args[0]
-			if _, ok := cfg.Repos[repo]; !ok {
-				return fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
-			}
-
-			res, upErr := fleet.Upgrade(cmd.Context(), cfg, repo, opts)
-			printUpgrade(cmd, res)
-			return upErr
+			return runUpgradeSingle(cmd, cfg, args[0], opts, flagApply, jsonMode)
 		},
 	}
 	cmd.Flags().BoolVar(&flagApply, "apply", false,
@@ -165,6 +152,100 @@ func printUpgradeSummary(w io.Writer, results []*fleet.UpgradeResult) {
 		}
 		fmt.Fprintf(w, "  %s: %s\n", res.Repo, upgradeStatus(res))
 	}
+}
+
+// validateUpgradeArgs enforces the --all/positional arg contract. Extracted
+// to keep the cobra RunE under the gocognit threshold.
+func validateUpgradeArgs(args []string, all bool, workDir string) error {
+	if len(args) > 1 {
+		return errors.New("upgrade: at most one positional argument (repo name)")
+	}
+	if all && len(args) > 0 {
+		return errors.New("upgrade: cannot specify both --all and a repo name")
+	}
+	if !all && len(args) == 0 {
+		return errors.New("upgrade: specify either a repo name or --all")
+	}
+	if workDir != "" && all {
+		return errors.New("upgrade: --work-dir cannot be used with --all")
+	}
+	return nil
+}
+
+// runUpgradeAll routes the --all path between text-mode (UpgradeAll batch +
+// summary print) and JSON-mode (per-repo NDJSON via runUpgradeAllJSON).
+func runUpgradeAll(
+	cmd *cobra.Command, cfg *fleet.Config, opts fleet.UpgradeOpts, apply, audit, jsonMode bool,
+) error {
+	if jsonMode {
+		return runUpgradeAllJSON(cmd, cfg, opts, apply)
+	}
+	results, allErr := fleet.UpgradeAll(cmd.Context(), cfg, opts)
+	printUpgradeAll(cmd, results, audit)
+	return allErr
+}
+
+// runUpgradeSingle routes the single-repo path. Validates the repo is tracked
+// before invoking Upgrade; both modes get a structured rejection on miss.
+func runUpgradeSingle(
+	cmd *cobra.Command, cfg *fleet.Config, repo string, opts fleet.UpgradeOpts, apply, jsonMode bool,
+) error {
+	if _, ok := cfg.Repos[repo]; !ok {
+		notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, fleet.ConfigFile)
+		if jsonMode {
+			return preResultFailureEnvelope(cmd, "upgrade", repo, apply, notTrackedErr)
+		}
+		return notTrackedErr
+	}
+	res, upErr := fleet.Upgrade(cmd.Context(), cfg, repo, opts)
+	if jsonMode {
+		return emitUpgradeEnvelope(cmd, repo, apply, res, upErr)
+	}
+	printUpgrade(cmd, res)
+	return upErr
+}
+
+// emitUpgradeEnvelope writes a single-repo upgrade envelope. Hints come from
+// res.OutputLog (the captured combined stdout+stderr of gh aw upgrade/update),
+// matching the text-mode hint source at cmd/upgrade.go:110.
+func emitUpgradeEnvelope(cmd *cobra.Command, repo string, apply bool, res *fleet.UpgradeResult, upErr error) error {
+	var hints []fleet.Diagnostic
+	if res != nil && res.OutputLog != "" {
+		emitHints(res.Repo, fleet.CollectHints(res.OutputLog))
+		hints = fleet.CollectHintDiagnostics(res.OutputLog)
+	}
+	if res == nil && upErr != nil {
+		hints = []fleet.Diagnostic{fleet.HintFromError(upErr)}
+	}
+	if writeErr := writeEnvelope(cmd, "upgrade", repo, apply, res, nil, hints); writeErr != nil {
+		return writeErr
+	}
+	return upErr
+}
+
+// runUpgradeAllJSON emits one envelope per repo as each upgrade completes.
+// Diverges from text-mode `UpgradeAll` (which short-circuits on first error)
+// because the NDJSON contract requires every repo to surface.
+//
+// Future parallelization MUST serialize the writeEnvelope calls behind a
+// mutex to prevent interleaved partial lines (contracts/ndjson.md).
+func runUpgradeAllJSON(cmd *cobra.Command, cfg *fleet.Config, opts fleet.UpgradeOpts, apply bool) error {
+	var firstErr error
+	repos := make([]string, 0, len(cfg.Repos))
+	for r := range cfg.Repos {
+		repos = append(repos, r)
+	}
+	sort.Strings(repos)
+	for _, repo := range repos {
+		res, upErr := fleet.Upgrade(cmd.Context(), cfg, repo, opts)
+		if writeErr := emitUpgradeEnvelope(cmd, repo, apply, res, upErr); writeErr != nil && firstErr == nil {
+			firstErr = writeErr
+		}
+		if upErr != nil && firstErr == nil {
+			firstErr = upErr
+		}
+	}
+	return firstErr
 }
 
 func upgradeStatus(res *fleet.UpgradeResult) string {

--- a/fleet.example.json
+++ b/fleet.example.json
@@ -2,26 +2,29 @@
   "version": 1,
   "profiles": {
     "default": {
-      "description": "baseline profile — see profiles/default.json for the canonical copy. Loaded automatically when a profile is named 'default' and this block is absent.",
+      "description": "Baseline profile. Workflows pulled from agentics (the curated library) wherever an equivalent exists; gh-aw only for dogfooded items with no agentics counterpart (audit-workflows, docs-noob-tester, mergefest). Mirrors profiles/default.json — keep them in sync.",
       "sources": {
         "github/gh-aw": { "ref": "v0.68.3" },
-        "githubnext/agentics": { "ref": "main" }
+        "githubnext/agentics": { "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a" }
       },
       "workflows": [
         { "name": "audit-workflows",          "source": "github/gh-aw" },
-        { "name": "ci-doctor",                "source": "github/gh-aw" },
-        { "name": "code-simplifier",          "source": "github/gh-aw" },
-        { "name": "daily-doc-updater",        "source": "github/gh-aw" },
         { "name": "docs-noob-tester",         "source": "github/gh-aw" },
         { "name": "mergefest",                "source": "github/gh-aw" },
+        { "name": "ci-doctor",                "source": "githubnext/agentics" },
+        { "name": "code-simplifier",          "source": "githubnext/agentics" },
+        { "name": "daily-doc-updater",        "source": "githubnext/agentics" },
         { "name": "daily-malicious-code-scan","source": "githubnext/agentics" },
         { "name": "pr-fix",                   "source": "githubnext/agentics" },
-        { "name": "weekly-issue-summary",     "source": "githubnext/agentics" }
+        { "name": "weekly-issue-summary",     "source": "githubnext/agentics" },
+        { "name": "issue-arborist",           "source": "githubnext/agentics" },
+        { "name": "sub-issue-closer",         "source": "githubnext/agentics" },
+        { "name": "dependabot-pr-bundler",    "source": "githubnext/agentics" }
       ]
     }
   },
   "repos": {
-    "__TODO__": {
+    "acme/widgets": {
       "profiles": ["default"],
       "engine": "copilot",
       "extra": [],

--- a/internal/fleet/add.go
+++ b/internal/fleet/add.go
@@ -15,6 +15,9 @@ const (
 	extraSpecShortParts = 3
 )
 
+// AddOptions controls the `fleet add` onboarding call. Apply=false is dry-run;
+// Apply=true writes fleet.local.json and requires Confirmed=true to guard
+// against non-interactive misuse.
 type AddOptions struct {
 	Repo           string
 	Profiles       []string
@@ -26,6 +29,9 @@ type AddOptions struct {
 	Dir            string
 }
 
+// AddResult aggregates what an Add call resolved and persisted. SynthesizedLocal
+// is true when Add had to create fleet.local.json from scratch (no prior
+// private overlay existed); WroteLocal is true only after --apply succeeded.
 type AddResult struct {
 	Repo             string
 	Profiles         []string
@@ -73,6 +79,9 @@ func ValidateSlug(s string) (string, error) {
 	return owner + "/" + repo, nil
 }
 
+// Add onboards a new repo into the fleet. Validates profiles/engine/extras,
+// resolves the candidate's workflows for preview, and — when Apply=true —
+// persists a minimal fleet.local.json overlay for the new repo.
 func Add(cfg *Config, opts AddOptions) (*AddResult, error) {
 	if opts.Apply && !opts.Confirmed {
 		return nil, errors.New("--apply requires --yes or interactive confirmation")

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -39,24 +39,24 @@ type DeployOpts struct {
 
 // DeployResult aggregates what happened for a single-repo deploy.
 type DeployResult struct {
-	Repo          string
-	CloneDir      string
-	Added         []WorkflowOutcome
-	Skipped       []WorkflowOutcome
-	Failed        []WorkflowOutcome
-	InitWasRun    bool
-	BranchPushed  string
-	PRURL         string
-	MissingSecret string // non-empty if the engine secret is absent from the repo
-	SecretKeyURL  string // where to obtain the key for MissingSecret
+	Repo          string            `json:"repo"`
+	CloneDir      string            `json:"clone_dir"`
+	Added         []WorkflowOutcome `json:"added"`
+	Skipped       []WorkflowOutcome `json:"skipped"`
+	Failed        []WorkflowOutcome `json:"failed"`
+	InitWasRun    bool              `json:"init_was_run"`
+	BranchPushed  string            `json:"branch_pushed"`
+	PRURL         string            `json:"pr_url"`
+	MissingSecret string            `json:"missing_secret"` // non-empty if the engine secret is absent from the repo
+	SecretKeyURL  string            `json:"secret_key_url"` // where to obtain the key for MissingSecret
 }
 
 // WorkflowOutcome is one workflow's fate during a deploy.
 type WorkflowOutcome struct {
-	Name   string
-	Spec   string
-	Reason string
-	Error  string
+	Name   string `json:"name"`
+	Spec   string `json:"spec"`
+	Reason string `json:"reason"`
+	Error  string `json:"error"`
 }
 
 // Deploy runs the deploy pipeline for a single repo.

--- a/internal/fleet/diagnostics.go
+++ b/internal/fleet/diagnostics.go
@@ -1,12 +1,38 @@
+// Package fleet diagnostic layer scans gh-aw CLI output for known error
+// patterns and emits remediation hints.
+//
+// CollectHintDiagnostics is the base scanner; CollectHints projects its
+// output to []string for text-mode consumers. Adding a hint pattern means
+// touching one table.
 package fleet
 
 import "strings"
+
+// Diagnostic is the shared shape for warnings and hints embedded in the
+// JSON envelope (cmd/output.go) and emitted on stderr via zerolog.
+type Diagnostic struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Fields  map[string]any `json:"fields,omitempty"`
+}
+
+// Stable diagnostic codes. Snake_case identifiers consumed by downstream
+// agents to gate on classes of warning/hint without parsing free-form text.
+const (
+	DiagMissingSecret   = "missing_secret"
+	DiagDriftDetected   = "drift_detected"
+	DiagHint            = "hint"
+	DiagUnknownProperty = "unknown_property"
+	DiagHTTP404         = "http_404"
+	DiagGPGFailure      = "gpg_failure"
+)
 
 // Hint is a remediation suggestion keyed by a substring match against
 // gh-aw CLI output.
 type Hint struct {
 	Pattern string
 	Message string
+	Code    string
 }
 
 // Ordered most-specific first; only the first match per input text is emitted.
@@ -19,35 +45,44 @@ var hints = []Hint{
 			"`gh extension upgrade gh-aw` if your CLI is out of date; if already latest, " +
 			"the upstream is ahead of the release — pin the source to a tagged release (e.g. `@v0.68.3`) " +
 			"via `fleet sync --apply --force`.",
+		Code: DiagUnknownProperty,
 	},
 	{
 		Pattern: "Unknown property:",
 		Message: "Workflow uses a property your installed `gh aw` CLI doesn't recognize. " +
 			"Try `gh extension upgrade gh-aw`, or pin the workflow source to a tagged release.",
+		Code: DiagUnknownProperty,
 	},
 	{
 		Pattern: "HTTP 404",
 		Message: "Source path not found. Check the spec — `github/gh-aw` workflows live under `.github/workflows/`; " +
 			"`githubnext/agentics` workflows live under `workflows/`.",
+		Code: DiagHTTP404,
 	},
 	{
 		Pattern: "gpg failed to sign",
 		Message: "gpg-agent couldn't prompt for a passphrase in this non-interactive context. " +
 			"Unlock gpg-agent in your shell (`echo test | gpg -as > /dev/null`) and re-run.",
+		Code: DiagGPGFailure,
 	},
 }
 
-// CollectHints scans any amount of output text for known error patterns and
-// returns unique applicable remediation hints, ordered by first appearance.
-// Most-specific hint wins per input string.
-func CollectHints(texts ...string) []string {
+// CollectHintDiagnostics scans output text for known error patterns and
+// returns one Diagnostic per matched hint (deduped by message, ordered by
+// first appearance; most-specific hint wins per input string). Returns a
+// non-nil empty slice when no patterns match (JSON arrays never null).
+func CollectHintDiagnostics(texts ...string) []Diagnostic {
 	seen := map[string]bool{}
-	var out []string
+	out := []Diagnostic{}
 	for _, t := range texts {
 		for _, h := range hints {
 			if strings.Contains(t, h.Pattern) {
 				if !seen[h.Message] {
-					out = append(out, h.Message)
+					out = append(out, Diagnostic{
+						Code:    h.Code,
+						Message: h.Message,
+						Fields:  map[string]any{"hint": h.Message},
+					})
 					seen[h.Message] = true
 				}
 				break
@@ -55,4 +90,31 @@ func CollectHints(texts ...string) []string {
 		}
 	}
 	return out
+}
+
+// CollectHints returns just the message strings from CollectHintDiagnostics
+// for text-mode consumers.
+func CollectHints(texts ...string) []string {
+	diags := CollectHintDiagnostics(texts...)
+	if len(diags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(diags))
+	for _, d := range diags {
+		out = append(out, d.Message)
+	}
+	return out
+}
+
+// HintFromError wraps err as a free-form Diagnostic using the DiagHint code.
+// Used by subcommands when an error blocks result construction and there's
+// no structured context to attach — the error message becomes both Message
+// and Fields.hint (the latter for jq filter convenience).
+func HintFromError(err error) Diagnostic {
+	msg := err.Error()
+	return Diagnostic{
+		Code:    DiagHint,
+		Message: msg,
+		Fields:  map[string]any{"hint": msg},
+	}
 }

--- a/internal/fleet/diagnostics_test.go
+++ b/internal/fleet/diagnostics_test.go
@@ -1,0 +1,81 @@
+package fleet
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestDiagnostic_JSONShape(t *testing.T) {
+	d := Diagnostic{
+		Code:    DiagMissingSecret,
+		Message: "secret missing",
+		Fields:  map[string]any{"secret": "FOO"},
+	}
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"code":"missing_secret","message":"secret missing","fields":{"secret":"FOO"}}`
+	if string(out) != want {
+		t.Errorf("marshal = %s; want %s", out, want)
+	}
+}
+
+func TestDiagnostic_FieldsOmittedWhenEmpty(t *testing.T) {
+	d := Diagnostic{Code: DiagHint, Message: "x"}
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"code":"hint","message":"x"}`
+	if string(out) != want {
+		t.Errorf("marshal = %s; want %s (fields should be omitempty)", out, want)
+	}
+}
+
+func TestHints_AllHaveSnakeCaseCode(t *testing.T) {
+	codePat := regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	for _, h := range hints {
+		if h.Code == "" {
+			t.Errorf("hint %q has empty Code", h.Pattern)
+			continue
+		}
+		if !codePat.MatchString(h.Code) {
+			t.Errorf("hint %q Code = %q; want snake_case matching %s", h.Pattern, h.Code, codePat)
+		}
+	}
+}
+
+func TestCollectHintDiagnostics_UnknownProperty(t *testing.T) {
+	got := CollectHintDiagnostics("Unknown property: foo")
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d; want 1; got=%+v", len(got), got)
+	}
+	if got[0].Code != DiagUnknownProperty {
+		t.Errorf("Code = %q; want %q", got[0].Code, DiagUnknownProperty)
+	}
+	if got[0].Fields["hint"] != got[0].Message {
+		t.Errorf("Fields[hint] = %v; want = Message %q", got[0].Fields["hint"], got[0].Message)
+	}
+}
+
+func TestCollectHintDiagnostics_EmptyInputReturnsNonNilEmptySlice(t *testing.T) {
+	got := CollectHintDiagnostics("")
+	if got == nil {
+		t.Fatal("got = nil; want non-nil empty slice (FR-006: JSON arrays never null)")
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d; want 0", len(got))
+	}
+}
+
+func TestCollectHintDiagnostics_DedupesWithinAndAcrossInputs(t *testing.T) {
+	got := CollectHintDiagnostics(
+		"Unknown property: foo and Unknown property: bar",
+		"another Unknown property: baz",
+	)
+	if len(got) != 1 {
+		t.Errorf("len(got) = %d; want 1 (deduped); got=%+v", len(got), got)
+	}
+}

--- a/internal/fleet/list_result.go
+++ b/internal/fleet/list_result.go
@@ -1,0 +1,79 @@
+package fleet
+
+import "sort"
+
+// ListResult is the machine-readable form of `fleet list`'s tabwriter output.
+// Embedded in the JSON envelope when --output json is active. Slice fields
+// are normalized to non-nil empty slices by BuildListResult so JSON
+// marshaling renders them as [] (FR-009).
+type ListResult struct {
+	LoadedFrom string    `json:"loaded_from"`
+	Repos      []ListRow `json:"repos"`
+}
+
+// ListRow is one repo entry in ListResult.Repos. Engine renders as the empty
+// string when no engine is configured, NOT the text-mode "-" placeholder.
+// Profiles, Workflows, Excluded, and Extra are always non-nil.
+type ListRow struct {
+	Repo      string   `json:"repo"`
+	Profiles  []string `json:"profiles"`
+	Engine    string   `json:"engine"`
+	Workflows []string `json:"workflows"`
+	Excluded  []string `json:"excluded"`
+	Extra     []string `json:"extra"`
+}
+
+// BuildListResult walks cfg.Repos in sorted order, resolves each repo's
+// workflows, and builds the structured form for JSON emission.
+//
+// Returns an error if any repo's workflow resolution fails (matches the
+// behavior of the existing tabwriter list path, which short-circuits on
+// the first ResolveRepoWorkflows error).
+func BuildListResult(cfg *Config) (*ListResult, error) {
+	repoNames := make([]string, 0, len(cfg.Repos))
+	for r := range cfg.Repos {
+		repoNames = append(repoNames, r)
+	}
+	sort.Strings(repoNames)
+
+	rows := make([]ListRow, 0, len(repoNames))
+	for _, repo := range repoNames {
+		spec := cfg.Repos[repo]
+		resolved, err := cfg.ResolveRepoWorkflows(repo)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, ListRow{
+			Repo:      repo,
+			Profiles:  nonNilStrings(spec.Profiles),
+			Engine:    cfg.EffectiveEngine(repo),
+			Workflows: workflowNames(resolved),
+			Excluded:  nonNilStrings(spec.ExcludeFromProfiles),
+			Extra:     extraNames(spec.ExtraWorkflows),
+		})
+	}
+	return &ListResult{LoadedFrom: cfg.LoadedFrom, Repos: rows}, nil
+}
+
+func workflowNames(resolved []ResolvedWorkflow) []string {
+	out := make([]string, 0, len(resolved))
+	for _, w := range resolved {
+		out = append(out, w.Name)
+	}
+	return out
+}
+
+func extraNames(extras []ExtraWorkflow) []string {
+	out := make([]string, 0, len(extras))
+	for _, e := range extras {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/fleet/list_result_test.go
+++ b/internal/fleet/list_result_test.go
@@ -1,0 +1,115 @@
+package fleet
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestBuildListResult_Shape(t *testing.T) {
+	cfg := &Config{
+		LoadedFrom: "fleet.local.json",
+		Defaults:   Defaults{Engine: "copilot"},
+		Profiles: map[string]Profile{
+			"empty": {
+				Sources:   map[string]SourcePin{},
+				Workflows: []ProfileWorkflow{},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			"z/last": {Profiles: []string{"empty"}},
+			"a/first": {
+				Profiles:            []string{"empty"},
+				ExcludeFromProfiles: []string{"never"},
+				ExtraWorkflows:      []ExtraWorkflow{{Name: "custom-extra", Source: SourceLocal}},
+				Engine:              "claude",
+			},
+		},
+	}
+
+	res, err := BuildListResult(cfg)
+	if err != nil {
+		t.Fatalf("BuildListResult: %v", err)
+	}
+	if res.LoadedFrom != "fleet.local.json" {
+		t.Errorf("LoadedFrom = %q; want fleet.local.json", res.LoadedFrom)
+	}
+	if len(res.Repos) != 2 {
+		t.Fatalf("len(Repos) = %d; want 2", len(res.Repos))
+	}
+	// Sorted alphabetically by Repo.
+	got := make([]string, len(res.Repos))
+	for i, r := range res.Repos {
+		got[i] = r.Repo
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("Repos not sorted: %v", got)
+	}
+	if got[0] != "a/first" || got[1] != "z/last" {
+		t.Errorf("repo order = %v; want [a/first z/last]", got)
+	}
+
+	first := res.Repos[0]
+	if first.Engine != "claude" {
+		t.Errorf("a/first Engine = %q; want claude", first.Engine)
+	}
+	if len(first.Excluded) != 1 || first.Excluded[0] != "never" {
+		t.Errorf("a/first Excluded = %v; want [never]", first.Excluded)
+	}
+	if len(first.Extra) != 1 || first.Extra[0] != "custom-extra" {
+		t.Errorf("a/first Extra = %v; want [custom-extra]", first.Extra)
+	}
+
+	last := res.Repos[1]
+	if last.Engine != "copilot" {
+		t.Errorf("z/last Engine = %q; want copilot (from defaults)", last.Engine)
+	}
+	// All slice fields non-nil even when empty.
+	for _, r := range res.Repos {
+		if r.Profiles == nil {
+			t.Errorf("repo %q Profiles is nil; want non-nil empty slice", r.Repo)
+		}
+		if r.Workflows == nil {
+			t.Errorf("repo %q Workflows is nil; want non-nil empty slice", r.Repo)
+		}
+		if r.Excluded == nil {
+			t.Errorf("repo %q Excluded is nil; want non-nil empty slice", r.Repo)
+		}
+		if r.Extra == nil {
+			t.Errorf("repo %q Extra is nil; want non-nil empty slice", r.Repo)
+		}
+	}
+}
+
+func TestBuildListResult_EmptyConfig(t *testing.T) {
+	cfg := &Config{LoadedFrom: ""}
+	res, err := BuildListResult(cfg)
+	if err != nil {
+		t.Fatalf("BuildListResult: %v", err)
+	}
+	if res.Repos == nil {
+		t.Error("Repos is nil; want non-nil empty slice")
+	}
+	if len(res.Repos) != 0 {
+		t.Errorf("len(Repos) = %d; want 0", len(res.Repos))
+	}
+	if res.LoadedFrom != "" {
+		t.Errorf("LoadedFrom = %q; want empty", res.LoadedFrom)
+	}
+}
+
+func TestBuildListResult_EngineEmptyStringNotDash(t *testing.T) {
+	// Engine empty when neither defaults nor per-repo override is set.
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"p": {Sources: map[string]SourcePin{}, Workflows: []ProfileWorkflow{}},
+		},
+		Repos: map[string]RepoSpec{"x/y": {Profiles: []string{"p"}}},
+	}
+	res, err := BuildListResult(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Repos[0].Engine != "" {
+		t.Errorf("Engine = %q; want empty string (NOT \"-\" placeholder)", res.Repos[0].Engine)
+	}
+}

--- a/internal/fleet/load.go
+++ b/internal/fleet/load.go
@@ -7,10 +7,14 @@ import (
 	"path/filepath"
 )
 
+// Filenames the fleet reads/writes relative to the working directory.
 const (
-	ConfigFile      = "fleet.json"
+	// ConfigFile is the committed, public declarative config (example fleet).
+	ConfigFile = "fleet.json"
+	// LocalConfigFile is the private, gitignored overlay merged on top of ConfigFile at load time.
 	LocalConfigFile = "fleet.local.json"
-	TemplatesFile   = "templates.json"
+	// TemplatesFile is the upstream-catalog cache written by `fleet template fetch`.
+	TemplatesFile = "templates.json"
 
 	// SourceLocal marks an ExtraWorkflow / ResolvedWorkflow as living in the
 	// target repo itself (no upstream fetch; `gh aw add` takes a local path).
@@ -121,6 +125,7 @@ func LoadTemplates(dir string) (*Templates, error) {
 	return &t, nil
 }
 
+// SaveTemplates writes the upstream-catalog cache to dir/TemplatesFile as indented JSON.
 func SaveTemplates(dir string, t *Templates) error {
 	return writeJSON(resolve(dir, TemplatesFile), t)
 }

--- a/internal/fleet/schema.go
+++ b/internal/fleet/schema.go
@@ -2,6 +2,10 @@ package fleet
 
 import "time"
 
+// SchemaVersion is the fleet config-file (fleet.json / fleet.local.json) format
+// version written into Config.Version. Bumped only on breaking changes to the
+// on-disk structure; additive changes (new optional fields) do not bump.
+// Distinct from cmd.SchemaVersion, which versions the JSON output envelope.
 const SchemaVersion = 1
 
 // Config is the declarative desired state for the fleet.

--- a/internal/fleet/sync.go
+++ b/internal/fleet/sync.go
@@ -19,14 +19,14 @@ type SyncOpts struct {
 
 // SyncResult aggregates what happened for a single-repo sync.
 type SyncResult struct {
-	Repo            string        // repo owner/name
-	CloneDir        string        // where the clone lives
-	Missing         []string      // workflow names not yet deployed
-	Drift           []string      // workflow files present but not declared
-	Expected        []string      // workflow names matching fleet.json (informational)
-	Deploy          *DeployResult // set iff Apply==true and Missing/Prune required action
-	Pruned          []string      // files removed when --prune --apply
-	DeployPreflight *DeployResult // set iff Apply==false to surface compilation failures
+	Repo            string        `json:"repo"`             // repo owner/name
+	CloneDir        string        `json:"clone_dir"`        // where the clone lives
+	Missing         []string      `json:"missing"`          // workflow names not yet deployed
+	Drift           []string      `json:"drift"`            // workflow files present but not declared
+	Expected        []string      `json:"expected"`         // workflow names matching fleet.json (informational)
+	Deploy          *DeployResult `json:"deploy"`           // set iff Apply==true and Missing/Prune required action
+	Pruned          []string      `json:"pruned"`           // files removed when --prune --apply
+	DeployPreflight *DeployResult `json:"deploy_preflight"` // set iff Apply==false to surface compilation failures
 }
 
 // Sync reconciles one repo's .github/workflows/ to match its declared profile(s).

--- a/internal/fleet/upgrade.go
+++ b/internal/fleet/upgrade.go
@@ -13,6 +13,9 @@ import (
 	"time"
 )
 
+// UpgradeOpts controls upgrade behavior. Apply=false is dry-run; Audit=true
+// runs `gh aw audit` instead of the upgrade pipeline; Major=true permits
+// major-version source bumps; Force=true passes through to `gh aw upgrade`.
 type UpgradeOpts struct {
 	Apply   bool
 	Audit   bool
@@ -21,18 +24,21 @@ type UpgradeOpts struct {
 	WorkDir string
 }
 
+// UpgradeResult aggregates what happened for a single-repo upgrade. OutputLog
+// captures combined stdout+stderr from gh aw upgrade/update so the diagnostics
+// layer can extract actionable hints on failure.
 type UpgradeResult struct {
-	Repo         string
-	CloneDir     string
-	UpgradeOK    bool
-	UpdateOK     bool
-	ChangedFiles []string
-	Conflicts    []string
-	NoChanges    bool
-	BranchPushed string
-	PRURL        string
-	AuditJSON    json.RawMessage
-	OutputLog    string // combined stdout+stderr from gh aw upgrade/update; used for hint extraction
+	Repo         string          `json:"repo"`
+	CloneDir     string          `json:"clone_dir"`
+	UpgradeOK    bool            `json:"upgrade_ok"`
+	UpdateOK     bool            `json:"update_ok"`
+	ChangedFiles []string        `json:"changed_files"`
+	Conflicts    []string        `json:"conflicts"`
+	NoChanges    bool            `json:"no_changes"`
+	BranchPushed string          `json:"branch_pushed"`
+	PRURL        string          `json:"pr_url"`
+	AuditJSON    json.RawMessage `json:"audit_json"`
+	OutputLog    string          `json:"output_log"` // combined stdout+stderr from gh aw upgrade/update; used for hint extraction
 }
 
 // Upgrade runs the upgrade pipeline for a single repo.

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Command gh-aw-fleet is the declarative fleet manager for GitHub Agentic
+// Workflows. It reconciles target repos toward the desired state declared in
+// fleet.json, delegating to `gh aw`, `gh`, and `git` under the hood.
 package main
 
 import (

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",

--- a/skills/fleet-build-profile/SKILL.md
+++ b/skills/fleet-build-profile/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: fleet-build-profile
+description: Scaffold a new fleet profile — add a `profiles.<name>` entry to fleet.json (or fleet.local.json) with a curated workflow list and pinned source refs, and optionally mirror it to `profiles/<name>.json`. Use this skill whenever the user says "build a profile", "create a profile", "scaffold a profile", "new profile", "add a profile to fleet.json", "make a profiles/<name>.json", "start a docs-plus / security-plus / quality-plus / community-plus profile", or proposes a named profile that doesn't exist yet. Also trigger when `fleet-eval-templates` has surfaced candidates the user now wants materialized into a profile definition. The skill reads `templates.json` for workflow metadata, proposes the profile JSON inline, writes on approval, and for the `default` profile mirrors both files to preserve the documented verbatim-match invariant. Do not trigger for evaluating upstream workflows (that's `fleet-eval-templates`), for deploying an existing profile to a repo (that's `fleet-deploy`), for rotating pins on already-deployed workflows (that's `fleet-upgrade-review`), or for onboarding a repo into the fleet (that's `fleet-onboard-repo`).
+---
+
+# Fleet Build Profile
+
+Scaffold a new profile (or materialize candidates from `fleet-eval-templates`) as a `profiles.<name>` entry in `fleet.json` or `fleet.local.json`, with pinned sources and a curated workflow list.
+
+## Why this skill exists
+
+Profiles are the *intent layer* of the fleet. `templates.json` says what exists upstream; `fleet.json` says which curated subset a repo gets, pinned to which ref. The gap between them is judgment — "these eight agentics workflows make a coherent `security-plus` bundle at this ref, tagged so audits don't drift."
+
+`fleet-eval-templates` answers "which workflows deserve inclusion?" and stops at a proposed diff. That stop-point is deliberate: the decision to name a profile, choose pins, and write the file is a separate operator act. This skill is that act. Keeping the two skills split means evaluation stays read-only and profile-creation stays explicit — neither accidentally does the other.
+
+Two other facts shape the flow:
+
+- `fleet.json` is the public, committed declarative state (five profiles today: `default`, `quality-plus`, `security-plus`, `docs-plus`, `community-plus`). `fleet.local.json` layers on top, is gitignored, and is where private / experimental profiles live. The user picks which to write — usually `fleet.local.json` for new or one-off profiles, `fleet.json` only when the profile is stable and meant to be shared.
+- `profiles/<name>.json` is a separate, human-readable mirror. Only `profiles/default.json` exists today, and no Go code reads it — it's a documentation convention. CLAUDE.md still requires `profiles/default.json` to match `fleet.json`'s `default` profile verbatim, so any write that touches the `default` profile has to update both files in the same turn.
+
+## When to use
+
+- User has a name in mind for a new profile and a rough workflow list (often the output of `fleet-eval-templates`).
+- User wants to fork an existing profile into a specialized variant (e.g., `security-plus-strict` from `security-plus`).
+- User is editing `profiles/default.json` as documentation and needs fleet.json kept in sync.
+
+Skip for:
+- Evaluating which upstream workflows deserve inclusion — `fleet-eval-templates`.
+- Adding workflows to an already-existing profile without changing pins or scope (a small edit — just do it directly, no skill needed).
+- Deploying a profile to a repo — `fleet-deploy`.
+- Rotating pins on workflows already deployed across the fleet — `fleet-upgrade-review`.
+- Onboarding a repo — `fleet-onboard-repo`.
+
+## The flow
+
+### Step 1 — confirm scope
+
+Before touching anything, confirm four things with the user:
+
+1. **Profile name.** e.g., `docs-plus`, `security-plus-strict`, `experimental`. If the name already exists in the target file, this is an edit, not a build — stop and ask whether to merge workflows or rename.
+2. **Target file.** `fleet.local.json` (private, experimental, gitignored) or `fleet.json` (shared, committed). Default to `fleet.local.json` unless the user explicitly wants a shared profile.
+3. **Mirror into `profiles/<name>.json`?** Only needed if this is the `default` profile (required, per invariant) or if the user wants a standalone example file for humans. Say "no" by default for new profiles — the file has no code consumer.
+4. **Workflow source** — either inline list from the user, or "use the candidates from the last `fleet-eval-templates` run." In the second case, re-read `templates.json` to pull metadata; don't rely on memory.
+
+If any of these is underspecified, ask. A mis-named or mis-placed profile is annoying to untangle because `fleet sync --apply --force` would have to re-pin deployed repos.
+
+### Step 2 — pick sources and pins
+
+A profile has a `sources` map: for each upstream repo it draws from, a `ref`. Decide pins by these rules:
+
+- **`githubnext/agentics`**: pin to a commit SHA (preferred) or `main`. `main` is acceptable for agentics — it's a curated library and its tip is generally safer than gh-aw's. Copy the ref from `profiles/default.json` / `fleet.json`'s `default` profile unless the user has a reason to diverge (e.g., a known-good earlier SHA, or pinning to `main` to track the library).
+- **`github/gh-aw`**: pin to a tag (`vX.Y.Z`), **never `main`**. CLAUDE.md is explicit: gh-aw's `main` often contains unreleased compiler features (e.g., `mount-as-clis`) that break the installed CLI. If the user says `main`, push back once and propose the latest tag instead.
+- **Omit sources this profile doesn't use.** A `docs-plus` profile that draws only from agentics shouldn't carry a `github/gh-aw` pin. Extra pins don't hurt deploys but pollute the diff surface on pin bumps.
+
+Read `templates.json`'s `fetched_at` for context on how old the catalog is — if it's stale (>a week), mention it and suggest running `fleet-eval-templates` first.
+
+### Step 3 — curate the workflow list
+
+For each candidate workflow, verify against `templates.json` before adding:
+
+```bash
+jq '.sources["githubnext/agentics"].workflows[] | select(.name == "<name>") | {description, triggers, safe_outputs}' templates.json
+```
+
+- If the workflow isn't in `templates.json`, stop — either the name is wrong or the catalog is stale. Don't guess.
+- If `triggers` or `safe_outputs` are empty/null, read `.body` before including — the fetch may not have resolved imports, and the workflow's real shape is in the body.
+- Cross-check the source: gh-aw workflows need `.github/workflows/` layout, agentics workflows use `workflows/`. `ResolvedWorkflow.Spec()` handles this, but the `source` field in the profile entry must match the `SourceLayout` key exactly (`github/gh-aw` or `githubnext/agentics`).
+
+Name-order inside `workflows: [...]` is conventional: gh-aw entries first (dogfooded items with no agentics counterpart), then agentics entries alphabetical. Match the formatting of `profiles/default.json` — aligned-column `"source":` values are hand-maintained, and diffs stay readable.
+
+### Step 4 — propose the diff inline
+
+Show the full JSON block for the new profile entry before writing. Include a short description field (one sentence — see existing profile descriptions for tone: "Baseline every tracked repo gets. Low-noise, broadly useful."). If `mirror to profiles/<name>.json` was requested, show both blocks.
+
+Call out anything the user should sanity-check:
+- Any gh-aw workflow included → flag the source stability note.
+- Pin ref differs from `default` profile → mention it and why.
+- Any workflow with `safe_outputs: create-pull-request` or `push-to-pull-request-branch` → note the noise profile, since the whole bundle's character is set by its heaviest safe-outputs.
+
+Stop. Wait for explicit approval ("go", "apply", "looks good") before writing.
+
+### Step 5 — write the files
+
+On approval:
+
+- Insert the new profile into the target file's `profiles` map, using a JSON editor or `jq` in-place. Preserve existing formatting; `fleet.json`'s aligned columns are the convention.
+- If `name == "default"` **or** the user requested a mirror, write `profiles/<name>.json` with the same shape (top-level `description`, `sources`, `workflows` — no wrapping `version`/`defaults`/`profiles` map).
+- For `name == "default"`, both files **must** be written in the same turn — the invariant is docs-only but trips code review and `fleet-eval-templates` follow-ups if out of sync.
+
+Do not run `go run . ...` or `gh aw ...` as part of this step. The skill is declarative-state-only; deployment is the user's follow-up.
+
+### Step 6 — remind about sync
+
+Profile edits don't propagate automatically. Existing `gh aw update` on a deployed repo follows the *workflow's own frontmatter `source:` line*, not fleet.json — so a pin bump or workflow addition in a profile is invisible to already-deployed repos until the user runs:
+
+```bash
+go run . sync --apply --force <repo>
+```
+
+Call this out in the final summary. For a brand-new profile, there's nothing to sync until the user deploys it via `fleet-deploy` (`go run . deploy --apply --profile <name> <repo>`). Mention that path too.
+
+## Invariants
+
+- **Never default `github/gh-aw` to `main`.** If the user insists, push back once with the `mount-as-clis` example; if they still want it, proceed but log the risk in the profile description.
+- **Do not delete or reorder existing profiles.** This skill appends. If the user wants a rename or deletion, that's a separate edit and should be explicit.
+- **`default` profile edits require the mirror.** `fleet.json`'s `default` and `profiles/default.json` must match verbatim, including description, source order, workflow order, and column alignment. If they're already out of sync on entry, report it and fix alignment *first* before adding.
+- **Don't write to `fleet.local.json` if it doesn't exist** — it's gitignored and absence is meaningful (the user hasn't set up a private fleet yet). Offer to create it, don't silently do so.
+- **No git operations.** This skill edits declarative state only. Committing is the user's call, and CLAUDE.md forbids the Bash tool from running `git add`/`commit`/`push`.
+
+## What "success" looks like
+
+A concise, actionable summary:
+
+```
+Profile scaffolded: <name> → <target-file>[, profiles/<name>.json]
+
+Sources:
+  - <source>@<ref>   (inherited from default | set by user | bumped from X to Y)
+
+Workflows (N):
+  - <name> (<source>)
+  ...
+
+Next steps:
+  - To deploy to a repo:       go run . deploy --apply --profile <name> <repo>
+  - To re-pin deployed repos:  go run . sync --apply --force <repo>
+  - Review diff before commit: git diff fleet.json profiles/<name>.json
+```
+
+If the user asked for a mirror or touched `default`, explicitly confirm both files were written.
+
+## Examples
+
+### Example 1 — new experimental profile in fleet.local.json
+
+```
+User: scaffold a profiles/experimental.json with link-checker and markdown-linter from agentics
+
+You:
+  - Confirm scope: name=experimental, target=fleet.local.json (gitignored for experiments),
+    mirror to profiles/experimental.json? Ask — user says yes.
+  - jq templates.json for both workflows; confirm triggers + safe_outputs.
+  - Inherit agentics ref from existing default (96b9d4c...). Omit gh-aw source (not used).
+  - Propose JSON block for fleet.local.json's profiles.experimental and profiles/experimental.json.
+  - On approval: write both files. Remind about deploy command.
+```
+
+### Example 2 — materialize fleet-eval-templates output
+
+```
+User: take the docs-plus candidates we just discussed and make a profile
+
+You:
+  - Confirm scope: name=docs-plus (check — already exists in fleet.json). This is an edit
+    of an existing profile, not a new build. Flag this and ask whether to merge or pick a
+    new name (e.g., docs-plus-strict).
+  - On user choice (merge into docs-plus): switch out of this skill — it's an append edit,
+    not a scaffold. Just do the edit directly.
+  - On user choice (new name, docs-plus-strict): continue. Pin agentics to SHA from default.
+    Propose JSON block. Write to fleet.json on approval (user wants it shared).
+```
+
+### Example 3 — editing the default profile
+
+```
+User: add dependency-freshness-scanner to the default profile
+
+You:
+  - name=default: this triggers the mirror invariant. Target = fleet.json AND
+    profiles/default.json.
+  - Verify current alignment: diff fleet.json's profiles.default against profiles/default.json.
+    If drift, fix alignment first; flag to the user.
+  - Verify workflow in templates.json. Confirm safe_outputs are modest (create-issue only,
+    say) — otherwise it's a bad fit for default's low-noise framing.
+  - Propose diff for both files. Write both on approval. Remind about
+    `sync --apply --force <repo>` for each already-deployed repo, since pin bumps don't
+    flow through upgrade.
+```

--- a/skills/fleet-deploy/SKILL.md
+++ b/skills/fleet-deploy/SKILL.md
@@ -146,6 +146,8 @@ Stop. Wait for the user to report the PR URL or the merge. Don't try to run git 
 
 When a `--apply` fails across several repos (rare, but the failure modes are varied: secret drift, upstream changes, transient network), run the failing invocation with `--log-level=debug --log-format=json 2>/tmp/log.json` and inspect `/tmp/log.json` with `jq`. Subprocess summary events carry `tool`, `subcommand`, `exit_code`, `duration`, and `clone_dir`; warning events carry `repo` and the relevant detail field (`secret`, `drift`, `hint`). This gives a greppable, per-subprocess record of what the tool did without wading through interleaved live output. The three-turn pattern above is unchanged — this is an optional debugging aid for Turn 3 retrospectives.
 
+For machine-readable output, pass `-o json` on `list`/`deploy`/`sync`/`upgrade`. See `specs/003-cli-output-json/quickstart.md`.
+
 ## Invariants (non-negotiable)
 
 These apply regardless of how the user phrases the request:

--- a/skills/fleet-eval-templates/SKILL.md
+++ b/skills/fleet-eval-templates/SKILL.md
@@ -184,3 +184,7 @@ You:
   - Verdict: worth pin-bumping the agentics source in `default`. Flag that `threat-detection` is a new safe-output that might require opt-in at the gh-aw level.
   - Recommend: test on one repo first (finfocus) before bumping for all.
 ```
+
+## Extended usage
+
+For machine-readable output, pass `-o json` on `list`/`deploy`/`sync`/`upgrade`. See `specs/003-cli-output-json/quickstart.md`.

--- a/skills/fleet-onboard-repo/SKILL.md
+++ b/skills/fleet-onboard-repo/SKILL.md
@@ -214,3 +214,7 @@ You:
   - Proceed with fleet-onboard-repo flow.
   - After registration, chain into fleet-deploy.
 ```
+
+## Extended usage
+
+For machine-readable output, pass `-o json` on `list`/`deploy`/`sync`/`upgrade`. See `specs/003-cli-output-json/quickstart.md`.

--- a/skills/fleet-upgrade-review/SKILL.md
+++ b/skills/fleet-upgrade-review/SKILL.md
@@ -217,3 +217,7 @@ You:
   - Say: "Resolve in the clone, then re-run `go run . upgrade HavenTrack/goa-service-shared --apply --work-dir /tmp/gh-aw-fleet-...`. I'll wait."
   - Do NOT attempt --apply.
 ```
+
+## Extended usage
+
+For machine-readable output, pass `-o json` on `list`/`deploy`/`sync`/`upgrade`. See `specs/003-cli-output-json/quickstart.md`.

--- a/specs/003-cli-output-json/checklists/requirements.md
+++ b/specs/003-cli-output-json/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Specification Quality Checklist: CLI JSON Output Mode
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+### Validation approach
+
+The source material (GitHub issue #25) is unusually detailed — it already includes a proposed envelope shape, affected file list, acceptance criteria, and testing strategy. The spec distills these into testable user stories (P1/P2/P3), functional requirements with stable IDs, and technology-agnostic success criteria.
+
+### Flagged tensions that passed review
+
+- **FR-008 names `snake_case` as the JSON key convention.** This is a data-model convention, not an implementation detail — it's part of the contract consumers depend on. Kept.
+- **FR-017 enumerates `ListResult` fields by name.** These are data shape requirements (what the consumer sees), not code structure. Kept.
+- **FR-016 mentions `json.RawMessage` only in the Key Entities context for `audit_json`.** The requirement itself is phrased in terms of observable JSON output ("nest as a native JSON object, not a stringified blob"). Kept.
+- **Assumption about `stderr` as the diagnostic channel.** This is a user-facing contract (where diagnostics appear), not an internal detail. Kept.
+
+### Dependency note
+
+The spec's assumptions section records that issue #24 (zerolog) is a soft dependency. The spec does not block on #24 — FR-011 explicitly allows a stub fallback — which preserves schedule independence.
+
+### No [NEEDS CLARIFICATION] markers
+
+The source issue specified envelope shape, flag semantics, default value, error handling, and testing strategy in enough detail to answer every open question with a reasonable default. Three-marker budget was not needed.
+
+### Validation complete on first pass
+
+All items pass on the initial spec write. No revision iterations required.

--- a/specs/003-cli-output-json/contracts/cli-flags.md
+++ b/specs/003-cli-output-json/contracts/cli-flags.md
@@ -1,0 +1,139 @@
+# Contract: CLI Flag Surface
+
+**Feature**: 003-cli-output-json
+**Spec FRs**: FR-001, FR-002, FR-003, FR-013
+
+This contract defines the persistent CLI-flag surface this feature adds to the root `gh-aw-fleet` command. The flag is persistent (inherited by every subcommand). Default preserves pre-feature behavior.
+
+---
+
+## Flag
+
+### `-o` / `--output`
+
+| Property | Value |
+|---|---|
+| Type | string (enum) |
+| Default | `text` |
+| Valid values | `text`, `json` |
+| Short form | `-o` |
+| Long form | `--output` |
+| Scope | persistent on root (`rootCmd.PersistentFlags()`) |
+| Case | lowercase only; `JSON`, `Text`, `TEXT`, etc. are rejected |
+
+**Semantics**:
+
+- `text` (default) — every subcommand uses its existing text-mode printer. Stdout is byte-identical to pre-feature behavior (FR-014).
+- `json` — supported subcommands (`list`, `deploy`, `sync`, `upgrade`) emit a single JSON envelope on stdout per invocation (NDJSON per repo for `upgrade --all`). All human-oriented breadcrumbs (e.g., `(loaded fleet.local.json)`) are routed to stderr via zerolog. Unsupported subcommands (`template fetch`, `add`, `status` if present) reject `-o json` with a clear error.
+
+**Rejection behavior — invalid value** (FR-002):
+
+Cobra's `PersistentPreRunE` on the root command validates the flag value against the closed set. Any other value (including `yaml`, `YAML`, `Json`, empty string `""`) causes:
+
+```text
+Error: unsupported output mode "yaml": expected one of: text, json
+```
+
+...written to stderr as plain text (not JSON — flag errors are pre-serialization and never emit an envelope). Exit code: 1. Subcommand RunE is NOT invoked.
+
+**Rejection behavior — unsupported subcommand** (FR-013):
+
+When `-o json` is passed to `template fetch` (or any other subcommand that doesn't support JSON mode), the subcommand's own RunE rejects it with:
+
+```text
+Error: command "template fetch" does not support --output json; use --output text or omit the flag
+```
+
+...written to stderr as plain text. Exit code: 1. The subcommand does not execute.
+
+Rationale: a silent fallback to text mode when an operator expected JSON would cause `jq` parse failures and confusing debugging. Explicit rejection is kinder.
+
+---
+
+## Interaction with other persistent flags
+
+| Flag | Interaction |
+|---|---|
+| `--dir` | Orthogonal. `--dir` selects where to load `fleet.json` / `fleet.local.json`; `--output` selects how to render results. Both are persistent on root. Any combination is valid. |
+| `--log-level` | Orthogonal. `--log-level` filters stderr zerolog events by severity. In JSON mode, warnings and hints emit on stderr via zerolog AND in the envelope on stdout; `--log-level=error` suppresses the stderr emission but does NOT affect envelope contents. This is intentional — machine consumers get the full structured record regardless of log-level. |
+| `--log-format` | Orthogonal. `--log-format=json` makes stderr also line-structured JSON; stdout envelope is unaffected. A pipeline wanting pure machine-parseable output on both streams uses `-o json --log-format=json`. |
+| `--apply` | Orthogonal, subcommand-scoped (present on `deploy`, `sync`, `upgrade`). `-o json --apply` runs the actual apply and emits the envelope for the apply result. The three-turn pattern (constitution III) still applies; the `-o json` flag has no bearing on whether approval is required. |
+| `--all` | Scoped to `upgrade`. `upgrade --all -o json` triggers NDJSON emission per `contracts/ndjson.md`. |
+| `--work-dir` | Scoped to `deploy`. Orthogonal to `-o json`. The resume flow works identically in JSON mode. |
+
+---
+
+## Subcommand support matrix
+
+| Subcommand | `-o json` supported | Notes |
+|---|---|---|
+| `list` | ✓ | Emits `ListResult` envelope |
+| `deploy <repo>` | ✓ | Emits `DeployResult` envelope |
+| `sync <repo>` | ✓ | Emits `SyncResult` envelope |
+| `upgrade <repo>` | ✓ | Emits `UpgradeResult` envelope (single) |
+| `upgrade --all` | ✓ | Emits NDJSON stream (per contracts/ndjson.md) |
+| `add <owner/repo>` | ✗ | Out of scope. Rejects `-o json`. |
+| `template fetch` | ✗ | Explicitly out of scope per spec Out of Scope; has its own `--json` flag for a different purpose. Rejects `-o json`. |
+| `status [repo]` | ✗ | Stub command today; out of scope. Rejects `-o json`. |
+
+---
+
+## Implementation hooks
+
+### Root command (`cmd/root.go`)
+
+```go
+// Registration inside newRoot():
+root.PersistentFlags().StringP("output", "o", "text", "Output format: text|json")
+
+// Validation inside PersistentPreRunE (chained after existing log-flag validation):
+out, _ := cmd.Flags().GetString("output")
+switch out {
+case "text", "json":
+    // OK
+default:
+    return fmt.Errorf("unsupported output mode %q: expected one of: text, json", out)
+}
+```
+
+### Helper (`cmd/output.go`)
+
+```go
+// outputMode reads the resolved --output value from the given cobra command.
+// Safe to call from any subcommand's RunE; returns "text" if the flag is unset
+// (though PersistentPreRunE has already validated).
+func outputMode(cmd *cobra.Command) string {
+    v, _ := cmd.Flags().GetString("output")
+    if v == "" {
+        return "text"
+    }
+    return v
+}
+```
+
+### Subcommand-level rejection (example: `cmd/template.go`)
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    if outputMode(cmd) == "json" {
+        return fmt.Errorf("command %q does not support --output json; use --output text or omit the flag", "template fetch")
+    }
+    // ... existing RunE body unchanged
+},
+```
+
+---
+
+## Testing (`cmd/output_test.go`)
+
+| Test name | Covers |
+|---|---|
+| `TestOutputFlag_AcceptsText` | `-o text` passes validation (FR-001) |
+| `TestOutputFlag_AcceptsJSON` | `-o json` passes validation (FR-001) |
+| `TestOutputFlag_DefaultText` | omitting `--output` resolves to `text` (FR-001) |
+| `TestOutputFlag_RejectsYAML` | `-o yaml` returns non-nil error with expected message (FR-002) |
+| `TestOutputFlag_RejectsUpperCase` | `-o JSON` returns non-nil error (FR-002, case sensitivity) |
+| `TestOutputFlag_RejectsEmpty` | `-o ""` returns non-nil error (FR-002) |
+| `TestTemplateFetch_RejectsJSONMode` | `template fetch -o json` returns non-nil error (FR-013) |
+
+Tests use cobra's `ExecuteC` in-process invocation pattern (same as `cmd/root_logging_test.go` from #34).

--- a/specs/003-cli-output-json/contracts/envelope.md
+++ b/specs/003-cli-output-json/contracts/envelope.md
@@ -1,0 +1,196 @@
+# Contract: JSON Envelope
+
+**Feature**: 003-cli-output-json
+**Spec FRs**: FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-015, FR-016, FR-020
+
+This contract pins the wire shape of the JSON object emitted on stdout when `--output json` is active. It is the machine-readable contract that downstream consumers depend on. Changes to this contract require a `schema_version` bump.
+
+---
+
+## Top-level shape
+
+```json
+{
+  "schema_version": 1,
+  "command": "deploy",
+  "repo": "rshade/gh-aw-fleet",
+  "apply": false,
+  "result": { "...": "command-specific struct, or null on pre-result failure" },
+  "warnings": [
+    { "code": "missing_secret", "message": "Actions secret ANTHROPIC_API_KEY is missing...", "fields": { "secret": "ANTHROPIC_API_KEY", "url": "https://..." } }
+  ],
+  "hints": [
+    { "code": "hint", "message": "Workflow uses a property your installed gh aw CLI doesn't recognize...", "fields": { "hint": "Workflow uses a property your installed gh aw CLI doesn't recognize..." } }
+  ]
+}
+```
+
+All output is **compact single-line JSON** (FR-015). No pretty-printing. Consumers pipe through `jq` for formatting.
+
+---
+
+## Pinned top-level keys
+
+All seven keys MUST appear in every envelope (FR-004, SC-005). No `omitempty`. Ordering MAY vary (JSON objects are unordered by spec) but the `encoding/json` emission order is stable Go-field-declaration order in practice — consumers MUST NOT depend on it.
+
+| Key | Type | Nullable | Notes |
+|---|---|---|---|
+| `schema_version` | integer | no | `1` for this release. Monotonically bumped on breaking changes. |
+| `command` | string | no | One of: `"list"`, `"deploy"`, `"sync"`, `"upgrade"`. |
+| `repo` | string | no (may be empty string) | `owner/name`; empty for `list` or on pre-result failure before repo parse. |
+| `apply` | boolean | no | `true` only when `--apply` was passed AND the command is one that mutates (`deploy`, `sync`, `upgrade`). `false` for `list`, and for dry-runs. |
+| `result` | object \| null | yes | Command-specific struct; `null` on pre-result failure (FR-020). |
+| `warnings` | array | no (may be `[]`) | Array of `Diagnostic`. Always present. `[]` when no warnings. |
+| `hints` | array | no (may be `[]`) | Array of `Diagnostic`. Always present. `[]` when no hints. |
+
+---
+
+## `schema_version` policy
+
+- Integer, initially `1`.
+- Bumped (monotonic `+1`) on any breaking change to:
+  - top-level envelope keys (add/remove/rename)
+  - `Diagnostic` shape
+  - `ListResult` / `ListRow` field names or types
+  - `DeployResult` / `WorkflowOutcome` / `SyncResult` / `UpgradeResult` JSON field names or types
+- Additive changes (new optional fields on existing structs, new `Diagnostic` codes, new nested objects) do NOT bump the version — they are backward-compatible.
+- Version history is maintained in `CHANGELOG.md` under the `### JSON envelope schema` sub-section.
+
+**Consumer guidance**: Agents MUST check `schema_version === 1` and fail loudly on any other value. Forward-compatibility is not promised; a bump signals "re-read the contract before trusting fields."
+
+---
+
+## `command`
+
+The canonical form used in the envelope. One of:
+
+| Value | Emitting subcommand |
+|---|---|
+| `"list"` | `gh-aw-fleet list` |
+| `"deploy"` | `gh-aw-fleet deploy <repo>` |
+| `"sync"` | `gh-aw-fleet sync <repo>` |
+| `"upgrade"` | `gh-aw-fleet upgrade <repo>` or `gh-aw-fleet upgrade --all` (per-repo line) |
+
+**Not emitted**: `"template"`, `"template fetch"`, `"add"`, `"status"` — those subcommands reject `-o json`.
+
+Consumers dispatching on `command` to apply a result-schema can use a stable Go switch / object lookup.
+
+---
+
+## `result`
+
+The type of `result` depends on `command`:
+
+| `command` | `result` type (Go) |
+|---|---|
+| `"list"` | `*fleet.ListResult` |
+| `"deploy"` | `*fleet.DeployResult` |
+| `"sync"` | `*fleet.SyncResult` |
+| `"upgrade"` | `*fleet.UpgradeResult` |
+
+All result fields use snake_case JSON keys (FR-008). See `data-model.md` for the full field list per struct.
+
+**Null semantics**:
+- `result` MUST be `null` when the command failed before building its result struct (FR-020: config parse error, missing tool, repo not in fleet, profile resolution failure). In this case, `warnings[]` or `hints[]` MUST carry enough structured context for the consumer to understand the failure.
+- `result` MUST NOT be `null` when the command structurally succeeded — even if the command's logical outcome is "empty" (e.g., a sync run with no drift produces `{"missing":[], "drift":[], "expected":[...]}`, not `null`).
+
+---
+
+## Slice normalization (FR-006, FR-009)
+
+Every array field in the envelope MUST serialize as `[]` (not `null`) when empty. This applies recursively:
+
+- `warnings`, `hints` at the envelope top level
+- Every slice field of every result struct (`added`, `skipped`, `failed` in `DeployResult`; `missing`, `drift`, `expected`, `pruned` in `SyncResult`; `changed_files`, `conflicts` in `UpgradeResult`; `profiles`, `workflows`, `excluded`, `extra` in `ListRow`; `repos` in `ListResult`)
+- Future-added slice fields on any of the above
+
+**Enforcement**: `cmd.output.initSlices(result)` reflection helper (see `research.md` R2) walks the result struct and sets all nil slices to empty non-nil slices before `json.Encoder.Encode`. Runs unconditionally on every envelope emission.
+
+**Non-slice-but-nullable fields** (e.g., `SyncResult.Deploy *DeployResult`, `SyncResult.DeployPreflight *DeployResult`) keep their nil semantics and marshal as `null` when unset. The helper skips pointer-to-struct fields intentionally.
+
+---
+
+## Stdout vs stderr routing (FR-010, FR-011, FR-012)
+
+Stdout in JSON mode contains EXACTLY:
+- One complete JSON envelope (single-repo commands), OR
+- N complete JSON envelopes separated by newlines (NDJSON for `upgrade --all`; see `contracts/ndjson.md`).
+
+Nothing else. No breadcrumbs, no progress, no diagnostic text. `jq -e . < <(cmd -o json)` succeeds for every invocation (SC-002).
+
+Stderr in JSON mode contains:
+- Zerolog structured events for warnings, hints, errors (filtered by `--log-level`).
+- Cobra's own error output on flag validation failure (plain text, not JSON).
+- Any `fmt.Fprintf(cmd.OutOrStderr(), ...)` calls that existed pre-feature (e.g., `(loaded fleet.local.json)` breadcrumb in `list.go`).
+
+Text mode is unaffected — stdout keeps its existing tabwriter content; stderr keeps its existing zerolog events.
+
+---
+
+## `audit_json` nesting (FR-016)
+
+`UpgradeResult.AuditJSON` is `json.RawMessage`. When populated (typical upgrade run), it MUST serialize as a native nested JSON object in the envelope — not as a string-wrapped escape-encoded blob.
+
+Good (expected):
+```json
+{ "result": { "audit_json": { "version": "1", "findings": [] } } }
+```
+
+Bad (regression):
+```json
+{ "result": { "audit_json": "{\"version\":\"1\",\"findings\":[]}" } }
+```
+
+This is the default behavior of `json.RawMessage` with the stdlib `encoding/json` package. No additional code is required. A regression test (`TestEnvelope_AuditJSONNests`) pins this against future type changes.
+
+When `AuditJSON` is unset (e.g., `gh aw audit` was not invoked on this upgrade), it MUST marshal as JSON `null` — the default for a nil `RawMessage`.
+
+---
+
+## Pre-result failure shape (FR-020)
+
+When a command cannot build its result struct, stdout still gets one complete envelope. Example — `deploy nonexistent/repo -o json`:
+
+```json
+{
+  "schema_version": 1,
+  "command": "deploy",
+  "repo": "nonexistent/repo",
+  "apply": false,
+  "result": null,
+  "warnings": [],
+  "hints": [
+    { "code": "hint", "message": "Repo \"nonexistent/repo\" is not declared in fleet.json; add it with `gh-aw-fleet add nonexistent/repo` first.", "fields": { "hint": "..." } }
+  ]
+}
+```
+
+Exit code is non-zero. `jq -e .` succeeds (SC-002). `jq '.result == null'` returns `true`, which is the canonical test for "command did not produce a result."
+
+---
+
+## Exit code contract (FR-021)
+
+JSON mode exit codes mirror text mode exactly. There is no new exit-code contract. Summary:
+
+| Condition | Exit code | Both modes |
+|---|---|---|
+| Clean success | 0 | ✓ |
+| Warnings present, structurally succeeded | 0 (text-mode parity) | ✓ |
+| Pre-result failure (config parse, missing tool, repo not in fleet) | non-zero | ✓ |
+| `--apply` failure mid-pipeline | non-zero | ✓ |
+| Flag validation failure (e.g., `-o yaml`) | non-zero | ✓ |
+
+Agents requiring warning-level gating MUST parse `warnings[]` from the envelope rather than infer from exit code.
+
+---
+
+## Test fixture (pinning)
+
+`cmd/output_test.go` contains a `TestEnvelope_TopLevelKeysPinned` test that marshals a synthetic envelope (empty result struct, empty warnings, empty hints) and asserts the output matches exactly:
+
+```json
+{"schema_version":1,"command":"list","repo":"","apply":false,"result":{"loaded_from":"","repos":[]},"warnings":[],"hints":[]}
+```
+
+This fails if any top-level key is added, removed, or renamed — including accidental drift during refactor.

--- a/specs/003-cli-output-json/contracts/ndjson.md
+++ b/specs/003-cli-output-json/contracts/ndjson.md
@@ -1,0 +1,115 @@
+# Contract: NDJSON Stream for `upgrade --all`
+
+**Feature**: 003-cli-output-json
+**Spec FRs**: FR-019; User Story 3 acceptance scenario 5; Clarification Q1
+
+This contract defines the newline-delimited JSON (NDJSON) stream emitted on stdout when `upgrade --all -o json` is invoked.
+
+---
+
+## Shape
+
+For a fleet of N repos, `upgrade --all -o json` emits exactly **N** complete JSON envelopes on stdout, one per line. Each line is a full, single-repo envelope matching `contracts/envelope.md` — not a fragment, not a shared header, not an aggregate.
+
+Example for N=3:
+
+```text
+{"schema_version":1,"command":"upgrade","repo":"owner/repo-a","apply":false,"result":{...},"warnings":[],"hints":[]}
+{"schema_version":1,"command":"upgrade","repo":"owner/repo-b","apply":false,"result":null,"warnings":[],"hints":[{"code":"hint","message":"..."}]}
+{"schema_version":1,"command":"upgrade","repo":"owner/repo-c","apply":false,"result":{...},"warnings":[{"code":"missing_secret",...}],"hints":[]}
+```
+
+Each envelope is self-contained. A consumer can process each line independently with `jq -c` or any JSON-streaming parser.
+
+---
+
+## Invariants
+
+1. **Exactly one envelope per line.** No pretty-printing. No embedded newlines inside any envelope (the stdlib `json.Encoder` guarantees this for valid JSON — no stdin-injected newline can appear inside string fields without being `\n`-escaped).
+2. **Exactly one newline terminator per envelope.** `json.Encoder.Encode(v)` writes one `\n` after each value. No trailing empty line after the Nth envelope (the Nth line's terminator is the file's last byte).
+3. **Per-repo flush semantics.** Each envelope MUST be flushed to stdout when the corresponding repo's `Upgrade` returns — not batched until all repos finish. Consumers can stream: a downstream `jq -c '.'` or Python `for line in sys.stdin` consumer sees each repo's result within tens of milliseconds of the repo completing.
+4. **Error envelopes are included in-line.** When `upgrade` for repo X fails (pre-result failure or mid-pipeline), the envelope for repo X MUST still appear on its own line with `result: null` and diagnostics populated. Processing continues with repo X+1. The loop does NOT short-circuit on first failure (existing `upgrade --all` text-mode behavior is preserved under FR-014 byte-identity — confirm against current `cmd/upgrade.go`).
+5. **No preamble, no footer.** The first byte of stdout in NDJSON mode is `{` (the opening brace of the first envelope). The last byte is `\n` (the terminator of the last envelope). No bash-style banner, no count summary, nothing else.
+
+---
+
+## Parallelism and the mutex requirement
+
+The current `upgrade --all` implementation is **serial** — repos are processed one at a time. NDJSON emission is trivially safe in this mode because `json.Encoder.Encode` is the only writer to stdout inside the loop.
+
+If `upgrade --all` is parallelized in a future feature (e.g., concurrent upgrade of independent repos), the NDJSON emission path **MUST** be serialized behind a mutex. Concurrent `json.Encoder.Encode` calls to the same `os.Stdout` would interleave bytes mid-line, producing invalid JSON.
+
+Implementation guidance for future parallelization:
+
+```go
+var stdoutMu sync.Mutex
+enc := json.NewEncoder(os.Stdout)
+
+// Per repo (possibly from a goroutine):
+envelope := buildEnvelope(...)
+stdoutMu.Lock()
+_ = enc.Encode(envelope)
+stdoutMu.Unlock()
+```
+
+The serialization point is the `Encode` call, which must be atomic from the underlying writer's perspective. The Go scheduler does not guarantee `Write` atomicity for multi-byte writes to `os.Stdout` unless the write fits within the OS `PIPE_BUF` (4096 bytes on Linux, POSIX minimum 512). A typical envelope for a 20-workflow repo is well under 4096 bytes, but we do not rely on that — the mutex is the correctness guarantee.
+
+This contract documents the mutex requirement explicitly so the future parallelization PR cannot forget it.
+
+---
+
+## Streaming consumption patterns
+
+### Consumer pattern 1: jq per-line filter
+
+```bash
+gh-aw-fleet upgrade --all -o json 2>/dev/null | jq -c 'select(.result.upgrade_ok == false)'
+```
+
+Streams each failed repo's envelope as it completes.
+
+### Consumer pattern 2: Aggregate into a single object
+
+```bash
+gh-aw-fleet upgrade --all -o json 2>/dev/null | jq -s '{schema_version: 1, command: "upgrade_all", repos: .}'
+```
+
+Collects all envelopes into a list under a single aggregate object. Waits for the full run to finish — loses streaming, but recovers an aggregate shape for consumers that want one.
+
+### Consumer pattern 3: Python line-by-line
+
+```python
+import json, subprocess
+proc = subprocess.Popen(
+    ["gh-aw-fleet", "upgrade", "--all", "-o", "json"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+)
+for line in proc.stdout:
+    envelope = json.loads(line)
+    if envelope["result"] and envelope["result"]["conflicts"]:
+        print(f"conflicts in {envelope['repo']}: {envelope['result']['conflicts']}")
+```
+
+Streams each repo's result to a Python handler as it completes.
+
+---
+
+## Edge cases
+
+- **Zero repos in fleet.** If `upgrade --all` is run against an empty fleet, stdout is empty (0 lines). `jq` given empty input exits cleanly. This is identical to the text-mode behavior (the for-loop body never runs).
+- **Interrupt (Ctrl-C / SIGTERM) during a run.** stdout contains complete envelopes for repos that completed before the signal; nothing partial. The Go runtime flushes `os.Stdout` on program exit; `json.Encoder.Encode` writes atomically per call. If the signal lands mid-`Encode` for repo K, the partial bytes of repo K's line may be present on stdout — this is an accepted failure mode. A consumer encountering a mid-line EOF can discard the trailing partial line and re-run.
+- **Single-repo `upgrade <repo> -o json` (no `--all`).** NOT NDJSON — a single envelope, no trailing newline required beyond `json.Encoder.Encode`'s default. Consumers CAN still line-parse it (`json.loads(line)` works on a single-line input) but MUST NOT depend on the NDJSON framing semantics for single-repo invocations.
+
+---
+
+## Test (`cmd/output_test.go`)
+
+| Test name | Covers |
+|---|---|
+| `TestUpgradeAll_NDJSONLineCount` | Given a mock fleet of 3 repos, stdout contains exactly 3 lines, each a valid JSON object. |
+| `TestUpgradeAll_PerLineSelfContained` | Each line parses with `json.Unmarshal` into a `cmd.Envelope` independently; no cross-line state. |
+| `TestUpgradeAll_ErrorRepoIncluded` | When one of the 3 repos fails before producing a result, its line is still emitted with `result: null` and diagnostics; the other 2 lines are unaffected. |
+| `TestUpgradeAll_EmptyFleet` | Given an empty fleet, stdout is empty (no lines). Exit code is 0. |
+
+Tests use an in-process mock of `fleet.Upgrade` to avoid subprocess and network dependencies.

--- a/specs/003-cli-output-json/data-model.md
+++ b/specs/003-cli-output-json/data-model.md
@@ -1,0 +1,260 @@
+# Phase 1 Data Model: CLI JSON Output Mode
+
+**Feature**: 003-cli-output-json
+**Date**: 2026-04-21
+
+This feature has no persistent state (no database, no config file, no cache). The "data model" here describes the runtime and serialization entities that shape the JSON envelope emitted on stdout. All entities live in memory for the lifetime of one CLI invocation.
+
+---
+
+## Entity 1: Envelope
+
+**Purpose**: The top-level JSON object emitted on stdout when `--output json` is active. Every invocation of a JSON-supporting subcommand (`list`, `deploy`, `sync`, `upgrade`) produces exactly one envelope — or N envelopes for `upgrade --all` (one per repo, NDJSON).
+
+**Location**: Defined in `cmd/output.go`.
+
+| Field | JSON key | Type | Presence | Source |
+|---|---|---|---|---|
+| `SchemaVersion` | `schema_version` | `int` | always | constant `1` for this release |
+| `Command` | `command` | `string` | always | one of `"list"`, `"deploy"`, `"sync"`, `"upgrade"` |
+| `Repo` | `repo` | `string` | always | target repo (`owner/name`); empty string for `list`; may be empty on pre-result failure if not yet parsed |
+| `Apply` | `apply` | `bool` | always | `true` only when `--apply` was passed AND the command would mutate; `false` otherwise (including `list`, which has no apply path) |
+| `Result` | `result` | command-specific struct or `null` | always (value may be `null`) | `ListResult` / `DeployResult` / `SyncResult` / `UpgradeResult`, or `null` on pre-result failure (FR-020) |
+| `Warnings` | `warnings` | `[]Diagnostic` | always (may be `[]`) | collected at warning sites in each command |
+| `Hints` | `hints` | `[]Diagnostic` | always (may be `[]`) | from `fleet.CollectHintDiagnostics` |
+
+**Invariants**:
+- `warnings` and `hints` marshal as `[]` when empty, NEVER `null` (FR-006, FR-009). Enforced by `initSlices` helper in envelope writer.
+- Every field listed is present on every envelope — FR-004 pins the top-level key set (`schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, `hints`). No `omitempty` on envelope fields.
+- `schema_version` is the **only** machine-readable schema contract; bumps are monotonic and signal breaking changes to envelope or result field shapes (FR-005).
+
+**Go struct sketch** (for reference; actual code lives in `cmd/output.go`):
+
+```go
+type Envelope struct {
+    SchemaVersion int          `json:"schema_version"`
+    Command       string       `json:"command"`
+    Repo          string       `json:"repo"`
+    Apply         bool         `json:"apply"`
+    Result        any          `json:"result"` // nil → JSON null
+    Warnings      []Diagnostic `json:"warnings"`
+    Hints         []Diagnostic `json:"hints"`
+}
+```
+
+---
+
+## Entity 2: Diagnostic
+
+**Purpose**: Shared shape for entries in `warnings[]` and `hints[]`. A single row that a downstream consumer can machine-parse (`code`) or render to a human (`message`) with structured context for downstream automation (`fields`).
+
+**Location**: Defined in `cmd/output.go`. Constructed at warning sites in command code; constructed by `fleet.CollectHintDiagnostics` for hints.
+
+| Field | JSON key | Type | Presence | Notes |
+|---|---|---|---|---|
+| `Code` | `code` | `string` | always | stable, snake_case identifier — e.g., `missing_secret`, `drift_detected`, `hint`, `unknown_property`, `http_404`, `gpg_failure` |
+| `Message` | `message` | `string` | always | human-readable text; same string that would appear in text-mode `⚠ WARNING:` or `hint:` output |
+| `Fields` | `fields` | `map[string]any` | optional (omitted when empty) | structured context: `{secret: "ANTHROPIC_API_KEY", url: "..."}` etc. |
+
+**Go struct sketch**:
+
+```go
+type Diagnostic struct {
+    Code    string         `json:"code"`
+    Message string         `json:"message"`
+    Fields  map[string]any `json:"fields,omitempty"`
+}
+```
+
+**Diagnostic code catalogue** (initial):
+
+| Code | Source | Fields |
+|---|---|---|
+| `missing_secret` | `cmd/deploy.go` MissingSecret detection | `secret` (name), `url` (key-retrieval URL) |
+| `drift_detected` | `cmd/sync.go` drift detection | `drift` (array of workflow filenames) |
+| `hint` | `fleet.CollectHintDiagnostics` wrapper — every hint from `fleet/diagnostics.go` | `hint` (full hint text, duplicated for `jq '.fields.hint'` filter convenience) |
+| `unknown_property` | hint classifier | `pattern` (the offending property name, when extractable) |
+| `http_404` | hint classifier | `pattern` (the URL or path that 404'd, when extractable) |
+| `gpg_failure` | hint classifier | (no additional fields — message is self-explanatory) |
+
+Adding a new diagnostic code:
+1. Define a package-level constant in `cmd/output.go` (e.g., `DiagMissingSecret = "missing_secret"`).
+2. At the warning site, build `Diagnostic{Code: DiagMissingSecret, Message: "...", Fields: map[string]any{...}}`.
+3. Append to the local `[]Diagnostic` slice that the command threads into the envelope.
+
+---
+
+## Entity 3: ListResult (NEW)
+
+**Purpose**: Machine-readable form of the data `cmd/list.go` currently prints as a tabwriter table. The existing list command builds rows inline and flushes them; this feature extracts the data into a typed struct so it can be embedded in the envelope.
+
+**Location**: Defined in `internal/fleet/list_result.go` (new file).
+
+| Field | JSON key | Type | Source |
+|---|---|---|---|
+| `LoadedFrom` | `loaded_from` | `string` | `Config.LoadedFrom` — one of `"fleet.local.json"` or `"fleet.json"` |
+| `Repos` | `repos` | `[]ListRow` | sorted by repo name (same ordering as existing tabwriter output) |
+
+```go
+type ListResult struct {
+    LoadedFrom string    `json:"loaded_from"`
+    Repos      []ListRow `json:"repos"`
+}
+```
+
+### ListRow (nested inside ListResult.Repos)
+
+| Field | JSON key | Type | Source |
+|---|---|---|---|
+| `Repo` | `repo` | `string` | map key from `Config.Repos` (e.g., `"rshade/gh-aw-fleet"`) |
+| `Profiles` | `profiles` | `[]string` | `Config.Repos[repo].Profiles` |
+| `Engine` | `engine` | `string` | `Config.EffectiveEngine(repo)` — empty string renders as `""`, NOT the text-mode `"-"` placeholder (that's a human-readability hack) |
+| `Workflows` | `workflows` | `[]string` | names of workflows resolved from `Config.ResolveRepoWorkflows(repo)` |
+| `Excluded` | `excluded` | `[]string` | `Config.Repos[repo].ExcludeFromProfiles`; `[]` when absent |
+| `Extra` | `extra` | `[]string` | names from `Config.Repos[repo].ExtraWorkflows` |
+
+```go
+type ListRow struct {
+    Repo      string   `json:"repo"`
+    Profiles  []string `json:"profiles"`
+    Engine    string   `json:"engine"`
+    Workflows []string `json:"workflows"`
+    Excluded  []string `json:"excluded"`
+    Extra     []string `json:"extra"`
+}
+```
+
+**Key shape difference from text mode**: Text mode renders empty engine as `"-"` (via `orDash` in `cmd/list.go`). JSON mode renders it as `""` (empty string). This is intentional — `"-"` is a human placeholder; machine consumers use truthiness on the empty string.
+
+**Construction**: A new `fleet.BuildListResult(cfg *Config) (*ListResult, error)` function walks `cfg.Repos`, sorts keys, resolves workflows per repo, and returns the populated struct. `cmd/list.go`'s JSON branch calls this; the text-mode branch keeps its existing inline tabwriter code.
+
+---
+
+## Entity 4: DeployResult (EXISTING — JSON tags added)
+
+**Location**: `internal/fleet/deploy.go`. Struct shape unchanged; only JSON tags added.
+
+| Go field | JSON key | Type | Notes |
+|---|---|---|---|
+| `Repo` | `repo` | `string` | |
+| `CloneDir` | `clone_dir` | `string` | `/tmp/gh-aw-fleet-*` path; preserved on `--apply` failure |
+| `Added` | `added` | `[]WorkflowOutcome` | MUST be `[]` when empty (FR-009) |
+| `Skipped` | `skipped` | `[]WorkflowOutcome` | MUST be `[]` when empty |
+| `Failed` | `failed` | `[]WorkflowOutcome` | MUST be `[]` when empty |
+| `InitWasRun` | `init_was_run` | `bool` | `true` when `gh aw init` was invoked during deploy |
+| `BranchPushed` | `branch_pushed` | `string` | branch name pushed to remote, empty on dry-run |
+| `PRURL` | `pr_url` | `string` | URL returned by `gh pr create`, empty on dry-run or on push failure |
+| `MissingSecret` | `missing_secret` | `string` | secret name (e.g., `ANTHROPIC_API_KEY`) when absent; empty when present or unchecked |
+| `SecretKeyURL` | `secret_key_url` | `string` | URL to retrieve the missing secret key |
+
+### WorkflowOutcome (nested inside Added/Skipped/Failed)
+
+| Go field | JSON key | Type | Notes |
+|---|---|---|---|
+| `Name` | `name` | `string` | workflow filename without `.md` |
+| `Spec` | `spec` | `string` | `owner/repo/path@ref` form used by `gh aw add` |
+| `Reason` | `reason` | `string` | human-readable classification (e.g., `"added"`, `"already present"`, `"compile failed"`) |
+| `Error` | `error` | `string` | error text from `gh aw` / `git`; empty when outcome was not an error |
+
+---
+
+## Entity 5: SyncResult (EXISTING — JSON tags added)
+
+**Location**: `internal/fleet/sync.go`.
+
+| Go field | JSON key | Type | Notes |
+|---|---|---|---|
+| `Repo` | `repo` | `string` | |
+| `CloneDir` | `clone_dir` | `string` | |
+| `Missing` | `missing` | `[]string` | workflow names declared in fleet.json but absent from the repo; MUST be `[]` when empty |
+| `Drift` | `drift` | `[]string` | workflow files present in the repo but not declared; MUST be `[]` when empty |
+| `Expected` | `expected` | `[]string` | informational: workflow names matching fleet.json |
+| `Deploy` | `deploy` | `*DeployResult` (pointer, may be nil) | set when `Apply==true` AND a deploy was triggered; MUST marshal as `null` when unset |
+| `Pruned` | `pruned` | `[]string` | files removed by `--prune --apply`; MUST be `[]` when empty |
+| `DeployPreflight` | `deploy_preflight` | `*DeployResult` (pointer, may be nil) | set on dry-run (`Apply==false`) to surface compilation failures; MUST marshal as `null` when unset |
+
+**Key rule for pointer fields**: `Deploy` and `DeployPreflight` are pointers. A nil pointer marshals as JSON `null` (stdlib default). No `initSlices`-style pre-processing needed — pointers and their nil semantics map cleanly.
+
+---
+
+## Entity 6: UpgradeResult (EXISTING — JSON tags added)
+
+**Location**: `internal/fleet/upgrade.go`.
+
+| Go field | JSON key | Type | Notes |
+|---|---|---|---|
+| `Repo` | `repo` | `string` | |
+| `CloneDir` | `clone_dir` | `string` | |
+| `UpgradeOK` | `upgrade_ok` | `bool` | |
+| `UpdateOK` | `update_ok` | `bool` | |
+| `ChangedFiles` | `changed_files` | `[]string` | MUST be `[]` when empty |
+| `Conflicts` | `conflicts` | `[]string` | MUST be `[]` when empty |
+| `NoChanges` | `no_changes` | `bool` | |
+| `BranchPushed` | `branch_pushed` | `string` | |
+| `PRURL` | `pr_url` | `string` | |
+| `AuditJSON` | `audit_json` | `json.RawMessage` | nested native JSON object when non-nil (FR-016); `null` when nil |
+| `OutputLog` | `output_log` | `string` | combined stdout+stderr from `gh aw upgrade/update`; used by `CollectHints` |
+
+**Note on `output_log`**: This field today contains raw `gh aw` stderr that may include non-printable characters, ANSI color codes, and multi-MB payloads on large repos. Embedding it inline in the envelope preserves the existing data fidelity but may bloat the JSON. This is accepted — consumers who don't need it can drop the field with `jq 'del(.result.output_log)'`. A future feature may add a `--output-log=false` flag to suppress it; out of scope here.
+
+---
+
+## Relationships
+
+```text
+Envelope
+├── Result: any (one of)
+│   ├── *ListResult
+│   │   └── Repos: []ListRow
+│   ├── *DeployResult
+│   │   ├── Added:   []WorkflowOutcome
+│   │   ├── Skipped: []WorkflowOutcome
+│   │   └── Failed:  []WorkflowOutcome
+│   ├── *SyncResult
+│   │   ├── Deploy:          *DeployResult (nullable)
+│   │   └── DeployPreflight: *DeployResult (nullable)
+│   └── *UpgradeResult
+│       └── AuditJSON: json.RawMessage (nested JSON)
+├── Warnings: []Diagnostic
+└── Hints:    []Diagnostic
+```
+
+No circular references. No mutually recursive types. All serialization is a single downward walk from the envelope root.
+
+---
+
+## Validation rules
+
+Enforced at envelope-writer boundary (`writeEnvelope` in `cmd/output.go`):
+
+1. **Command-tag agreement** (defensive): reject at compile time — each subcommand calls `writeEnvelope(cmd, result, ...)` with its own hardcoded `cmd` string (`"list"`, `"deploy"`, `"sync"`, `"upgrade"`). No runtime validation needed.
+2. **Schema version pin**: `Envelope.SchemaVersion = 1` set by `writeEnvelope`; individual subcommands never set this directly.
+3. **Empty-slice normalization**: `initSlices(result)` runs unconditionally before `json.Encoder.Encode`. Walks nested structs. Leaves pointer-to-struct fields alone (nil pointers stay nil for JSON `null` semantics; non-nil get walked).
+4. **Pre-result failure shape**: when a command cannot build its result (config parse error, missing tool, repo not in fleet), the command returns early from its RunE with a `writeEnvelope(cmd, nil, warnings, hints)` call. The `result: null` rendering is handled by `Envelope.Result == nil` marshaling to JSON null.
+5. **No `omitempty` on envelope top-level fields**: ensures all 7 keys are always present (FR-004, SC-005). `omitempty` IS used on `Diagnostic.Fields` only (so an empty-fields diagnostic doesn't emit `"fields":{}`).
+
+---
+
+## Lifecycle summary
+
+```text
+CLI invocation (`cmd -o json`)
+  │
+  ├─ PersistentPreRunE (root.go)
+  │    └─ validateOutputMode(flag) — rejects yaml/JSON/etc before subcommand RunE
+  │
+  ├─ Subcommand RunE
+  │    ├─ Compute result (existing business logic — untouched)
+  │    ├─ Collect []Diagnostic warnings at existing zlog.Warn() sites
+  │    ├─ Call fleet.CollectHintDiagnostics(...) for hints (instead of CollectHints)
+  │    └─ Branch on outputMode():
+  │        ├─ "text" → existing printXxxReport path (untouched)
+  │        └─ "json" → writeEnvelope(cmd, result, warnings, hints)
+  │
+  └─ writeEnvelope (cmd/output.go)
+       ├─ initSlices(result) — ensure empty slices, not nil
+       ├─ Build Envelope{SchemaVersion: 1, Command, Repo, Apply, Result, Warnings, Hints}
+       └─ json.NewEncoder(stdout).Encode(env) — emits compact JSON + newline
+```
+
+For `upgrade --all`: the subcommand iterates repos, calls `writeEnvelope` once per repo, and flushes between. No aggregate envelope is built.

--- a/specs/003-cli-output-json/data-model.md
+++ b/specs/003-cli-output-json/data-model.md
@@ -48,7 +48,7 @@ type Envelope struct {
 
 **Purpose**: Shared shape for entries in `warnings[]` and `hints[]`. A single row that a downstream consumer can machine-parse (`code`) or render to a human (`message`) with structured context for downstream automation (`fields`).
 
-**Location**: Defined in `cmd/output.go`. Constructed at warning sites in command code; constructed by `fleet.CollectHintDiagnostics` for hints.
+**Location**: Defined in `internal/fleet/diagnostics.go` (alongside `CollectHintDiagnostics` and `HintFromError`). Constructed at warning sites in command code and by `fleet.CollectHintDiagnostics` for hints; consumed by the envelope writer in `cmd/output.go`.
 
 | Field | JSON key | Type | Presence | Notes |
 |---|---|---|---|---|
@@ -78,9 +78,9 @@ type Diagnostic struct {
 | `gpg_failure` | hint classifier | (no additional fields — message is self-explanatory) |
 
 Adding a new diagnostic code:
-1. Define a package-level constant in `cmd/output.go` (e.g., `DiagMissingSecret = "missing_secret"`).
-2. At the warning site, build `Diagnostic{Code: DiagMissingSecret, Message: "...", Fields: map[string]any{...}}`.
-3. Append to the local `[]Diagnostic` slice that the command threads into the envelope.
+1. Define a package-level constant in `internal/fleet/diagnostics.go` (e.g., `DiagMissingSecret = "missing_secret"`).
+2. At the warning site, build `fleet.Diagnostic{Code: fleet.DiagMissingSecret, Message: "...", Fields: map[string]any{...}}`.
+3. Append to the local `[]fleet.Diagnostic` slice that the command threads into the envelope.
 
 ---
 

--- a/specs/003-cli-output-json/plan.md
+++ b/specs/003-cli-output-json/plan.md
@@ -100,7 +100,7 @@ specs/003-cli-output-json/
 ```text
 cmd/
 ├── root.go              # +PersistentFlag "output", +validateOutputMode()
-├── output.go            # NEW: Diagnostic, Envelope, writeEnvelope, writeNDJSON, outputMode()
+├── output.go            # NEW: Envelope, writeEnvelope, writeNDJSON, outputMode()
 ├── output_test.go       # NEW: envelope shape, flag validator, empty-[], NDJSON, pre-result failure
 ├── list.go              # branch on outputMode(); text-mode path unchanged; json-mode path calls writeEnvelope
 ├── deploy.go            # branch on outputMode(); collect []Diagnostic from existing warning sites
@@ -116,7 +116,7 @@ internal/fleet/
 ├── deploy.go            # +json:"..." tags on DeployResult, WorkflowOutcome; ensure-[] helpers
 ├── sync.go              # +json:"..." tags on SyncResult; ensure-[] helpers
 ├── upgrade.go           # +json:"..." tags on UpgradeResult
-├── diagnostics.go       # +Code field on Hint; +CollectHintDiagnostics() []Diagnostic
+├── diagnostics.go       # NEW: Diagnostic type + stable code constants; +Code field on Hint; +CollectHintDiagnostics() []Diagnostic
 ├── fetch.go             # confirm AuditJSON json.RawMessage nests inline (no code change expected)
 ├── schema.go            # unchanged (reference style for json tags)
 ├── load.go              # unchanged
@@ -126,7 +126,7 @@ internal/fleet/
 └── *_test.go            # unchanged (existing tests continue to pass)
 ```
 
-**Structure Decision**: Single-project CLI layout (same as features 001 and 002). The `cmd/` package owns CLI wiring and serialization; `internal/fleet/` owns business types and their JSON contract. The `Diagnostic` type lives in `cmd/output.go` (not `internal/fleet/`) because it is a CLI-surface concern — it has no role in the core fleet business logic — and because importing `internal/fleet` from `cmd/` is the established direction (keeping it one-way avoids a cycle).
+**Structure Decision**: Single-project CLI layout (same as features 001 and 002). The `cmd/` package owns CLI wiring and serialization; `internal/fleet/` owns business types and their JSON contract. The `Diagnostic` type (and its code constants) lives in `internal/fleet/diagnostics.go` alongside `CollectHintDiagnostics` and `HintFromError` — the diagnostics layer already classifies gh-aw CLI output and is the natural producer of `Diagnostic` values, so co-locating the type with its producers keeps the one-way `cmd/ → internal/fleet/` import direction without forcing `cmd/` to own a type that `internal/fleet/` returns. `cmd/output.go` consumes `fleet.Diagnostic` via the envelope writer.
 
 ## Complexity Tracking
 

--- a/specs/003-cli-output-json/plan.md
+++ b/specs/003-cli-output-json/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: CLI JSON Output Mode
+
+**Branch**: `003-cli-output-json` | **Date**: 2026-04-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/003-cli-output-json/spec.md`
+
+## Summary
+
+Add a second serializer to four existing commands (`list`, `deploy`, `sync`, `upgrade`) that emits the commands' already-computed result structs as a versioned JSON envelope on stdout. A new persistent root flag `-o, --output {text|json}` (default `text`) selects the serializer. Text mode is byte-identical to current behavior. JSON mode emits one envelope on stdout (`{schema_version: 1, command, repo, apply, result, warnings, hints}`), routes all breadcrumbs and diagnostics to stderr via the existing zerolog layer (already landed in #34), and in bulk mode (`upgrade --all`) emits newline-delimited envelopes — one per repo, streamed as each completes. Pre-result failures still emit an envelope with `result: null`; exit codes mirror text mode (Q2/Q3 clarifications).
+
+Implementation is concentrated in `cmd/output.go` (new, ~120 LOC — envelope writer, `Diagnostic` type, mode validator, ND-stream helper), a small `ListResult` type factored out of `cmd/list.go` into `internal/fleet`, `json:"..."` tags added to `DeployResult`/`WorkflowOutcome`/`SyncResult`/`UpgradeResult`, and one new `CollectHintDiagnostics` helper in `internal/fleet/diagnostics.go` that returns structured `Diagnostic` entries instead of raw hint strings. Each of the four subcommands gains a single branch: after computing its result, it either calls the existing text-mode printer or `writeEnvelope(...)`. Warnings come from the same sites that today log via `zlog.Warn()` — the commands collect a parallel `[]Diagnostic` slice at those sites for embedding in the envelope.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.8 (from `go.mod`).
+**Primary Dependencies**: `encoding/json` (stdlib, new usage site); `github.com/spf13/cobra` v1.10.2 (existing); `github.com/rs/zerolog` v1.35.1 (existing, landed in #34). No new third-party dependencies — constitution Principle I.
+**Storage**: N/A (no persistent state; envelope writes are transient to stdout).
+**Testing**: Go standard `testing` package. New tests live in `cmd/output_test.go` (envelope shape, empty-array-not-null, schema_version pin, flag validator, NDJSON per-line structure, pre-result failure envelope). Existing `cmd/root_logging_test.go` and `internal/fleet/*_test.go` continue to pass unchanged.
+**Target Platform**: Cross-platform CLI (Linux, macOS, Windows) — same surface `gh-aw` extension already supports.
+**Project Type**: Single-project CLI (thin orchestrator around `gh aw`, `gh`, `git`).
+**Performance Goals**: JSON serialization overhead MUST be imperceptible (sub-millisecond per envelope; stdlib `json.Marshal` against small result structs is trivially fast relative to the network and subprocess work each command already does). No command regresses past constitution's 5-minute ceiling. NDJSON lines MUST flush as each repo completes (bufio flush after each `Encode` call) to enable true streaming consumption.
+**Constraints**:
+- **Text-mode byte-identity** (spec FR-014, SC-003): any run that omits `--output` or passes `--output text` MUST produce stdout byte-equal to pre-feature baseline. This is the invariant that makes the feature safe to land without a migration window.
+- **Single JSON object per command invocation** (spec SC-002): `jq -e . < <(cmd -o json)` succeeds for every invocation, including non-zero exits (covered by FR-020 pre-result failure envelope).
+- **Empty arrays, never null** (spec FR-009): enforced via `json:"...,omitempty"` NOT used on slice fields — slices stay un-tagged-omitempty so `nil` slices marshal as `null`; the fix is to initialize slice fields to non-nil empty slices before JSON marshal. A helper `ensureSlicesInitialized(result any) any` handles this at the envelope-writer boundary.
+- **Snake_case JSON keys** (spec FR-008): applied via explicit `json:"snake_case_name"` tags; no reliance on auto-lowercasing.
+- **No new third-party dependencies** (constitution I; spec FR-018): verified by `go mod graph` diff = 0 new edges after implementation.
+- **gpg signing, three-turn mutation pattern, git-from-Bash deny** (constitution III + Declarative Reconcile Invariants): untouched — this feature only changes serialization, not mutation flow.
+**Scale/Scope**: 1 new file (`cmd/output.go`). 1 new file (`internal/fleet/list_result.go` — houses `ListResult` / `ListRow`; a few dozen LOC moved from `cmd/list.go`). Small edits to 4 subcommand files (`cmd/list.go`, `cmd/deploy.go`, `cmd/sync.go`, `cmd/upgrade.go`). Small edits to 3 result-struct files (`internal/fleet/deploy.go`, `sync.go`, `upgrade.go`) to add `json:"..."` tags and ensure empty-slice semantics. Small edit to `internal/fleet/diagnostics.go` to add `Code` field to `Hint` and expose `CollectHintDiagnostics`. One edit to `cmd/root.go` to register `--output` with validator. One new test file (`cmd/output_test.go`). ~400 new LOC total; no file crosses 300 LOC.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` version 1.0.0.
+
+### I. Thin-Orchestrator Code Quality — **PASS**
+
+- Zero new dependencies. All serialization uses stdlib `encoding/json`. Verified by spec FR-018, SC-008.
+- The feature does not duplicate any upstream tool behavior: `gh aw`, `gh`, `git` remain the mutation surface; this change only re-serializes results that are already computed during dry-run / apply.
+- `go build ./...` and `go vet ./...` MUST stay clean. The `make ci` gate (fmt-check, vet, lint, test) MUST pass locally before the change is reported done (user feedback memory `feedback_local_gate.md`).
+- File-size guidance (~300 LOC): `cmd/output.go` is projected at ~120 LOC; `cmd/list.go` stays under its current 59 LOC after the extraction; no existing file crosses the threshold as a result of this change.
+- Comments explain WHY only — specifically (a) why we initialize slices before marshal (to satisfy FR-009 `[]`-not-`null`), (b) why `upgrade --all` emits NDJSON and not an aggregate envelope (Q1 clarification; single-parser contract for consumers), (c) why we embed warnings inline in the envelope AND on stderr (FR-011 contract; satisfies both scripted and human consumers simultaneously). WHAT comments are avoided.
+
+### II. Testing Standards (Build-Green + Real-World Dry-Run) — **PASS**
+
+- `go build ./...` and `go vet ./...` stay green trivially — changes are additive.
+- Dry-run surface (`deploy` / `sync` / `upgrade` without `--apply`) is unchanged; the JSON branch runs off the same `*DeployResult` / `*SyncResult` / `*UpgradeResult` the dry-run already produces. `fleet.CollectHints` continues to run inside dry-runs; the new `CollectHintDiagnostics` is a parallel call-site that produces structured versions of the same hints for envelope embedding — text-mode path still sees the same `[]string` return from `CollectHints`.
+- Skills (`skills/fleet-deploy`, `skills/fleet-eval-templates`, `skills/fleet-upgrade-review`, `skills/fleet-onboard-repo`): Each gains a one-line note under its "Debugging" or "Extended usage" section that `-o json` is available for programmatic consumption. No skill-logic change; three-turn pattern untouched.
+- New unit tests in `cmd/output_test.go` cover: (a) envelope top-level key set pinning (FR-004, FR-005, SC-005); (b) empty slices marshal as `[]` not `null` for every result type (FR-009, SC-004); (c) `--output` flag validator accepts `text`/`json`, rejects `yaml`/`JSON`/empty (FR-001, FR-002); (d) `audit_json` embeds as nested JSON object when the underlying bytes are valid JSON (FR-016); (e) pre-result failure emits an envelope with `result: null` (FR-020); (f) NDJSON mode produces exactly N lines for N repos, each a valid standalone envelope (FR-019, User Story 3 acceptance scenario 5).
+- Integration check (manual, documented in `quickstart.md`): run `go run . list -o json | jq -e .schema_version` and confirm output is `1`; run `go run . deploy rshade/gh-aw-fleet -o json 2>/dev/null | jq -e .command` and confirm output is `"deploy"`.
+
+### III. User Experience Consistency (Three-Turn Mutation Pattern) — **PASS**
+
+- Three-turn pattern (dry-run → approval → apply) is untouched. The `--output` flag is orthogonal to `--apply`. `-o json` without `--apply` is a dry-run in JSON form; with `--apply` it is an actual apply in JSON form. The interactive go-ahead requirement from constitution III still applies to `--apply` in either mode.
+- Conventional Commits (`ci(workflows)` scope; ≤72-char subject; no trailing period): unchanged; this feature's own commit lands on the tool's `main` branch, not in any workflow repo.
+- Diagnostic hints via `fleet.CollectHints`: extended, not replaced. Text mode still prints `hint:` lines on failure; JSON mode additionally embeds structured equivalents in `hints[]` and emits them on stderr via zerolog. **UX shift (documented in CHANGELOG.md)**: In JSON mode, the tabwriter `hint:` lines do not appear on stdout — consumers parse `.hints[]` from the envelope. Operators reading human output (text mode, default) see no change.
+- Scratch clones at `/tmp/gh-aw-fleet-*` after `--apply` failure: preserved identically. The envelope's `result.clone_dir` carries the path so agents can resume via `--work-dir`.
+
+### IV. Performance Requirements — **PASS**
+
+- Parallelism / catalog-cache surface untouched.
+- `encoding/json.Marshal` on a result struct of ~10 fields with ~20–50 total nested entries is O(μs) — invisible against network and subprocess overhead.
+- `upgrade --all` NDJSON emission requires per-repo flush. This doesn't change parallelism (the command remains serial today), but makes streaming consumption practical once parallelization lands. **Note**: If `upgrade --all` is parallelized in a future feature, the NDJSON emission helper MUST serialize writes behind a mutex to prevent interleaved partial lines. The Phase 1 contract (`contracts/ndjson.md`) documents this requirement explicitly so it's not forgotten.
+- No command regresses past the 5-minute ceiling.
+
+### Declarative Reconcile Invariants — **PASS**
+
+- `fleet.json`/`fleet.local.json` source-of-truth direction untouched.
+- `fleet.local.json` MUST NOT be committed — unchanged.
+- gpg signing bypass forbidden — unchanged (this feature touches serialization, not git).
+- `git add`/`git commit`/`git push` from Bash denied — unchanged (feature does not invoke git at all).
+- `github/gh-aw` source pinning rule — unchanged.
+
+### Gate verdict
+
+All gates pass on initial check. **Complexity Tracking table is intentionally empty — no violations to justify.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-cli-output-json/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── cli-flags.md     # --output flag contract
+│   ├── envelope.md      # JSON envelope shape and invariants
+│   └── ndjson.md        # NDJSON stream contract for upgrade --all
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+├── spec.md              # Feature specification
+└── tasks.md             # (Phase 2 — created by /speckit.tasks, NOT by this command)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── root.go              # +PersistentFlag "output", +validateOutputMode()
+├── output.go            # NEW: Diagnostic, Envelope, writeEnvelope, writeNDJSON, outputMode()
+├── output_test.go       # NEW: envelope shape, flag validator, empty-[], NDJSON, pre-result failure
+├── list.go              # branch on outputMode(); text-mode path unchanged; json-mode path calls writeEnvelope
+├── deploy.go            # branch on outputMode(); collect []Diagnostic from existing warning sites
+├── sync.go              # branch on outputMode(); collect []Diagnostic from existing drift-warn site
+├── upgrade.go           # branch on outputMode(); NDJSON path for --all; audit_json nesting
+├── hints.go             # unchanged (existing zerolog hint-emit helper)
+├── add.go               # unchanged (not in scope)
+├── template.go          # reject -o json with clear error (FR-013)
+└── stubs.go             # unchanged
+
+internal/fleet/
+├── list_result.go       # NEW: ListResult, ListRow (moved from cmd/list.go inline), json tags
+├── deploy.go            # +json:"..." tags on DeployResult, WorkflowOutcome; ensure-[] helpers
+├── sync.go              # +json:"..." tags on SyncResult; ensure-[] helpers
+├── upgrade.go           # +json:"..." tags on UpgradeResult
+├── diagnostics.go       # +Code field on Hint; +CollectHintDiagnostics() []Diagnostic
+├── fetch.go             # confirm AuditJSON json.RawMessage nests inline (no code change expected)
+├── schema.go            # unchanged (reference style for json tags)
+├── load.go              # unchanged
+├── add.go               # unchanged
+├── frontmatter.go       # unchanged
+├── execlog.go           # unchanged
+└── *_test.go            # unchanged (existing tests continue to pass)
+```
+
+**Structure Decision**: Single-project CLI layout (same as features 001 and 002). The `cmd/` package owns CLI wiring and serialization; `internal/fleet/` owns business types and their JSON contract. The `Diagnostic` type lives in `cmd/output.go` (not `internal/fleet/`) because it is a CLI-surface concern — it has no role in the core fleet business logic — and because importing `internal/fleet` from `cmd/` is the established direction (keeping it one-way avoids a cycle).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+_No violations to justify. All gates pass as designed. This section is intentionally left without entries._
+
+## Phase 0: Research Summary
+
+Full details in [research.md](research.md). Five research tasks:
+
+- **R1**: Go `encoding/json` handling of `json.RawMessage` nested inside a parent struct (verify no double-encoding when `AuditJSON` is marshaled as a field of `UpgradeResult`). **Decision**: `json.RawMessage` is documented to embed verbatim bytes when present and valid; it marshals as `null` when the slice is nil and produces a marshal error when the bytes are malformed. Plan: ensure the bytes captured from `gh aw audit --json` are either valid JSON (the happy path) or the slice is nil (in which case the envelope field renders as `null`). Validation at capture time is already done implicitly by `gh aw audit` — if it emits invalid JSON, that's an upstream bug and we let the marshal error surface.
+- **R2**: Empty-slice-vs-nil-slice JSON marshaling (how to guarantee `[]` not `null` without plumbing `omitempty` everywhere). **Decision**: Initialize slice fields to `[]T{}` (non-nil empty) before marshaling. Either in the business-logic layer (constructor-time) or via a small `ensureSlicesInitialized(*Result)` helper invoked from the envelope writer. Plan chooses the latter — keeps business logic untouched, confines the JSON concern to the JSON path.
+- **R3**: Cobra persistent-flag validation pattern (how to reject `--output yaml` before subcommand RunE fires). **Decision**: Use a `PersistentPreRunE` on the root command that validates the `--output` value against a closed set and returns an error; cobra routes that error to its default stderr writer and exits non-zero without calling the subcommand. Matches the pattern already used by `--log-level` / `--log-format`.
+- **R4**: NDJSON emission semantics (one JSON object per line, with flush semantics for streaming). **Decision**: Use `json.NewEncoder(stdout).Encode(envelope)` per repo — `Encoder.Encode` writes the JSON form followed by a newline and flushes the underlying writer if it's a bufio-wrapped stream. Per-repo flush is implicit in os.Stdout being unbuffered by default. Document the mutex requirement for future parallelization.
+- **R5**: Zerolog stderr-duplication for warnings (how warnings land both in `warnings[]` and on stderr via the logger). **Decision**: At each warning site, the command builds a `Diagnostic{Code, Message, Fields}` struct, appends it to a local `[]Diagnostic` slice for later envelope embedding, and also calls `zlog.Warn().Fields(d.Fields).Msg(d.Message)` at the same site. The two emissions share a source (the `Diagnostic` struct); the zerolog call is unchanged in structure from pre-feature (warnings already emit to stderr via zerolog — #34 landed this). Net effect: one new line of code per warning site (`warnings = append(warnings, d)`).
+
+## Phase 1: Design Artifacts
+
+### data-model.md
+Defines four entities: `Envelope` (the top-level JSON object), `Diagnostic` (shared shape for warnings and hints), `ListResult` / `ListRow` (new types), and the JSON-tag contract for `DeployResult`/`WorkflowOutcome`/`SyncResult`/`UpgradeResult`.
+
+### contracts/cli-flags.md
+The `--output` / `-o` flag surface: accepted values, default, rejection behavior, interaction with `--log-level` / `--log-format` / `--dir`, and the `template fetch` rejection (FR-013).
+
+### contracts/envelope.md
+The JSON envelope shape: top-level key set (pinned), per-key semantics (`schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, `hints`), nullability rules (`result: null` on pre-result failure), and the snake_case key convention per result struct.
+
+### contracts/ndjson.md
+The NDJSON stream contract for `upgrade --all -o json`: one envelope per line, flush-per-repo, no trailing bare newline beyond per-line terminators, mutex-requirement note for future parallelization.
+
+### quickstart.md
+Operator-oriented walkthrough: install, invoke `-o json` on each of the four commands, pipe through `jq`, observe stderr routing, observe NDJSON stream for `upgrade --all`.
+
+### Agent context update
+Ran `.specify/scripts/bash/update-agent-context.sh claude` — appended "Active Technologies" entry covering the `--output` flag surface and the `internal/fleet.ListResult` / `Diagnostic` types to `CLAUDE.md`'s managed block.

--- a/specs/003-cli-output-json/quickstart.md
+++ b/specs/003-cli-output-json/quickstart.md
@@ -1,0 +1,312 @@
+# Quickstart: CLI JSON Output Mode
+
+**Feature**: 003-cli-output-json
+**Audience**: Operators and agent-pipeline authors who want to consume `gh-aw-fleet` output programmatically.
+
+This walkthrough shows how to invoke `-o json` on each of the four supported commands, how to pipe the output through `jq`, and how to interpret the envelope. All commands are non-destructive (dry-runs) — no `--apply` is involved.
+
+---
+
+## Prerequisites
+
+- `gh-aw-fleet` built from this branch: `go build ./...` (run from repo root).
+- `jq` installed (most distros have it; on macOS: `brew install jq`).
+- A `fleet.local.json` or `fleet.json` with at least one declared repo. (`go run . list` without JSON mode will confirm you have one.)
+
+---
+
+## 1. `list -o json` — the simplest case
+
+```bash
+go run . list -o json 2>/dev/null | jq .
+```
+
+Expected output (pretty-printed by `jq`):
+
+```json
+{
+  "schema_version": 1,
+  "command": "list",
+  "repo": "",
+  "apply": false,
+  "result": {
+    "loaded_from": "fleet.local.json",
+    "repos": [
+      {
+        "repo": "rshade/gh-aw-fleet",
+        "profiles": ["default"],
+        "engine": "claude",
+        "workflows": ["issue-triage", "ci-failure-doctor"],
+        "excluded": [],
+        "extra": []
+      }
+    ]
+  },
+  "warnings": [],
+  "hints": []
+}
+```
+
+**What to notice**:
+- `schema_version: 1` — the only contract version byte. Check it first in your agent.
+- `command: "list"` — canonical form.
+- `repo: ""` — `list` is not scoped to a repo.
+- `result.loaded_from` tells you which config file was active (matches the `(loaded fleet.local.json)` breadcrumb, now on stderr).
+- `warnings: []` and `hints: []` — arrays, never null, even when empty.
+- `2>/dev/null` suppresses the stderr breadcrumb so you see only the envelope. In production you'd keep stderr to capture warnings live.
+
+### Extract all tracked repos
+
+```bash
+go run . list -o json 2>/dev/null | jq -r '.result.repos[].repo'
+```
+
+Outputs one repo name per line — much easier than regex-scraping the tabwriter table.
+
+---
+
+## 2. `deploy <repo> -o json` (dry-run)
+
+Pick a repo from your fleet and run:
+
+```bash
+go run . deploy rshade/gh-aw-fleet -o json 2>/dev/null | jq .
+```
+
+Expected (shortened):
+
+```json
+{
+  "schema_version": 1,
+  "command": "deploy",
+  "repo": "rshade/gh-aw-fleet",
+  "apply": false,
+  "result": {
+    "repo": "rshade/gh-aw-fleet",
+    "clone_dir": "/tmp/gh-aw-fleet-12345",
+    "added": [
+      { "name": "issue-triage", "spec": "githubnext/agentics/issue-triage@main", "reason": "added", "error": "" }
+    ],
+    "skipped": [],
+    "failed": [],
+    "init_was_run": false,
+    "branch_pushed": "",
+    "pr_url": "",
+    "missing_secret": "",
+    "secret_key_url": ""
+  },
+  "warnings": [],
+  "hints": []
+}
+```
+
+**Notice**:
+- `apply: false` — this was a dry-run.
+- `added[]` has one entry; `skipped[]` and `failed[]` are empty arrays, not null.
+- `clone_dir` points to the scratch clone — still present on disk after the dry-run for inspection (preserved per constitution III).
+- `missing_secret` is `""` — the engine secret is present. If it were missing, a `missing_secret` diagnostic would appear in `warnings[]` AND on stderr.
+
+### Trigger a missing-secret warning (demo)
+
+Run against a repo that you know does not have `ANTHROPIC_API_KEY` set as an Actions secret:
+
+```bash
+go run . deploy some-test-repo -o json | jq '.warnings'
+```
+
+Expected output includes:
+
+```json
+[
+  {
+    "code": "missing_secret",
+    "message": "Actions secret ANTHROPIC_API_KEY is missing on some-test-repo. Workflows using the claude engine will fail at runtime.",
+    "fields": { "secret": "ANTHROPIC_API_KEY", "url": "https://github.com/some-test-repo/settings/secrets/actions" }
+  }
+]
+```
+
+The same warning also appeared on stderr via zerolog — humans and machines both get it.
+
+---
+
+## 3. `sync <repo> -o json`
+
+```bash
+go run . sync rshade/gh-aw-fleet -o json 2>/dev/null | jq .
+```
+
+Expected shape:
+
+```json
+{
+  "schema_version": 1,
+  "command": "sync",
+  "repo": "rshade/gh-aw-fleet",
+  "apply": false,
+  "result": {
+    "repo": "rshade/gh-aw-fleet",
+    "clone_dir": "/tmp/gh-aw-fleet-67890",
+    "missing": [],
+    "drift": ["orphan-workflow"],
+    "expected": ["issue-triage", "ci-failure-doctor"],
+    "deploy": null,
+    "pruned": [],
+    "deploy_preflight": { "...": "nested DeployResult" }
+  },
+  "warnings": [
+    { "code": "drift_detected", "message": "1 drift workflow(s) found", "fields": { "drift": ["orphan-workflow"] } }
+  ],
+  "hints": []
+}
+```
+
+**Notice**:
+- `deploy` is `null` because this was a dry-run with no `--apply` (so no actual deploy was triggered).
+- `deploy_preflight` is a nested `DeployResult` object — useful for spotting compile failures during dry-run.
+- `drift[]` lists workflow files present on the remote but not declared in `fleet.json`.
+- `warnings[]` has a `drift_detected` diagnostic with the drift list in structured fields.
+
+### Filter only drifted repos
+
+```bash
+go run . sync rshade/gh-aw-fleet -o json 2>/dev/null \
+  | jq 'select(.result.drift | length > 0) | {repo, drift: .result.drift}'
+```
+
+---
+
+## 4. `upgrade <repo> -o json` (single repo)
+
+```bash
+go run . upgrade rshade/gh-aw-fleet -o json 2>/dev/null | jq '.result | {upgrade_ok, changed_files, pr_url}'
+```
+
+Expected:
+
+```json
+{
+  "upgrade_ok": true,
+  "changed_files": [".github/workflows/issue-triage.lock.yml"],
+  "pr_url": ""
+}
+```
+
+On dry-run, `pr_url` is empty; with `--apply` (and user approval), it would be the GitHub PR URL.
+
+### Extract raw audit JSON
+
+```bash
+go run . upgrade rshade/gh-aw-fleet -o json 2>/dev/null | jq '.result.audit_json'
+```
+
+The audit JSON is a **native nested object** (not a stringified blob). You can descend into it directly with `jq '.result.audit_json.findings[]'` without an intermediate `fromjson`.
+
+---
+
+## 5. `upgrade --all -o json` (NDJSON stream)
+
+This is the streaming case. Each repo's envelope is one line:
+
+```bash
+go run . upgrade --all -o json 2>/dev/null
+```
+
+Example raw output (3-repo fleet):
+
+```text
+{"schema_version":1,"command":"upgrade","repo":"rshade/gh-aw-fleet","apply":false,"result":{...},"warnings":[],"hints":[]}
+{"schema_version":1,"command":"upgrade","repo":"rshade/repo-b","apply":false,"result":null,"warnings":[],"hints":[{"code":"hint",...}]}
+{"schema_version":1,"command":"upgrade","repo":"rshade/repo-c","apply":false,"result":{...},"warnings":[],"hints":[]}
+```
+
+### Process line-by-line with `jq -c`
+
+```bash
+go run . upgrade --all -o json 2>/dev/null | jq -c 'select(.result == null) | {repo, error: .hints[0].message}'
+```
+
+Streams — each repo's envelope is printed as it completes, so you see failures in real time.
+
+### Aggregate to a single object (optional)
+
+```bash
+go run . upgrade --all -o json 2>/dev/null | jq -s '{schema_version:1,command:"upgrade_all",repos: .}'
+```
+
+`jq -s` (`--slurp`) reads the whole stream into an array and wraps it. Loses streaming; useful when you want a single JSON object for a downstream tool that can't handle NDJSON.
+
+---
+
+## 6. Error envelopes
+
+Try a repo that's not in your fleet:
+
+```bash
+go run . deploy nonexistent/repo -o json; echo "exit=$?"
+```
+
+Expected stdout:
+
+```json
+{"schema_version":1,"command":"deploy","repo":"nonexistent/repo","apply":false,"result":null,"warnings":[],"hints":[{"code":"hint","message":"Repo \"nonexistent/repo\" is not declared in fleet.json; add it with `gh-aw-fleet add nonexistent/repo` first.","fields":{"hint":"..."}}]}
+exit=1
+```
+
+**Notice**:
+- `result: null` — command did not produce a result.
+- `hints[]` carries the actionable error.
+- Exit code is non-zero.
+- `jq -e .` would still succeed on this output — the envelope is valid JSON.
+
+---
+
+## 7. Invalid output mode
+
+```bash
+go run . list -o yaml
+```
+
+Expected stderr:
+
+```text
+Error: unsupported output mode "yaml": expected one of: text, json
+```
+
+Exit code: 1. Stdout is empty — NOT a JSON envelope, because flag validation happens before serialization.
+
+Agents consuming `-o json` SHOULD spell the flag exactly — typos surface immediately as flag errors, not as silent text-mode output.
+
+---
+
+## 8. Text mode is byte-identical
+
+```bash
+diff <(go run . list) <(go run . list -o text)
+```
+
+Expected: empty diff. `-o text` is the default; specifying it explicitly changes nothing.
+
+And:
+
+```bash
+# Pre-feature output (captured before this branch landed):
+go run . list > /tmp/before.txt
+
+# After this branch:
+go run . list > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt
+```
+
+Expected: empty diff. FR-014 / SC-003 are load-bearing for this feature — any diff here is a regression.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `jq: parse error: Invalid numeric literal` on `gh-aw-fleet <cmd> -o json \| jq .` | Stderr leaked into stdout (e.g., `2>&1` was in the pipeline) | Redirect stderr explicitly: `cmd -o json 2>/dev/null \| jq .` |
+| `result: null` unexpectedly | Command failed before building its result. Inspect `.hints[0].message` and `.warnings[0].message`. | Fix the underlying issue; the hint usually tells you how. |
+| All slice fields show `null` instead of `[]` | You're running a broken build — `initSlices` helper isn't firing. | Rebuild from `main` and re-run. This would be a regression; report it. |
+| Unexpected `schema_version` (not `1`) | You're running a future version that bumped the schema. | Read `CHANGELOG.md` under the `### JSON envelope schema` section for the breaking changes. |

--- a/specs/003-cli-output-json/research.md
+++ b/specs/003-cli-output-json/research.md
@@ -1,0 +1,165 @@
+# Phase 0 Research: CLI JSON Output Mode
+
+**Feature**: 003-cli-output-json
+**Date**: 2026-04-21
+
+This document resolves the technical unknowns identified in `plan.md`'s Technical Context. Each section follows the Decision / Rationale / Alternatives pattern.
+
+---
+
+## R1: `json.RawMessage` nesting for `UpgradeResult.AuditJSON`
+
+**Question**: When `UpgradeResult.AuditJSON` (of type `json.RawMessage`) is marshaled as part of the envelope, does it nest as a native JSON object, or does the encoder stringify/escape it? What happens on invalid JSON bytes or a nil slice?
+
+**Decision**: Keep `json.RawMessage` as-is and rely on its documented marshal behavior: a non-nil, valid-JSON slice embeds verbatim into the output at the field position (native nested object — no escape-encoding). A nil slice marshals as JSON `null`. A non-nil slice with invalid JSON bytes causes `json.Marshal` on the parent struct to return an error, which the envelope writer surfaces as a fatal.
+
+**Rationale**:
+- From `encoding/json` source (`encode.go`): `encodeByteSlice` is short-circuited for `RawMessage` — the implementation type-asserts and writes the bytes directly via `Write(...)` without wrapping, base64-encoding, or escaping.
+- `json.Marshal(struct{ X json.RawMessage }{X: []byte(`{"k":1}`)})` yields `{"X":{"k":1}}` — a native nested object, verifiable in any Go playground.
+- `AuditJSON` is populated from `gh aw audit --json` output (see `internal/fleet/upgrade.go:145 res.AuditJSON = out`). `gh aw audit` produces valid JSON by contract. If it ever regresses and emits non-JSON bytes, the marshal error will fail the envelope write cleanly (non-zero exit, stderr error) rather than producing a broken envelope on stdout.
+- No defensive validation (`json.Valid(bytes)` at capture time) is added. It would double-scan every upgrade's audit payload without materially improving the failure mode — a malformed `gh aw audit` is an upstream bug that deserves to surface, not get hidden.
+
+**Alternatives considered**:
+- **Validate at capture time with `json.Valid`**: Rejected. Adds a full JSON-scan per upgrade for no meaningful benefit; silently converting malformed bytes to a fallback value (`null`, empty object) would hide an upstream bug; surfacing the error at marshal time is cleaner.
+- **Change type to `any` / `map[string]any`**: Rejected. Pulls the whole audit payload through reflection-based decode+encode, losing the zero-copy property of `RawMessage` and introducing unnecessary allocations. Also re-encodes keys in Go-map order (non-deterministic) unless sorted, which changes byte-for-byte output day to day.
+- **Store as `string`**: Rejected. Would force consumers to `fromjson()` the value instead of descending with `jq '.result.audit_json.foo'` — directly violates spec FR-016.
+
+---
+
+## R2: Empty-slice-vs-nil-slice JSON marshaling
+
+**Question**: How do we guarantee that empty slice fields on `DeployResult`, `SyncResult`, `UpgradeResult`, and `ListResult` marshal as `[]` (not `null`) without plumbing `omitempty` into every struct (which would *hide* empty fields entirely, the opposite of what we want)?
+
+**Decision**: Initialize slice fields to non-nil empty slices (`[]T{}`) before envelope marshal. Implement as a small helper `initSlices(result any)` in `cmd/output.go` that uses reflection to walk the result struct and replace nil slices with empty-slice equivalents of the same element type. Call this helper from `writeEnvelope` just before `json.Encoder.Encode`. Leave business-layer code (`internal/fleet/*.go`) untouched — the JSON-shape concern stays in the JSON path.
+
+**Rationale**:
+- `encoding/json` marshals a nil slice as `null` and a non-nil empty slice as `[]`. This is documented in the package docs and is stable across Go versions.
+- The alternative of setting the initial value at struct construction time (e.g., `&DeployResult{Added: []WorkflowOutcome{}}`) requires touching every construction site and creates a permanent maintenance burden — any new code path that builds a `DeployResult` risks missing the init.
+- Centralizing the init in the envelope writer means the JSON contract is enforced at exactly one point. Business logic continues to use idiomatic Go (`var added []WorkflowOutcome` + `append`), which creates nil slices by default.
+- Reflection cost is negligible — `json.Marshal` already uses reflection; walking the struct once more adds ~microseconds per envelope.
+
+**Alternatives considered**:
+- **`omitempty` on every slice field**: Rejected. Would omit empty-slice fields entirely from the JSON output, forcing consumers to write `result.added // []` everywhere. Breaks the SC-004 / FR-009 promise that "every slice is always present as an array".
+- **Initialize at construction time**: Rejected (maintenance burden; see above).
+- **Custom `MarshalJSON` on each result struct**: Rejected. Multiplies boilerplate across four struct types; each custom marshaler has to re-emit every field, so adding a new field to `DeployResult` would require an edit in two places.
+- **Third-party library (go-cmp, sjson, etc.) to rewrite the JSON output**: Rejected — adds a dependency, violates Principle I.
+
+**Implementation sketch** (for reference; actual code lives in `cmd/output.go`):
+
+```go
+// initSlices walks a pointer-to-struct result and sets nil slice fields to
+// empty non-nil slices so json.Marshal emits them as "[]" not "null".
+// Handles nested struct fields and slices-of-structs.
+func initSlices(v any) {
+    rv := reflect.ValueOf(v)
+    if rv.Kind() == reflect.Ptr {
+        rv = rv.Elem()
+    }
+    if rv.Kind() != reflect.Struct {
+        return
+    }
+    for i := 0; i < rv.NumField(); i++ {
+        f := rv.Field(i)
+        if !f.CanSet() {
+            continue
+        }
+        switch f.Kind() {
+        case reflect.Slice:
+            if f.IsNil() {
+                f.Set(reflect.MakeSlice(f.Type(), 0, 0))
+            } else {
+                // Walk slice elements (in case of []Struct)
+                for j := 0; j < f.Len(); j++ {
+                    if f.Index(j).Kind() == reflect.Struct {
+                        initSlices(f.Index(j).Addr().Interface())
+                    }
+                }
+            }
+        case reflect.Struct:
+            initSlices(f.Addr().Interface())
+        case reflect.Ptr:
+            if !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+                initSlices(f.Interface())
+            }
+        }
+    }
+}
+```
+
+---
+
+## R3: Cobra persistent-flag validation before subcommand RunE
+
+**Question**: How do we reject `--output yaml` (or empty string, or `JSON`) before any subcommand RunE fires — so the user gets one clean "unsupported output mode" error and exit, not a partial subcommand invocation?
+
+**Decision**: Validate inside `PersistentPreRunE` on the root `*cobra.Command`. The root command already has a `PersistentPreRunE` (wired in #34 for log-level/log-format validation). Extend it to additionally read `--output`, check the value against the closed set `{"text", "json"}`, and return `fmt.Errorf("unsupported output mode %q: expected one of: text, json", v)` on mismatch. Cobra's default error routing writes the message to stderr and exits non-zero without calling the subcommand's RunE.
+
+**Rationale**:
+- `PersistentPreRunE` runs after flag parsing but before `RunE`. Perfect hook for cross-subcommand validation.
+- Reusing the existing `PersistentPreRunE` slot (rather than adding a separate validator per subcommand) guarantees the check fires for every subcommand including `add`, `template fetch`, etc. — even those that don't accept `-o json` (FR-013). For those commands, a second check inside their own `RunE` rejects JSON mode with a more specific error ("command `template fetch` does not support --output json").
+- The pattern matches what #34 already established for `--log-level` / `--log-format`. Consistency is better than re-inventing.
+
+**Alternatives considered**:
+- **`cobra.PositionalArgs`-style validator on the flag itself**: Cobra doesn't have first-class enum-flag support. `spf13/pflag` has no `EnumVar`. Possible via a custom `pflag.Value` implementation, but that's a heavier abstraction than a three-line `PersistentPreRunE` check for two values.
+- **Validate inside each subcommand's RunE**: Rejected. Four duplicated validation blocks; easy to drift; violates DRY without the compensating benefit.
+- **Accept any string and treat unknown as text**: Rejected. Silent fallback is a footgun — an operator typing `-o jsno` (typo) would get text output and wonder why `jq` parse fails on the ANSI tabwriter. Explicit rejection is kinder.
+
+---
+
+## R4: NDJSON emission semantics for `upgrade --all`
+
+**Question**: For `upgrade --all -o json`, how do we emit one JSON envelope per repo per line, ensuring each line is flushed as the repo completes (so downstream consumers can process streaming)? And what happens if `upgrade --all` is parallelized in a future feature — does the emission path become racy?
+
+**Decision**: Use `json.NewEncoder(os.Stdout).Encode(envelope)` once per repo completion inside the existing per-repo loop in `cmd/upgrade.go`'s `--all` branch. `Encoder.Encode` writes the JSON form followed by a single newline and does not buffer internally — the next-level writer (`os.Stdout`) is line-buffered when attached to a terminal and unbuffered when piped. Flush is implicit. Document a **mutex requirement** in `contracts/ndjson.md` for any future parallelization: the envelope write MUST be serialized, otherwise partial lines from concurrent `Encode` calls can interleave.
+
+**Rationale**:
+- `encoding/json.Encoder.Encode` is documented to "terminate each value with a newline character" — exactly the NDJSON contract. No extra framing needed.
+- For the current serial-upgrade loop, concurrency is not a concern. The mutex note is forward-defensive, not required today.
+- Using `Encoder` (not `Marshal` + manual `fmt.Println`) has a subtle correctness benefit: `Encoder` writes directly to the underlying writer without an intermediate `[]byte` allocation for each envelope. Memory-friendly on 20+ repo fleets.
+
+**Alternatives considered**:
+- **Accumulate all envelopes into an aggregate `{results: [...]}` and emit once at the end**: Already rejected in Q1 clarification (user chose NDJSON). Also breaks streaming — consumer waits N×per-repo-duration before seeing any output.
+- **Emit NDJSON only to a bufio-wrapped stdout with explicit flush-per-line**: Unnecessary. `os.Stdout` is already line-buffered for terminals and unbuffered for pipes; adding bufio would actually hurt (need to remember to flush at exit).
+- **Use `encoding/json.Marshal(envelope)` + `fmt.Fprintln(os.Stdout, ...)`**: Functionally equivalent but adds an intermediate `[]byte` allocation per repo and a split-write risk (Marshal could succeed, Fprintln could fail partway) versus Encoder's single Write.
+
+---
+
+## R5: Dual-emission of warnings (envelope + stderr via zerolog)
+
+**Question**: How do warnings land BOTH in the envelope's `warnings[]` AND on stderr via the zerolog logger, without duplicating source-of-truth or creating drift between the two emissions?
+
+**Decision**: At each warning site (currently: `cmd/deploy.go` missing-secret, `cmd/sync.go` drift detected, `cmd/hints.go` hint emission), construct a single `Diagnostic{Code, Message, Fields}` value. Append it to a local `[]Diagnostic` slice that the command carries through to the envelope writer. At the same site, also call `zlog.Warn().Fields(d.Fields).Msg(d.Message)` (for warnings) or `zlog.Warn().Str("hint", d.Message).Msg(d.Message)` (for hints). The `Diagnostic` value is constructed once and used twice — no drift possible between stderr and envelope contents.
+
+**Rationale**:
+- Warnings today already emit to stderr via zerolog (#34 landed this). The change is purely additive: at each existing `zlog.Warn()` site, also capture the same fact into a `Diagnostic` slice. Cost: one `append` per warning.
+- The `Diagnostic` struct's `Code` field satisfies spec FR-011's "stable code identifier" requirement. Codes are defined as package-level string constants in `cmd/output.go` (e.g., `DiagMissingSecret = "missing_secret"`, `DiagDriftDetected = "drift_detected"`). Adding a new warning class adds one constant.
+- The alternative of extracting warnings from zerolog output (via a capture hook on the logger) was considered and rejected: it would couple the envelope contents to the zerolog field schema, making any zerolog format change a breaking change to the JSON envelope.
+
+**Mapping table** (warning sites → Diagnostic codes):
+
+| Site | Code | Fields |
+|---|---|---|
+| `cmd/deploy.go` missing secret | `missing_secret` | `{secret: <name>, url: <secret_key_url>}` |
+| `cmd/sync.go` drift detected | `drift_detected` | `{repo, drift: [...]}` |
+| `cmd/hints.go` each hint | `hint` | `{hint: <full-hint-text>}` — maps 1:1 to existing zerolog hint event |
+
+The hint path uses `CollectHintDiagnostics()` (new) in `internal/fleet/diagnostics.go`: it extends the existing `Hint` struct with a `Code` field and returns a structured `[]Diagnostic` parallel to `CollectHints() []string`. Text-mode callers keep using `CollectHints`; JSON-mode callers use `CollectHintDiagnostics`. Same hints.table backs both.
+
+**Alternatives considered**:
+- **Hook into zerolog via a custom `io.Writer` that tees warnings into a slice**: Rejected. Couples JSON envelope schema to zerolog's field schema; any format change in zerolog propagates through.
+- **Post-process the zerolog-produced stderr buffer after the command finishes**: Rejected. Requires capturing stderr (redirection), parsing emitted log lines back into structured form, and re-encoding — round-trip is wasteful and fragile.
+- **Move the source of truth to `warnings[]` and have zerolog pull from it**: Rejected. Breaks text-mode (which has no envelope to read from). The chosen direction — local `Diagnostic` value shared at the emission site — works for both modes symmetrically.
+
+---
+
+## Summary
+
+| Research | Decision | Key consequence |
+|---|---|---|
+| R1 (`json.RawMessage`) | Pass-through marshal; no validation at capture | `AuditJSON` nests as native object (FR-016); malformed bytes surface as marshal error |
+| R2 (empty slices) | Reflection-based `initSlices` in envelope writer | Business logic untouched; JSON shape enforced at one point (FR-009) |
+| R3 (flag validator) | `PersistentPreRunE` on root | One error path; all subcommands covered; matches #34 pattern |
+| R4 (NDJSON) | `json.Encoder.Encode` per repo | Streaming for free; mutex note for future parallelism |
+| R5 (dual-emission) | Local `Diagnostic` value, used twice at the site | No drift between envelope and stderr; adds one `append` per warning |
+
+All NEEDS CLARIFICATION items from plan.md are resolved. Phase 1 design artifacts can proceed.

--- a/specs/003-cli-output-json/spec.md
+++ b/specs/003-cli-output-json/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: CLI JSON Output Mode
+
+**Feature Branch**: `003-cli-output-json`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: GitHub issue #25 — `feat(cli): add --output json to list/deploy/sync/upgrade for LLM consumption`
+
+## Clarifications
+
+### Session 2026-04-21
+
+- Q: How should `upgrade --all -o json` emit its output across multiple repos? → A: NDJSON stream — one complete JSON envelope per line, one per repo, preserving the single-repo envelope shape per line.
+- Q: What envelope shape is emitted on stdout when a command fails before its internal result struct is built (e.g., config parse error, missing tool, repo not found)? → A: `result: null` with populated `warnings[]`/`hints[]`; envelope still carries `schema_version`, `command`, `repo`, `apply`; command exits non-zero.
+- Q: What are the exit code semantics in JSON mode when warnings are present but the command structurally succeeded? → A: Text-mode-parity — JSON mode exit codes mirror text mode exactly for the same conditions; no new exit-code contract is introduced. Agents that want warning-level gating parse `warnings[]` from the envelope.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Structured `list` output for agentic consumption (Priority: P1)
+
+An operator running `gh-aw-fleet list -o json` receives a single, valid JSON object on stdout describing every repo in the fleet (repo name, profiles, engine, workflow slugs, exclusions, extras) along with which config file was loaded. The human-readable tabwriter table is fully suppressed in JSON mode; any diagnostics go to stderr.
+
+**Why this priority**: `list` is read-only, side-effect-free, and the most frequent entry point for any automation that wants a snapshot of fleet state. It has the highest value-to-risk ratio, unblocks LLM agents and shell scripts immediately, and validates the envelope contract before any write-path command adopts it.
+
+**Independent Test**: Run `gh-aw-fleet list -o json | jq -e .schema_version` and `... | jq '.result.repos[0]'`; both must succeed and return expected shape without any regex scraping.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `fleet.local.json` with multiple repos, **When** the operator runs `gh-aw-fleet list -o json`, **Then** stdout contains exactly one JSON object with `schema_version: 1`, `command: "list"`, `result.loaded_from`, and `result.repos[]` populated with one entry per repo.
+2. **Given** the JSON mode is active, **When** the command would normally print the `(loaded fleet.local.json)` breadcrumb, **Then** that breadcrumb is emitted on stderr (never stdout), leaving stdout as pure JSON consumable by `jq -e`.
+3. **Given** the `list` command is invoked without `--output`, **When** the operator runs `gh-aw-fleet list`, **Then** the tabwriter output is byte-identical to the behavior before this feature landed.
+
+---
+
+### User Story 2 - Structured `deploy` output with embedded warnings (Priority: P2)
+
+An operator pipes `gh-aw-fleet deploy rshade/gh-aw-fleet -o json` (dry-run) into their agentic pipeline. The envelope carries the full `DeployResult` (added, skipped, failed, PR URL if applicable, missing-secret state) plus a `warnings[]` array populated with any `⚠ WARNING: Actions secret ...` diagnostics. The same warnings are also emitted on stderr via the structured logger, so humans tailing the run still see them.
+
+**Why this priority**: `deploy` is the highest-value write-path command. Agents need to programmatically inspect which workflows were added vs. skipped vs. failed, pick up PR URLs for downstream tracking, and surface missing-secret conditions without scraping text. Embedding warnings in the envelope makes the JSON output self-sufficient (no need to also parse stderr).
+
+**Independent Test**: Run a dry-run `deploy` that would trigger a missing-secret warning; assert the envelope contains a matching entry in `warnings[]` with a `code` (e.g., `missing_secret`) and a populated `fields` object, and that the same warning appears on stderr.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo that would have workflows added, skipped, and failed in a dry-run, **When** the operator runs `... deploy <repo> -o json`, **Then** `result.added`, `result.skipped`, and `result.failed` are present as JSON arrays (never `null`, never omitted), each containing structured entries with `name`, `spec`, `reason`, and optional `error`.
+2. **Given** a deploy that detects a missing Actions secret, **When** the command completes, **Then** `warnings[]` includes an entry with a stable `code` identifying the class of warning and enough structured context (e.g., secret name) to drive downstream automation without regex.
+3. **Given** JSON mode is active and a failure occurs mid-pipeline, **When** hints from the diagnostics layer fire (e.g., unknown-property, HTTP 404), **Then** they appear in `hints[]` inside the envelope and also on stderr, and the command still exits with a non-zero status.
+4. **Given** `deploy` is run without `--output` or with `--output text`, **When** it executes, **Then** the existing tabwriter output and ordering is preserved exactly (no drift, no extra blank lines, no moved text).
+
+---
+
+### User Story 3 - Structured `sync` and `upgrade` output (Priority: P3)
+
+An operator running `gh-aw-fleet sync <repo> -o json` or `gh-aw-fleet upgrade <repo> -o json` receives envelopes carrying the full `SyncResult` / `UpgradeResult`. For `sync`: missing/drift/expected workflow lists, pruned entries, and an optional nested deploy preview. For `upgrade`: changed files, merge conflict list, PR URL, and the raw `gh aw` audit JSON embedded inline as a JSON sub-object (not a stringified blob).
+
+**Why this priority**: These commands are valuable for complete fleet coverage, but lower-frequency than `list`/`deploy` and more complex to serialize (sync can carry a nested dry-run deploy result; upgrade embeds a `json.RawMessage` audit blob). Deferring them to P3 lets the envelope contract settle on the simpler two commands first.
+
+**Independent Test**: Run `sync` against a repo with known drift; assert `result.drift[]` is a structured array. Run `upgrade` that produces a PR; assert `result.pr_url` is a string and `result.audit_json` parses as a nested object under `jq '.result.audit_json'` (no escape-encoded string).
+
+**Acceptance Scenarios**:
+
+1. **Given** a `sync` run where the repo is fully in sync, **When** the operator runs `... sync <repo> -o json`, **Then** `result.missing`, `result.drift`, `result.expected`, and `result.pruned` are all `[]` (not `null`, not absent), and `result.deploy` is `null`.
+2. **Given** a `sync` with drift that triggers a dry-run deploy preview, **When** the envelope is emitted, **Then** `result.deploy` is a nested object carrying the full embedded `DeployResult`, using the same JSON key conventions.
+3. **Given** an `upgrade` run that produces merge conflicts, **When** the envelope is emitted, **Then** `result.conflicts[]` is populated, `result.upgrade_ok` is `false`, and the raw `gh aw audit` JSON is embedded inline under `result.audit_json` as a nested object, preserving every field that `gh aw audit --json` produced.
+4. **Given** an `upgrade` with no changes, **When** the envelope is emitted, **Then** `result.no_changes` is `true`, `result.changed_files` is `[]`, and `result.pr_url` is an empty string or omitted consistently.
+5. **Given** `upgrade --all -o json` across N repos, **When** the command runs, **Then** stdout contains exactly N lines, each line a complete, single-repo JSON envelope (NDJSON) with its own `repo`, `result`, `warnings`, and `hints`; `jq -c` consumers can process each line independently as it streams.
+
+---
+
+### Edge Cases
+
+- **Invalid flag value**: `gh-aw-fleet list -o yaml` must error with a clear message (e.g., `unsupported output mode "yaml"; expected "text" or "json"`) and exit non-zero, without emitting a partial envelope.
+- **Unsupported subcommand**: `gh-aw-fleet template fetch -o json` must error (not silently fall back to text), since `template fetch` is explicitly out of scope and would confuse downstream consumers expecting the envelope.
+- **Stderr contamination**: Any diagnostic, breadcrumb, or warning printed to stdout in text mode must be routed to stderr in JSON mode so that `stdout` is pure, single-object JSON parseable by `jq -e`.
+- **Empty collections**: Every slice field in every result struct must marshal as `[]` when empty, never as `null`, so downstream consumers can iterate without nil-guards.
+- **Nested JSON fidelity**: The `upgrade` command's `audit_json` field (a `json.RawMessage`) must nest as a native JSON object inside the envelope, not as a string containing escaped JSON.
+- **Interrupted runs**: If a command panics or is killed mid-output, downstream consumers must either get a complete envelope or nothing on stdout — not a truncated JSON fragment. (The command should compute the full result before beginning stdout emission.)
+- **Pre-result failure**: If the command fails before it can build a result struct (config parse error, missing tool, repo not in fleet, profile resolution failure), JSON mode still emits one complete envelope on stdout with `result: null` and the cause recorded in `warnings[]` or `hints[]` — never an empty stdout. Exit code is non-zero.
+- **Dependency ordering**: If issue #24 (zerolog) has not landed yet, the stderr warning emission path must still work (via a stub helper), so this feature is not blocked on #24's merge order.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The root command MUST accept a persistent `-o` / `--output` flag whose values are restricted to `text` (default) and `json`.
+- **FR-002**: The flag validator MUST reject any other value (including `yaml`, `JSON`, empty string) with a clear error message naming the accepted values, and MUST cause the process to exit non-zero before any subcommand logic runs.
+- **FR-003**: When `--output json` is set, the `list`, `deploy`, `sync`, and `upgrade` commands MUST emit a single JSON object to stdout and suppress all existing tabwriter output for that command.
+- **FR-004**: The JSON envelope MUST contain, at minimum, the top-level keys `schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, and `hints`, in any order.
+- **FR-005**: `schema_version` MUST be the integer `1` for the initial release and MUST be bumped (monotonically) on any breaking change to envelope or result field shapes.
+- **FR-006**: `warnings` and `hints` MUST always be JSON arrays (never `null`, never absent), each element of which MUST include at minimum a `code` (string), `message` (string), and optional `fields` (object) for structured context.
+- **FR-007**: The `result` field MUST be the typed struct already produced internally by the command (`DeployResult`, `SyncResult`, `UpgradeResult`, or a new `ListResult`), serialized with explicit, stable JSON tags.
+- **FR-008**: JSON keys in every result struct MUST use `snake_case` (e.g., `clone_dir`, `pr_url`, `missing_secret`, `audit_json`, `loaded_from`) for consistency with the rest of the project's JSON surface.
+- **FR-009**: All slice/array fields in result structs MUST marshal as empty arrays `[]` (never `null`) when empty.
+- **FR-010**: Any diagnostic, breadcrumb, or warning that appears on stdout in text mode MUST be routed to stderr in JSON mode, so stdout remains a single valid JSON object parseable by `jq -e`.
+- **FR-011**: In JSON mode, every warning embedded in the envelope's `warnings[]` MUST also be emitted on stderr via the structured logger (zerolog from issue #24, or a stub helper if #24 has not landed), so humans monitoring a run still see them live.
+- **FR-012**: In JSON mode, every diagnostic hint from the existing `CollectHints` layer MUST be embedded in `hints[]` in the envelope and MUST also appear on stderr via the structured logger.
+- **FR-013**: Subcommands outside the four primary commands (notably `template fetch`) MUST reject `--output json` with a clear error rather than silently falling back to text mode.
+- **FR-014**: Text-mode output (when `--output` is omitted or set to `text`) MUST remain byte-identical to the pre-feature behavior for all existing commands, including ordering, spacing, and blank lines.
+- **FR-015**: The envelope MUST be emitted as compact single-line JSON (no pretty-printing); consumers wanting formatted output can pipe through `jq`.
+- **FR-016**: The `upgrade` command's `audit_json` field MUST nest as a native JSON object inside the envelope when the underlying `gh aw audit --json` output is present, not as a string containing escape-encoded JSON.
+- **FR-017**: The new `ListResult` type MUST be defined as part of this feature with fields `loaded_from` (string) and `repos` (array of rows containing `repo`, `profiles`, `engine`, `workflows`, `excluded`, `extra`), matching the data the current tabwriter `list` path already computes.
+- **FR-018**: No new dependencies MAY be introduced; JSON serialization MUST use only the standard library `encoding/json` package.
+- **FR-019**: When `upgrade --all` is invoked with `--output json`, the command MUST emit newline-delimited JSON (NDJSON) on stdout — one complete single-repo envelope per line, one per repo — preserving the single-repo envelope shape (`schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, `hints`) on each line. Envelopes MUST be flushed as each repo completes to enable streaming consumption.
+- **FR-020**: When a command fails before its internal result struct can be built (e.g., config parse error, missing `gh aw` binary, target repo not found in fleet, profile resolution failure), JSON mode MUST still emit exactly one complete envelope on stdout with `result: null`, the failure described in `warnings[]` or `hints[]` as appropriate, `schema_version`, `command`, `repo` (may be empty if not yet determined), and `apply` populated; the process MUST exit non-zero.
+- **FR-021**: Exit codes in JSON mode MUST mirror text-mode exit codes for every condition (warnings, structural success, pre-result failure, `--apply` mid-pipeline failure, flag validation). JSON mode MUST NOT introduce a new exit-code contract. Agents requiring warning-level gating MUST parse `warnings[]` from the envelope rather than gate on exit code alone.
+
+### Key Entities *(data)*
+
+- **JSON Envelope**: The top-level stdout object. Fields: `schema_version` (int), `command` (string — one of `list`, `deploy`, `sync`, `upgrade`), `repo` (string — may be empty for `list`), `apply` (bool — false for dry-runs and for `list`), `result` (command-specific struct), `warnings` (Diagnostic array), `hints` (Diagnostic array).
+- **Diagnostic**: Shared shape for warnings and hints. Fields: `code` (string — stable machine-parseable identifier like `missing_secret`, `unknown_property`), `message` (string — human-readable text), `fields` (object — optional structured context such as `{secret: "ANTHROPIC_API_KEY"}`).
+- **ListResult**: New struct introduced by this feature. Fields: `loaded_from` (string — which config file was loaded, e.g., `fleet.local.json`), `repos` (array of ListRow).
+- **ListRow**: A single repo entry in `ListResult.repos`. Fields: `repo` (string), `profiles` (string array), `engine` (string), `workflows` (string array), `excluded` (string array), `extra` (string array — workflows present on the remote but not in the profile).
+- **DeployResult**: Existing struct, newly JSON-tagged. Fields include `repo`, `clone_dir`, `added`, `skipped`, `failed`, `init_was_run`, `branch_pushed`, `pr_url`, `missing_secret`, `secret_key_url`.
+- **WorkflowOutcome**: Existing struct used inside deploy/sync arrays. Fields: `name`, `spec`, `reason`, `error`.
+- **SyncResult**: Existing struct, newly JSON-tagged. Fields include `repo`, `clone_dir`, `missing`, `drift`, `expected`, `deploy` (nullable nested DeployResult), `pruned`, `deploy_preflight`.
+- **UpgradeResult**: Existing struct, newly JSON-tagged. Fields include `repo`, `clone_dir`, `upgrade_ok`, `update_ok`, `changed_files`, `conflicts`, `no_changes`, `branch_pushed`, `pr_url`, `audit_json` (nested JSON object), `output_log`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A downstream consumer can extract any data point previously visible in the `list` / `deploy` / `sync` / `upgrade` tabwriter output using a single `jq` expression, with zero regex parsing of text — verifiable by round-tripping a known fleet state through `jq` and comparing against the text-mode output for equivalence.
+- **SC-002**: `stdout` in JSON mode is a single valid JSON object for 100% of runs (including failure paths); `jq -e . < <(gh-aw-fleet <cmd> -o json)` succeeds even when the underlying command exits non-zero.
+- **SC-003**: Text-mode output is byte-identical to pre-feature behavior across the full regression test suite (zero diffs when `--output` is omitted or set to `text`).
+- **SC-004**: Every slice field in every result struct round-trips as `[]` (not `null`) when empty, verified by a unit test fixture for each command.
+- **SC-005**: The envelope's top-level key set (`schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, `hints`) is pinned by a regression test that fails on accidental key addition, removal, or rename.
+- **SC-006**: A user running `gh-aw-fleet deploy <repo> -o json 2>/dev/null | jq .result.added[].name` gets the list of added workflow names with no stderr noise leaking into stdout.
+- **SC-007**: Agent pipelines consuming fleet state reduce their parsing code complexity measurably (qualitative: single `jq` expression replaces multi-step text scraping), enabling cleaner integration with LLM context windows.
+- **SC-008**: The feature adds zero new third-party dependencies to `go.mod` — confirmable by a `go.sum` diff.
+- **SC-009**: The full local gate (`make ci` — `fmt-check`, `vet`, `lint`, `test`) passes with the feature in place.
+
+## Assumptions
+
+- **JSON is the only new output format in scope.** The flag is designed to be extensible to `yaml` or other formats later, but only `text` and `json` ship in this iteration.
+- **`template fetch` is deferred.** It already writes its own `templates.json` as its primary artifact and has its own `--json` manifest flag; reconciling its output model with the envelope is out of scope here.
+- **Schema versioning uses a monotonic integer, not a published JSON Schema file.** The `schema_version` field is the contract. Publishing a separate schema document (e.g., `docs/json-schema/v1.json`) is a future task.
+- **Stderr is the accepted channel for human-readable diagnostics in JSON mode.** Consumers who want purely machine-readable output silence stderr (`2>/dev/null`). Humans running interactively get both structured JSON on stdout and live warnings/hints on stderr.
+- **Warnings and hints are populated from existing sources.** Warnings come from code paths that already print `⚠ WARNING: ...` lines; hints come from the existing `internal/fleet/diagnostics.go` `CollectHints` layer. No new diagnostic sources are introduced.
+- **The feature depends on issue #24 (zerolog) for stderr structured logging**, but can land alongside or before #24 via a thin `stderrWarn()` stub that #24 later replaces — the feature is not strictly blocked on #24's merge order.
+- **No internal fleet package result struct shapes change.** Only JSON tags are added; no fields are added, removed, or renamed (other than introducing the new `ListResult` which did not previously exist).
+- **Compact JSON output is acceptable.** No `--json-pretty` variant is provided; consumers pipe through `jq` if they want formatting.
+- **Flag is persistent on root.** All subcommands inherit it through cobra, even those that don't honor it (which error on `-o json` rather than silently ignore).

--- a/specs/003-cli-output-json/tasks.md
+++ b/specs/003-cli-output-json/tasks.md
@@ -1,0 +1,265 @@
+---
+description: "Task list for feature implementation: CLI JSON output mode"
+---
+
+# Tasks: CLI JSON Output Mode
+
+**Input**: Design documents from `/specs/003-cli-output-json/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/cli-flags.md](contracts/cli-flags.md), [contracts/envelope.md](contracts/envelope.md), [contracts/ndjson.md](contracts/ndjson.md), [quickstart.md](quickstart.md)
+
+**Tests**: Tests ARE included in this plan because spec.md's Testing Strategy section explicitly calls for: (a) envelope shape / schema_version / empty-array pinning tests in `cmd/output_test.go`; (b) flag-validator unit tests; (c) ListResult snapshot tests; (d) manual `jq` validation via quickstart.md. TDD ordering is used — each user story phase writes the failing test first, then the implementation makes it pass.
+
+**Organization**: Tasks are grouped by user story (US1 = list P1 MVP, US2 = deploy P2, US3 = sync + upgrade P3) so each story can be implemented and validated independently, matching the spec's three-slice priority breakdown.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Every description includes the exact file path(s) touched
+
+## Path Conventions
+
+Single-project Go CLI. Source under `cmd/` and `internal/fleet/`. Tests colocated as `*_test.go` next to production files. Module path `github.com/rshade/gh-aw-fleet`. No new dependencies — stdlib `encoding/json` + `reflect` only (per research.md R2).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Baseline capture for the invariants this feature must preserve: zero new deps, byte-identical text-mode output.
+
+- [X] T001 Capture baseline `go mod graph | sort > /tmp/gomod-003-before.txt` from repo root. No dependency changes are expected in this feature (FR-018, SC-008). T030 will diff against this file post-implementation; the diff MUST be empty.
+- [X] T002 Capture text-mode baseline outputs for later byte-identity verification (FR-014, SC-003). Run `go run . list > /tmp/list-text-before.txt 2>/dev/null`; run `go run . deploy rshade/gh-aw-fleet > /tmp/deploy-text-before.txt 2>/dev/null`; run `go run . sync rshade/gh-aw-fleet > /tmp/sync-text-before.txt 2>/dev/null`; run `go run . upgrade rshade/gh-aw-fleet > /tmp/upgrade-text-before.txt 2>/dev/null`. T028 will re-run without `--output` (default `text`) and diff; any diff fails SC-003.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Lock the shared types (`Envelope`, `Diagnostic`, `ListResult` base), helpers (`writeEnvelope`, `outputMode`, `initSlices`, `validateOutputMode`), and the `-o`/`--output` flag that every user story depends on.
+
+**⚠️ CRITICAL**: No user-story work may begin until this phase is complete.
+
+- [X] T003 [P] TDD — write failing tests in new `internal/fleet/diagnostics_test.go` covering: (a) `Diagnostic` struct marshals with snake_case JSON keys `code`, `message`, `fields`, and `fields` is omitted when nil/empty (per data-model.md Entity 2); (b) every entry in the package-level `hints` slice has a non-empty `Code` field that is snake_case (asserts pattern `^[a-z][a-z0-9_]*$`) — forces T005 to backfill codes; (c) `CollectHintDiagnostics("Unknown property: foo")` returns a single `Diagnostic` with `Code == DiagUnknownProperty`, `Message` equal to the hint text, and `Fields["hint"]` equal to the same text; (d) `CollectHintDiagnostics("")` returns an empty slice (non-nil — per FR-006 JSON arrays never null semantics for hint-collector consumers). Tests MUST be in package `fleet` (internal). They MUST fail initially because `Diagnostic` and `CollectHintDiagnostics` do not yet exist.
+- [X] T004 [P] TDD — write failing tests in new `cmd/output_test.go` covering: (a) `TestEnvelope_TopLevelKeysPinned` — construct an envelope with a `ListResult{LoadedFrom: "", Repos: []ListRow{}}` result, empty warnings/hints, marshal via `writeEnvelopeTo(&buf, ...)`, assert the output byte-equals exactly `{"schema_version":1,"command":"list","repo":"","apply":false,"result":{"loaded_from":"","repos":[]},"warnings":[],"hints":[]}\n`; (b) `TestEnvelope_SchemaVersionIs1` — assert the top-level `schema_version` is the integer `1`; (c) `TestInitSlices_NilToEmpty` — construct a `DeployResult{}` with all-nil slices, call `initSlices(&r)`, assert `r.Added`, `r.Skipped`, `r.Failed` are non-nil empty slices; (d) `TestOutputFlag_AcceptsText`, `TestOutputFlag_AcceptsJSON`, `TestOutputFlag_DefaultText`, `TestOutputFlag_RejectsYAML`, `TestOutputFlag_RejectsUpperCase`, `TestOutputFlag_RejectsEmpty` — build a root command with a stub subcommand, execute with the corresponding `-o` value, assert the validator error path per `contracts/cli-flags.md`; (e) `TestEnvelope_ResultNullOnPreFailure` — pass `nil` as result to `writeEnvelopeTo`, assert the output contains `"result":null` and `schema_version/command/repo/apply/warnings/hints` are still present. All tests MUST fail initially.
+- [X] T005 Extend `internal/fleet/diagnostics.go`: (a) add `Diagnostic` struct — `type Diagnostic struct { Code string \`json:"code"\`; Message string \`json:"message"\`; Fields map[string]any \`json:"fields,omitempty"\` }`; (b) add package-level constants — `const ( DiagMissingSecret = "missing_secret"; DiagDriftDetected = "drift_detected"; DiagHint = "hint"; DiagUnknownProperty = "unknown_property"; DiagHTTP404 = "http_404"; DiagGPGFailure = "gpg_failure" )`; (c) add `Code string` field to the existing `Hint` struct; (d) backfill each entry in the `hints` slice with its code — `Unknown property: mount-as-clis` → `DiagUnknownProperty`, `Unknown property:` → `DiagUnknownProperty`, `HTTP 404` → `DiagHTTP404`, `gpg failed to sign` → `DiagGPGFailure`; (e) add `func CollectHintDiagnostics(texts ...string) []Diagnostic` that mirrors `CollectHints`'s scan-and-dedupe loop but emits `Diagnostic{Code: h.Code, Message: h.Message, Fields: map[string]any{"hint": h.Message}}` per matched hint; return `[]Diagnostic{}` (non-nil empty) when no matches, for consumer iteration ergonomics. Add package comment explaining the two-function invariant: text-mode keeps using `CollectHints`, JSON-mode uses `CollectHintDiagnostics`; both must stay in sync by construction (same `hints` slice). Tests from T003 MUST pass.
+- [X] T006 Add JSON tags to `WorkflowOutcome` in `internal/fleet/deploy.go`: `Name` → `json:"name"`, `Spec` → `json:"spec"`, `Reason` → `json:"reason"`, `Error` → `json:"error"`. This is foundational (not US2-scoped) because `WorkflowOutcome` is nested inside `DeployResult.Added/Skipped/Failed` AND inside `SyncResult.Deploy.Added/...` AND inside `SyncResult.DeployPreflight.Added/...`, so it must be tagged before US3 can build its envelope. No struct-shape change; only tag additions.
+- [X] T007 Create `cmd/output.go` (package `cmd`). Contents: (a) imports — `encoding/json`, `fmt`, `io`, `os`, `reflect`, `github.com/spf13/cobra`, `github.com/rshade/gh-aw-fleet/internal/fleet`; (b) `type Envelope struct` with exactly the fields in `data-model.md` Entity 1, all with json tags; (c) `const SchemaVersion = 1` (package-level); (d) `func writeEnvelope(cmd *cobra.Command, commandName, repo string, apply bool, result any, warnings, hints []fleet.Diagnostic) error` that dispatches to `writeEnvelopeTo(cmd.OutOrStdout(), ...)`; (e) `func writeEnvelopeTo(w io.Writer, commandName, repo string, apply bool, result any, warnings, hints []fleet.Diagnostic) error` which calls `initSlices(result)` (only if non-nil), normalizes `warnings`/`hints` to non-nil empty slices if nil, builds an `Envelope{SchemaVersion, Command, Repo, Apply, Result, Warnings, Hints}`, and emits via `json.NewEncoder(w).Encode(env)` — `Encoder.Encode` handles newline termination per research.md R4; (f) `func outputMode(cmd *cobra.Command) string` — reads `--output`, returns `"text"` on empty (defensive; PersistentPreRunE has validated); (g) `func validateOutputMode(mode string) error` — closed set `{"text","json"}`, returns `fmt.Errorf("unsupported output mode %q: expected one of: text, json", mode)` on mismatch; (h) `func rejectJSONMode(cmd *cobra.Command, subcommand string) error` — returns non-nil error iff `outputMode(cmd) == "json"`, message per `contracts/cli-flags.md` FR-013 section; (i) `func initSlices(v any)` — reflection walker per research.md R2, handles pointer-to-struct, struct, `reflect.Slice`, nested slice-of-struct; skips pointer fields whose `Kind() == reflect.Ptr` but recurses into them when non-nil and pointing to a struct. Add comments explaining WHY `initSlices` exists (FR-009 `[]`-not-`null` contract) and WHY the mutex note for future parallelization (`contracts/ndjson.md`). Tests (a) and (c) from T004 MUST pass after this task; tests (d) and (e) MUST fail until T008 lands; test (b) passes trivially.
+- [X] T008 Update `cmd/root.go`: (a) add persistent flag registration — `root.PersistentFlags().StringP("output", "o", "text", "Output format: text|json")`; (b) extend the existing `PersistentPreRunE` (landed in #34 for log-flag validation) to additionally read the `--output` value and call `validateOutputMode(mode)`, returning its error directly so cobra's default error writer prints plain text to stderr and exits non-zero (FR-002 per `contracts/cli-flags.md`). Order: log-flag validation first (matches #34 pattern), then `--output` validation. Keep `SilenceUsage: true`. All T004 tests MUST pass after this task.
+
+**Checkpoint**: `Envelope`, `Diagnostic`, `writeEnvelope`, `outputMode`, `initSlices`, `validateOutputMode`, `rejectJSONMode`, the `-o`/`--output` flag with validator, and `WorkflowOutcome` JSON tags are all in place. All foundational tests green (T003, T004). User story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Structured `list` output for agentic consumption (Priority: P1) 🎯 MVP
+
+**Goal**: `go run . list -o json` emits a single JSON envelope on stdout with `schema_version: 1`, `command: "list"`, `result.loaded_from`, and `result.repos[]` populated. Text mode byte-identical. The `(loaded fleet.local.json)` breadcrumb stays on stderr.
+
+**Independent Test**: Run quickstart.md steps 1 (list -o json) and 8 (text mode byte-identity). Also run `go run . list -o json 2>/dev/null | jq -e .schema_version` — exit 0 with stdout `1`. Run `go run . list -o json 2>/dev/null | jq -e '.result.repos[0].repo'` — exit 0 with first repo name.
+
+### Tests for User Story 1 ⚠️
+
+> Write these tests FIRST, ensure they FAIL before implementation.
+
+- [X] T009 [P] [US1] Write failing test `TestBuildListResult_Shape` in new `internal/fleet/list_result_test.go`: load a fixture `Config` (inline literal, not from disk) with two repos — one minimal, one with `ExtraWorkflows` and `ExcludeFromProfiles`. Call `BuildListResult(cfg)`. Assert: `result.LoadedFrom == cfg.LoadedFrom`; `result.Repos` is sorted alphabetically by `Repo`; every `ListRow.Profiles/Workflows/Excluded/Extra` is non-nil (empty slice, not nil) per FR-009. Also assert `ListRow.Engine == cfg.EffectiveEngine(repo)` — empty string when no engine (NOT the text-mode `"-"` placeholder per data-model.md ListRow note).
+- [X] T010 [P] [US1] Write failing tests in `cmd/output_test.go`: (a) `TestListEnvelope_EmptyFleet` — build a `Config` with `Repos: map[string]RepoSpec{}`, call `fleet.BuildListResult`, pass through `writeEnvelopeTo`, assert stdout JSON has `result.repos == []` (non-null) and `result.loaded_from == ""`; (b) `TestListEnvelope_Populated` — use `testdata/list-envelope.golden.json` (create this fixture) and compare byte-for-byte via a canned config; (c) `TestListCmd_JSONMode` — use cobra `ExecuteC` in-process with a canned config via a test-only `--dir` override, capture stdout, assert it parses as `cmd.Envelope{Command: "list"}`.
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Create `internal/fleet/list_result.go` containing: (a) `type ListResult struct { LoadedFrom string \`json:"loaded_from"\`; Repos []ListRow \`json:"repos"\` }`; (b) `type ListRow struct { Repo string \`json:"repo"\`; Profiles []string \`json:"profiles"\`; Engine string \`json:"engine"\`; Workflows []string \`json:"workflows"\`; Excluded []string \`json:"excluded"\`; Extra []string \`json:"extra"\` }`; (c) `func BuildListResult(cfg *Config) (*ListResult, error)` — walks `cfg.Repos` keys, sorts via `sort.Strings`, for each repo calls `cfg.ResolveRepoWorkflows(repo)` (propagates errors), extracts names via a helper `workflowNames([]ResolvedWorkflow) []string`, builds `ListRow` with `Engine: cfg.EffectiveEngine(repo)` (NOT run through `orDash`), initializes `Profiles/Workflows/Excluded/Extra` as non-nil empty slices when absent. Returns `&ListResult{LoadedFrom: cfg.LoadedFrom, Repos: rows}`. Tests T009 and T010(a)/(b) MUST pass.
+- [X] T012 [US1] Update `cmd/list.go`: replace the current `RunE` to branch on `outputMode(cmd)`. Text path — keep existing tabwriter code unchanged (the breadcrumb `fmt.Fprintf(cmd.OutOrStderr(), "  (loaded %s)\n", cfg.LoadedFrom)` stays). JSON path — call `res, err := fleet.BuildListResult(cfg)`; on error, call `writeEnvelope(cmd, "list", "", false, nil, nil, []fleet.Diagnostic{{Code: fleet.DiagHint, Message: err.Error(), Fields: map[string]any{"hint": err.Error()}}})` and return the error (FR-020 + FR-021 — non-zero exit preserved); on success, call `return writeEnvelope(cmd, "list", "", false, res, nil, nil)`. Keep the breadcrumb route to stderr in BOTH modes — text mode consumers expect it, JSON mode consumers already redirect stderr. Test T010(c) MUST pass.
+- [X] T013 [US1] Reject `-o json` on subcommands that do not support it: edit `cmd/template.go` (template fetch RunE — first check), `cmd/add.go` (add RunE — first check), `cmd/stubs.go` (status stub RunE — first check). In each, add at the very top of RunE: `if err := rejectJSONMode(cmd, "<subcommand name>"); err != nil { return err }`. Subcommand names as they appear in the error message: `"template fetch"`, `"add"`, `"status"`. Add a test `TestJSONModeRejected_TemplateFetch` in `cmd/output_test.go` that executes `template fetch -o json` and asserts the error message matches the contract in `contracts/cli-flags.md`.
+
+**Checkpoint**: After this phase, `list -o json` works end-to-end. Quickstart steps 1 and 8 pass. The MVP is deliverable; US2 and US3 can be deferred to later sprints without breaking US1.
+
+---
+
+## Phase 4: User Story 2 - Structured `deploy` output with embedded warnings (Priority: P2)
+
+**Goal**: `go run . deploy <repo> -o json` emits an envelope with `result.added/skipped/failed` arrays (never null when empty), `result.missing_secret` / `result.secret_key_url`, `result.pr_url`, and when applicable a `warnings[]` entry with `code: "missing_secret"` AND the same warning on stderr via zerolog (dual-emission per research.md R5).
+
+**Independent Test**: Run quickstart.md step 2 (deploy -o json dry-run) and step 2's missing-secret demo. Verify `jq '.result.added | type'` returns `"array"` (not `"null"`) on a deploy with no adds. Verify `jq '.warnings[0].code'` returns `"missing_secret"` on a deploy targeting a repo without the engine secret.
+
+### Tests for User Story 2 ⚠️
+
+- [X] T014 [P] [US2] Write failing tests in `cmd/output_test.go`: (a) `TestDeployEnvelope_EmptyArrays` — construct a `fleet.DeployResult{Repo: "x/y"}` (all slices nil), pass through `writeEnvelopeTo` as the "deploy" command, parse the stdout JSON, assert `.result.added`, `.result.skipped`, `.result.failed` are all empty arrays (JSON type `array`, length 0); (b) `TestDeployEnvelope_MissingSecretWarning` — construct a `DeployResult{Repo: "x/y", MissingSecret: "ANTHROPIC_API_KEY", SecretKeyURL: "https://example.com/key"}`, build a warnings slice containing a single `fleet.Diagnostic{Code: DiagMissingSecret, Message: "Actions secret ANTHROPIC_API_KEY is missing...", Fields: map[string]any{"secret": "ANTHROPIC_API_KEY", "url": "https://example.com/key"}}`, emit envelope, assert `.warnings[0].code == "missing_secret"`, `.warnings[0].fields.secret == "ANTHROPIC_API_KEY"`; (c) `TestDeployEnvelope_ApplyFlag` — assert `envelope.apply == true` when `apply=true` is passed, `false` otherwise.
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Add JSON tags to `DeployResult` in `internal/fleet/deploy.go` per data-model.md Entity 4: `Repo` → `json:"repo"`, `CloneDir` → `json:"clone_dir"`, `Added` → `json:"added"`, `Skipped` → `json:"skipped"`, `Failed` → `json:"failed"`, `InitWasRun` → `json:"init_was_run"`, `BranchPushed` → `json:"branch_pushed"`, `PRURL` → `json:"pr_url"`, `MissingSecret` → `json:"missing_secret"`, `SecretKeyURL` → `json:"secret_key_url"`. Do NOT use `omitempty` on any slice — FR-009 requires `[]`-not-omitted even when empty. Do NOT change struct field shape. Verify with `go build ./...` + `go vet ./...` after the change.
+- [X] T016 [US2] Update `cmd/deploy.go` to branch on `outputMode(cmd)`:
+
+  (a) **Text-mode path (default)**: keep `printDeploy(cmd, res, flagApply); return deployErr` exactly as today — no change.
+
+  (b) **JSON-mode path**: do NOT call `printDeploy` (suppresses stdout tabwriter per FR-003). Instead:
+
+  1. Build `var warnings []fleet.Diagnostic`. If `res != nil && res.MissingSecret != ""`, call `emitDeployWarnings(res)` (existing zerolog stderr emission — unchanged, satisfies FR-011 stderr half) AND append `fleet.Diagnostic{Code: fleet.DiagMissingSecret, Message: <reconstruct the same text `emitDeployWarnings` builds at cmd/deploy.go:113–118>, Fields: map[string]any{"secret": res.MissingSecret, "url": res.SecretKeyURL}}` to `warnings` (envelope half of dual-emission). Consider factoring the message-construction out of `emitDeployWarnings` into a helper `buildMissingSecretMessage(res) string` so both paths share the exact text.
+  2. Build `var hints []fleet.Diagnostic`. If `res != nil && len(res.Failed) > 0`, construct `errs := make([]string, 0, len(res.Failed))` and populate from each `WorkflowOutcome.Error` field (matches cmd/deploy.go:84–88 existing text-mode pattern — this is the concrete hint source for deploy), then call `rawHints := fleet.CollectHints(errs...)` + `emitHints(res.Repo, rawHints)` (existing stderr emission — unchanged), then assign `hints = fleet.CollectHintDiagnostics(errs...)` (envelope half). Do NOT print `hint: ...` lines to stdout — those are text-mode-only tabwriter content.
+  3. On success (`deployErr == nil`): return `writeEnvelope(cmd, "deploy", repo, flagApply, res, warnings, hints)`.
+  4. On failure with a result (`res != nil && deployErr != nil`): `writeEnvelope(cmd, "deploy", repo, flagApply, res, warnings, hints)` — `result` is non-null because `Deploy` returned partial state; then `return deployErr` for the non-zero exit.
+  5. On pre-result failure (`res == nil && deployErr != nil`): `writeEnvelope(cmd, "deploy", repo, flagApply, nil, nil, []fleet.Diagnostic{{Code: fleet.DiagHint, Message: deployErr.Error(), Fields: map[string]any{"hint": deployErr.Error()}}})` (FR-020); then `return deployErr`.
+  6. Exit-code parity (FR-021): every return path returns the unwrapped `deployErr`, which is the same value the text-mode path returns.
+
+  Tests T014 MUST pass after this task.
+
+**Checkpoint**: After this phase, `deploy -o json` emits structured output including warnings. Quickstart step 2 passes. US3 (sync + upgrade) can proceed.
+
+---
+
+## Phase 5: User Story 3 - Structured `sync` and `upgrade` output (Priority: P3)
+
+**Goal**: `sync -o json` and `upgrade -o json` emit envelopes with full result structs; `upgrade --all -o json` emits NDJSON (one envelope per line per repo, streaming per-repo); `audit_json` nests as a native JSON object (not escape-encoded).
+
+**Independent Test**: Run quickstart.md steps 3, 4, 5 (sync, upgrade single, upgrade --all NDJSON). Verify `jq '.result.drift | type'` returns `"array"` on a sync with no drift. Verify `jq '.result.audit_json | type'` returns `"object"` on a successful upgrade (not `"string"`). Verify `upgrade --all -o json 2>/dev/null | wc -l` equals the repo count.
+
+### Tests for User Story 3 ⚠️
+
+- [X] T017 [P] [US3] Write failing tests in `cmd/output_test.go` for sync: (a) `TestSyncEnvelope_EmptyArrays` — `SyncResult{Repo: "x/y"}` zero-value, assert `.result.missing`, `.result.drift`, `.result.expected`, `.result.pruned` all serialize as `[]`; (b) `TestSyncEnvelope_NilDeployFields` — `SyncResult{Deploy: nil, DeployPreflight: nil}`, assert `.result.deploy == null` and `.result.deploy_preflight == null` (pointer-nil semantics per data-model.md Entity 5); (c) `TestSyncEnvelope_NestedDeployPreflight` — `SyncResult{DeployPreflight: &DeployResult{Repo: "x/y", Added: []WorkflowOutcome{{Name: "foo"}}}}`, assert `.result.deploy_preflight.added[0].name == "foo"` — confirms nested struct serializes through; (d) `TestSyncEnvelope_DriftDiagnostic` — build a warnings slice with `Diagnostic{Code: DiagDriftDetected, Fields: map[string]any{"drift": []string{"orphan"}}}`, assert the envelope `.warnings[0].fields.drift` is the JSON array `["orphan"]` (not `"[orphan]"` string).
+- [X] T018 [P] [US3] Write failing tests in `cmd/output_test.go` for upgrade: (a) `TestUpgradeEnvelope_EmptyArrays` — `UpgradeResult{Repo: "x/y"}` zero-value, assert `.result.changed_files` and `.result.conflicts` are `[]`; (b) `TestEnvelope_AuditJSONNests` — construct `UpgradeResult{AuditJSON: json.RawMessage(\`{"version":"1","findings":[]}\`)}`, marshal via `writeEnvelopeTo`, parse the output, assert `result.audit_json` is a JSON object (use `json.RawMessage` destination and `json.Unmarshal` re-parse into `map[string]any`), NOT a string — per `contracts/envelope.md` and research.md R1; (c) `TestUpgradeEnvelope_AuditJSONNil` — when `AuditJSON` is nil, `.result.audit_json == null` (stdlib default for nil RawMessage).
+- [X] T019 [P] [US3] Write failing tests for NDJSON mode in `cmd/output_test.go` (per `contracts/ndjson.md` test matrix): (a) `TestUpgradeAll_NDJSONLineCount` — stub `fleet.Upgrade` (or factor the per-repo emission into an extractable helper that takes pre-built results) to yield 3 synthetic `UpgradeResult` values; capture stdout, assert exactly 3 lines, each terminated by `\n`, no trailing blank line; (b) `TestUpgradeAll_PerLineSelfContained` — parse each line independently with `json.Unmarshal` into `cmd.Envelope`; assert each has distinct `repo` and `command == "upgrade"`; (c) `TestUpgradeAll_ErrorRepoIncluded` — one of the three synthetic results is `nil` + an error; assert that repo's line has `result: null` and a populated `hints[]`, while the other two lines are unaffected; (d) `TestUpgradeAll_EmptyFleet` — zero repos, assert stdout is exactly empty (0 bytes, 0 lines), exit code 0.
+
+### Implementation for User Story 3
+
+- [X] T020 [US3] Add JSON tags to `SyncResult` in `internal/fleet/sync.go` per data-model.md Entity 5: `Repo` → `json:"repo"`, `CloneDir` → `json:"clone_dir"`, `Missing` → `json:"missing"`, `Drift` → `json:"drift"`, `Expected` → `json:"expected"`, `Deploy` → `json:"deploy"` (pointer — stays nullable via stdlib default), `Pruned` → `json:"pruned"`, `DeployPreflight` → `json:"deploy_preflight"`. No `omitempty` on slice fields. No struct-shape change. Tests T017(a)-(c) for serialization MUST pass.
+- [X] T021 [US3] Add JSON tags to `UpgradeResult` in `internal/fleet/upgrade.go` per data-model.md Entity 6: `Repo` → `json:"repo"`, `CloneDir` → `json:"clone_dir"`, `UpgradeOK` → `json:"upgrade_ok"`, `UpdateOK` → `json:"update_ok"`, `ChangedFiles` → `json:"changed_files"`, `Conflicts` → `json:"conflicts"`, `NoChanges` → `json:"no_changes"`, `BranchPushed` → `json:"branch_pushed"`, `PRURL` → `json:"pr_url"`, `AuditJSON` → `json:"audit_json"` (keep the `json.RawMessage` type — research.md R1 confirms native nested-object semantics), `OutputLog` → `json:"output_log"`. Tests T018 MUST pass.
+- [X] T022 [US3] Update `cmd/sync.go` to branch on `outputMode(cmd)`:
+
+  (a) **Text-mode path (default)**: keep `printSync(cmd, res, flagApply, flagPrune); return syncErr` exactly as today — no change.
+
+  (b) **JSON-mode path**: do NOT call `printSync`. Instead:
+
+  1. Build `var warnings []fleet.Diagnostic`. If `res != nil && len(res.Drift) > 0`, call `emitSyncWarnings(res)` (existing zerolog stderr emission — unchanged) AND append `fleet.Diagnostic{Code: fleet.DiagDriftDetected, Message: "Drift detected: workflows on disk not declared in fleet.json" (match cmd/sync.go:95 verbatim), Fields: map[string]any{"drift": res.Drift}}`.
+  2. Build `var hints []fleet.Diagnostic` from `res.DeployPreflight.Failed` error strings — this is the ONLY sync-side hint source in current text-mode (see `printSyncPreflight` at cmd/sync.go:140–155). If `res != nil && res.DeployPreflight != nil && len(res.DeployPreflight.Failed) > 0`, construct `errs := make([]string, 0, len(res.DeployPreflight.Failed))` from each `WorkflowOutcome.Error`, then `rawHints := fleet.CollectHints(errs...)` + `emitHints(res.Repo, rawHints)` (existing stderr emission), then `hints = fleet.CollectHintDiagnostics(errs...)`. **Important — FR-014 parity**: `res.Deploy.Failed` (from actual apply) is NOT a hint source today (`printSyncDeploy` at cmd/sync.go:129–138 prints counts only, not failure details). JSON mode MUST mirror this — do NOT add `res.Deploy.Failed` as an additional hint source, even though it's technically available. Widening the hint surface is a separate feature that would affect text mode too.
+  3. On success (`syncErr == nil`): return `writeEnvelope(cmd, "sync", repo, flagApply, res, warnings, hints)`.
+  4. On failure with a result (`res != nil && syncErr != nil`): `writeEnvelope(cmd, "sync", repo, flagApply, res, warnings, hints)`; then `return syncErr`.
+  5. On pre-result failure (`res == nil && syncErr != nil`): `writeEnvelope(cmd, "sync", repo, flagApply, nil, nil, []fleet.Diagnostic{{Code: fleet.DiagHint, Message: syncErr.Error(), Fields: map[string]any{"hint": syncErr.Error()}}})` (FR-020); then `return syncErr`.
+  6. Exit-code parity (FR-021): every return path returns the unwrapped `syncErr`, matching text mode.
+
+  Tests T017(d) + quickstart §3 MUST pass.
+- [X] T023 [US3] Update `cmd/upgrade.go`: branch on `outputMode(cmd)`. (a) Single-repo path (positional arg form): after `res, err := fleet.Upgrade(...)`, emit `writeEnvelope(cmd, "upgrade", repo, opts.Apply, res, warnings, fleet.CollectHintDiagnostics(res.OutputLog))` on success. On error (pre-result failure), emit `writeEnvelope(..., nil, nil, []fleet.Diagnostic{{Code: DiagHint, Message: err.Error(), Fields: ...}})` and return the error. (b) `--all` path: keep the existing per-repo loop; inside the loop, after each `fleet.Upgrade` returns, call `writeEnvelope(...)` once per repo — this emits the NDJSON line (one envelope + one `\n` from `json.Encoder.Encode`). Do NOT accumulate results into a slice and batch-encode — streaming is explicit per `contracts/ndjson.md`. Error in the middle of the loop: emit the envelope for that repo with `result: null` + diagnostics, then CONTINUE to the next repo (do NOT short-circuit — preserves existing text-mode behavior per FR-014). Capture the worst exit code from all per-repo outcomes (same as text mode today). Tests T018 + T019 MUST pass. Quickstart steps 4 and 5 MUST pass.
+
+**Checkpoint**: All four commands support `-o json`. All three user stories are independently testable. Quickstart steps 1–8 all pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation updates, regression tests, and the final local gate that certifies the feature as done.
+
+- [X] T024 [P] Add `TestEnvelope_NoNullSlices_AllResultTypes` to `cmd/output_test.go`: a table-driven test iterating over zero-value instances of `fleet.ListResult`, `fleet.DeployResult`, `fleet.SyncResult`, `fleet.UpgradeResult` — for each, pass through `writeEnvelopeTo`, parse the output, and use reflection to walk the result struct's fields: for every `reflect.Slice` field (recursively), assert the JSON value is an array (not null). Catches future regressions where a new slice field is added without `initSlices` coverage.
+- [X] T025 [P] Add `TestEnvelope_SchemaVersionConstant` to `cmd/output_test.go`: assert `cmd.SchemaVersion == 1`. Trivial but pins the contract against accidental bumps during refactor.
+- [X] T026 [P] Update `CHANGELOG.md` with a `### Added` entry under the next release heading: `- CLI --output / -o flag with values text (default) and json. JSON mode emits a versioned envelope (schema_version: 1) on stdout for list, deploy, sync, upgrade; upgrade --all emits NDJSON. See specs/003-cli-output-json/quickstart.md.` Also add a new top-level section `### JSON envelope schema` documenting that schema_version 1 is the current contract and linking to `specs/003-cli-output-json/contracts/envelope.md` for the per-field detail.
+- [X] T027 [P] Update `skills/fleet-deploy/SKILL.md`, `skills/fleet-eval-templates/SKILL.md`, `skills/fleet-upgrade-review/SKILL.md`, `skills/fleet-onboard-repo/SKILL.md` with a one-line note under each skill's "Debugging" or "Extended usage" section (create the section if absent): `For machine-readable output, pass -o json on list/deploy/sync/upgrade. See specs/003-cli-output-json/quickstart.md.` Do NOT modify the three-turn pattern or any approval-gated wording.
+- [X] T028 Post-implementation text-mode byte-identity verification (FR-014, SC-003). Run each command without `--output` (default text) and diff against the T002 baseline: `diff /tmp/list-text-before.txt <(go run . list 2>/dev/null)`; same for `deploy`, `sync`, `upgrade` against their respective baselines. Every diff MUST be empty. If any diff has content, inspect whether the drift is intentional (e.g., a new stderr line accidentally landing on stdout in one of the phases) and fix it in the corresponding cmd/*.go file before declaring the feature complete.
+- [X] T029 Run quickstart.md end-to-end against a real fleet (`rshade/gh-aw-fleet` from `fleet.json` is sufficient for all 8 numbered sections). Each section's expected output must match. Sections of particular importance: §1 (`list -o json | jq`), §5 (NDJSON line count for `upgrade --all`), §6 (error envelope for non-existent repo), §7 (invalid flag error), §8 (text-mode byte-identity; this overlaps with T028 but runs as a user-flow check). Record any failures as bugs to fix before declaring done.
+- [X] T030 Verify `go mod graph | sort > /tmp/gomod-003-after.txt; diff /tmp/gomod-003-before.txt /tmp/gomod-003-after.txt` is empty (FR-018, SC-008). Zero new dependencies. If the diff is non-empty, something imported a package it shouldn't have (only stdlib + existing modules are permitted) — back out the offending import.
+- [X] T031 Run the full local CI gate: `make ci` (runs `fmt-check`, `vet`, `lint`, `test`). This MUST pass before the feature is reported done (user feedback memory `feedback_local_gate.md` — `go build` / `go vet` alone are not sufficient; CI runs stricter checks). If `make lint` takes >5 minutes, that's expected (CLAUDE.md note) — do not kill the run.
+
+**Feature complete** when T001–T031 all checked off, `make ci` green, quickstart.md verified end-to-end, no CHANGELOG drift, no byte-identity regressions in text mode.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — T001 and T002 capture baselines before any code changes.
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories. Must complete T003–T008 before any US1/US2/US3 work.
+- **User Story 1 (Phase 3)**: Depends on Foundational. T009–T013 can then proceed.
+- **User Story 2 (Phase 4)**: Depends on Foundational. Can run in parallel with US1 (different files: `cmd/deploy.go` vs `cmd/list.go` + `internal/fleet/list_result.go`) if staffed, or sequential after US1 for incremental delivery.
+- **User Story 3 (Phase 5)**: Depends on Foundational. Can run in parallel with US1 and US2 (different files: `cmd/sync.go`, `cmd/upgrade.go`, `internal/fleet/sync.go`, `internal/fleet/upgrade.go`) if staffed.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete. T024–T031 are the close-out.
+
+### User Story Dependencies
+
+- **User Story 1 (P1 MVP)**: No dependencies on other stories. Ships independently.
+- **User Story 2 (P2)**: No code dependencies on US1 — the two stories touch disjoint command files. Shares the foundational layer (`writeEnvelope`, `Diagnostic`, etc.).
+- **User Story 3 (P3)**: No code dependencies on US1 or US2 at the command level. `WorkflowOutcome` JSON tags (T006 in Foundational) ARE a shared prerequisite because `SyncResult.Deploy` nests `DeployResult` which nests `WorkflowOutcome` — hence T006's placement in Phase 2, not US2.
+
+### Within Each User Story
+
+- Tests come BEFORE implementation (TDD — tests must fail, then implementation makes them pass).
+- Types/structs come before consumers (e.g., T011 `ListResult` type before T012 `list.go` consumer).
+- Tags on existing structs (T015, T020, T021) come before command branches (T016, T022, T023).
+
+### Parallel Opportunities
+
+- **Phase 2**: T003 and T004 can run in parallel (different files). T006 is a single-file edit that can run at any point in Phase 2 before T007 (no ordering dependency). T005 depends on T003's failing tests; T007 depends on T004's failing tests and T005's Diagnostic type; T008 depends on T007's `validateOutputMode`.
+- **Phase 3 (US1)**: T009 and T010 can run in parallel (different test files). T011 depends on both sets of failing tests and unblocks T012. T013 is a disjoint-file task that can run any time after T007.
+- **Phase 4 (US2)**: T014 is the only test task (all in `cmd/output_test.go`); T015 and T016 are sequential (tag the struct, then wire the command).
+- **Phase 5 (US3)**: T017, T018, T019 can all run in parallel (distinct test cases in `cmd/output_test.go`). T020 and T021 can run in parallel (different files). T022 and T023 can run in parallel (different command files) — both depend on T020 and T021 respectively.
+- **Phase 6 (Polish)**: T024, T025, T026, T027 all parallelizable (distinct files). T028 and T029 are manual verification steps — can interleave. T030 is a single command. T031 is the final gate.
+
+---
+
+## Parallel Example: Foundational Phase (Phase 2)
+
+```bash
+# Launch two TDD test tasks together:
+Task: "Write failing tests in internal/fleet/diagnostics_test.go per T003"
+Task: "Write failing tests in cmd/output_test.go per T004"
+
+# T006 can also run in parallel (single-file edit on internal/fleet/deploy.go, no dep on T003/T004):
+Task: "Add json:\"...\" tags to WorkflowOutcome in internal/fleet/deploy.go per T006"
+
+# Then T005, T007, T008 sequentially (each depends on the previous).
+```
+
+## Parallel Example: User Story 3 Phase
+
+```bash
+# Launch all three TDD test tasks together:
+Task: "Write failing sync tests in cmd/output_test.go per T017"
+Task: "Write failing upgrade single-repo tests in cmd/output_test.go per T018"
+Task: "Write failing upgrade --all NDJSON tests in cmd/output_test.go per T019"
+
+# Then launch the two tag-adding tasks in parallel:
+Task: "Add JSON tags to SyncResult per T020"
+Task: "Add JSON tags to UpgradeResult per T021"
+
+# Then launch the two command-branch tasks in parallel:
+Task: "Update cmd/sync.go JSON branch per T022"
+Task: "Update cmd/upgrade.go JSON branch per T023"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001, T002 — just baselines).
+2. Complete Phase 2: Foundational (T003–T008 — shared types, helpers, flag). **CRITICAL — blocks all stories.**
+3. Complete Phase 3: User Story 1 (T009–T013).
+4. **STOP and VALIDATE**: quickstart §1 (`list -o json`) and §8 (text byte-identity) pass. `make ci` green.
+5. **Deploy/demo**: MVP shipped. Agents can consume `gh-aw-fleet list -o json`.
+
+### Incremental Delivery
+
+1. Setup + Foundational (Phases 1+2) → foundation ready.
+2. US1 → `list -o json` works → MVP demoable.
+3. US2 → `deploy -o json` works with warnings → expanded coverage.
+4. US3 → `sync -o json`, `upgrade -o json`, `upgrade --all -o json` NDJSON → full coverage.
+5. Polish (Phase 6) → release-ready.
+
+Each story increment can merge independently. Text-mode byte-identity (FR-014) means zero risk to existing text-mode consumers at any increment.
+
+### Parallel Team Strategy
+
+With multiple developers (after Phase 2 completes):
+
+1. Developer A: US1 (list + list_result + subcommand rejection)
+2. Developer B: US2 (DeployResult tags + deploy command)
+3. Developer C: US3 (SyncResult + UpgradeResult + NDJSON — the most involved phase)
+
+No file conflicts: the commands and types are disjoint. Shared test file `cmd/output_test.go` requires light coordination (distinct test-function names per phase; conventional Go test naming avoids conflicts).
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on uncommitted work.
+- [Story] label maps task to specific user story for traceability.
+- Each user story is independently completable and testable.
+- TDD discipline: verify tests fail before implementing (`go test ./cmd/ -run TestOutputFlag` must fail before T008; then pass after).
+- Commit after each task or logical group (per repo convention: Conventional Commits, scope `cli` or `output`; e.g., `feat(cli): add --output flag and JSON envelope writer`).
+- Stop at any Phase 3/4/5 checkpoint to validate story independently.
+- Avoid: vague tasks, cross-story file conflicts (none expected by design), skipping T028–T031 gate (non-negotiable per user memory `feedback_local_gate.md`).


### PR DESCRIPTION
## Summary

- New persistent `-o, --output` root flag (`text` default, `json`); rejects any other value before subcommand RunE fires
- JSON mode emits a single versioned envelope on stdout per invocation (`upgrade --all` emits NDJSON, one envelope per repo) with stable top-level keys: `schema_version`, `command`, `repo`, `apply`, `result`, `warnings`, `hints`
- Warnings (missing-secret, drift) and hints from the existing diagnostics layer dual-emit: structured entries in the envelope on stdout, zerolog events on stderr — humans tailing the run still see them live
- `template fetch`, `add`, and `status` reject `-o json` with a clear error rather than silently falling back to text
- Text mode (default) is byte-identical to pre-feature behavior; the only diff in `deploy`/`sync`/`upgrade` baselines is the random `/tmp/gh-aw-fleet-*` clone path, which was already non-deterministic
- Zero new dependencies — verified by `go mod graph` diff

## Test plan

- [x] `make ci` passes (fmt-check, vet, golangci-lint, full test suite)
- [x] 35+ new tests across `cmd/output_test.go`, `internal/fleet/diagnostics_test.go`, `internal/fleet/list_result_test.go`
- [x] Live verification on real fleet: `go run . list -o json | jq -e .schema_version` returns `1`; `go run . deploy rshade/gh-aw-fleet -o json` emits envelope with `missing_secret` warning; `go run . upgrade rshade/gh-aw-fleet -o json` emits envelope with `audit_json: null` and populated `changed_files`
- [x] `go mod graph` diff before/after is empty
- [x] Text-mode `list` output byte-identical to pre-feature baseline
- [x] Top-level envelope keys pinned by `TestEnvelope_TopLevelKeysPinned`
- [x] Empty slices marshal as `[]` for every result type via reflection-based regression test
- [ ] Live `--apply` against a real fleet repo with `-o json` — to be validated by the operator during a real deploy cycle

## Changes

### New files

- `cmd/output.go` — `Envelope`, `Diagnostic` constants, `writeEnvelope` / `writeEnvelopeTo`, `outputMode`, `validateOutputMode`, `rejectJSONMode`, `preResultFailureEnvelope`, `initSlices` reflection walker
- `cmd/output_test.go` — envelope shape, schema-version pin, flag validator, empty-array invariant, NDJSON line semantics, audit_json nesting, no-null-slices regression for all result types
- `internal/fleet/list_result.go` — `ListResult`, `ListRow`, `BuildListResult`
- `internal/fleet/list_result_test.go` — shape, empty config, engine-empty-not-dash
- `internal/fleet/diagnostics_test.go` — Diagnostic JSON shape, Hint codes snake_case, `CollectHintDiagnostics` dedup and non-nil-empty semantics
- `specs/003-cli-output-json/` — spec artifacts (plan, research, data model, quickstart, contracts, tasks, checklists)

### Modified files

- `cmd/root.go` — registers `--output` persistent flag; chains `validateOutputMode` into `PersistentPreRunE` after log-flag validation
- `cmd/list.go` — branches on `outputMode`; routes breadcrumb through `cmd.ErrOrStderr()` so JSON mode keeps stdout pure
- `cmd/deploy.go` — JSON branch; `emitDeployEnvelope` dual-emits warnings via factored `buildMissingSecretMessage` so envelope and zerolog text stay in sync
- `cmd/sync.go` — JSON branch; `emitSyncEnvelope` for drift and preflight diagnostics; preserves text-mode hint surface (DeployPreflight only)
- `cmd/upgrade.go` — JSON branch on single-repo path; `runUpgradeAllJSON` emits NDJSON streaming per-repo for `--all`; extracted `validateUpgradeArgs` / `runUpgradeAll` / `runUpgradeSingle` helpers to keep `RunE` readable
- `cmd/template.go`, `cmd/add.go`, `cmd/stubs.go` — reject `-o json` at top of RunE (FR-013)
- `internal/fleet/deploy.go` — JSON tags on `DeployResult` and `WorkflowOutcome`
- `internal/fleet/sync.go` — JSON tags on `SyncResult`
- `internal/fleet/upgrade.go` — JSON tags on `UpgradeResult`; `audit_json` is a `json.RawMessage` that nests as a native object (not a quoted string)
- `internal/fleet/diagnostics.go` — `Diagnostic` struct, stable code constants, `Code` field on `Hint`, parallel `CollectHintDiagnostics`
- `CHANGELOG.md` — Unreleased Added entry plus `### JSON envelope schema` section documenting the schema_version 1 contract
- `skills/fleet-deploy/SKILL.md`, `skills/fleet-eval-templates/SKILL.md`, `skills/fleet-upgrade-review/SKILL.md`, `skills/fleet-onboard-repo/SKILL.md` — one-line note that `-o json` is available; three-turn pattern unchanged

### Bug fixes surfaced during implementation

- `initSlices` was converting nil `json.RawMessage` (which is `[]byte`) to empty `[]byte{}`, causing `MarshalJSON` to fail with "unexpected end of JSON input" on every `upgrade -o json` invocation; fixed by skipping `[]byte` element kinds in the reflection walker
- `cmd/list.go` used `cmd.OutOrStderr()` for the breadcrumb, which despite the name returns the OUT writer (cobra naming quirk); switched to `cmd.ErrOrStderr()` so JSON-mode tests with `SetOut` don't leak the breadcrumb into the stdout buffer (production behavior unchanged)

Closes #25