### PR TITLE
fix(cli): name both config files in untracked-repo error

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -33,7 +33,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
+				notTrackedErr := fleet.ErrRepoNotTracked(repo, cfg.LoadedFrom)
 				if jsonMode {
 					return preResultFailureEnvelope(cmd, "deploy", repo, flagApply, notTrackedErr)
 				}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	logpkg "github.com/rshade/gh-aw-fleet/internal/log"
+	"github.com/rshade/gh-aw-fleet/internal/testutil"
+)
+
+// TestRootSilenceFlagsSet pins the two cobra silence flags on NewRootCmd.
+// Issue #30: errors double-printed because cobra and main.go both wrote.
+// SilenceErrors=true makes main.go the single error surface; SilenceUsage=true
+// keeps help text out of error output. Flipping either regresses the fix.
+func TestRootSilenceFlagsSet(t *testing.T) {
+	root := NewRootCmd()
+	if !root.SilenceErrors {
+		t.Error("root.SilenceErrors = false; want true (see issue #30 — main.go owns error output)")
+	}
+	if !root.SilenceUsage {
+		t.Error("root.SilenceUsage = false; want true")
+	}
+}
+
+// TestRootExecuteKeepsCobraErrorOffStderr verifies the behavioral effect of
+// SilenceErrors: when a subcommand returns an error, cobra must not write to
+// stderr, and Execute must return the error unchanged so main.go can print it.
+func TestRootExecuteKeepsCobraErrorOffStderr(t *testing.T) {
+	sentinel := errors.New("sentinel-root-test-failure")
+
+	root := NewRootCmd()
+	root.AddCommand(&cobra.Command{
+		Use: "__test_fail__",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return sentinel
+		},
+	})
+	root.SetArgs([]string{"__test_fail__"})
+
+	t.Cleanup(func() {
+		// CaptureStderr swaps os.Stderr and PersistentPreRunE reconfigures the
+		// global logger against it; restore a live sink for downstream tests.
+		_ = logpkg.Configure("info", "console")
+	})
+
+	var execErr error
+	stderr := testutil.CaptureStderr(t, func() {
+		execErr = root.Execute()
+	})
+
+	if !errors.Is(execErr, sentinel) {
+		t.Fatalf("Execute() = %v; want sentinel %v", execErr, sentinel)
+	}
+	if strings.Contains(stderr, sentinel.Error()) {
+		t.Errorf("cobra wrote error message to stderr (want silent); stderr=%q", stderr)
+	}
+	if strings.Contains(stderr, "Error:") {
+		t.Errorf("cobra's 'Error:' prefix appeared on stderr — SilenceErrors regressed; stderr=%q", stderr)
+	}
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -41,7 +41,7 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 				return err
 			}
 			if _, ok := cfg.Repos[repo]; !ok {
-				notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
+				notTrackedErr := fleet.ErrRepoNotTracked(repo, cfg.LoadedFrom)
 				if jsonMode {
 					return preResultFailureEnvelope(cmd, "sync", repo, flagApply, notTrackedErr)
 				}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -198,7 +198,7 @@ func runUpgradeSingle(
 	cmd *cobra.Command, cfg *fleet.Config, repo string, opts fleet.UpgradeOpts, apply, jsonMode bool,
 ) error {
 	if _, ok := cfg.Repos[repo]; !ok {
-		notTrackedErr := fmt.Errorf("repo %q not tracked in %s", repo, cfg.LoadedFrom)
+		notTrackedErr := fleet.ErrRepoNotTracked(repo, cfg.LoadedFrom)
 		if jsonMode {
 			return preResultFailureEnvelope(cmd, "upgrade", repo, apply, notTrackedErr)
 		}

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -1,0 +1,47 @@
+package fleet
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ErrRepoNotTracked returns a consistent error message for a repo that is not
+// present in the loaded config. The message names the file(s) actually loaded
+// so operators know whether to edit fleet.json, fleet.local.json, or both.
+func ErrRepoNotTracked(repo, loadedFrom string) error {
+	baseSource, localSource := parseLoadedSources(loadedFrom)
+
+	switch {
+	case baseSource != "" && localSource == "":
+		return fmt.Errorf("repo %q not tracked in %s", repo, baseSource)
+	case localSource != "" && baseSource == "":
+		return fmt.Errorf("repo %q not tracked in %s", repo, localSource)
+	default:
+		if baseSource == "" {
+			baseSource = ConfigFile
+		}
+		if localSource == "" {
+			localSource = LocalConfigFile
+		}
+		return fmt.Errorf("repo %q not tracked in %s or %s", repo, baseSource, localSource)
+	}
+}
+
+// parseLoadedSources inspects the LoadedFrom string (e.g. "/tmp/fleet.json",
+// "/tmp/fleet.local.json", or "/tmp/fleet.json + /tmp/fleet.local.json") and
+// returns the original source path for each recognized config file.
+func parseLoadedSources(loadedFrom string) (string, string) {
+	var base, local string
+	parts := strings.Split(loadedFrom, " + ")
+	for _, p := range parts {
+		source := strings.TrimSpace(p)
+		switch filepath.Base(source) {
+		case ConfigFile:
+			base = source
+		case LocalConfigFile:
+			local = source
+		}
+	}
+	return base, local
+}

--- a/internal/fleet/errors_test.go
+++ b/internal/fleet/errors_test.go
@@ -1,0 +1,59 @@
+package fleet
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrRepoNotTracked(t *testing.T) {
+	tests := []struct {
+		name       string
+		loadedFrom string
+		want       string
+	}{
+		{
+			name:       "base only",
+			loadedFrom: ConfigFile,
+			want:       `repo "owner/repo" not tracked in fleet.json`,
+		},
+		{
+			name:       "local only",
+			loadedFrom: LocalConfigFile,
+			want:       `repo "owner/repo" not tracked in fleet.local.json`,
+		},
+		{
+			name:       "both loaded",
+			loadedFrom: fmt.Sprintf("%s + %s", ConfigFile, LocalConfigFile),
+			want:       `repo "owner/repo" not tracked in fleet.json or fleet.local.json`,
+		},
+		{
+			name:       "base only with path",
+			loadedFrom: "/some/dir/fleet.json",
+			want:       `repo "owner/repo" not tracked in /some/dir/fleet.json`,
+		},
+		{
+			name:       "local only with path",
+			loadedFrom: "/some/dir/fleet.local.json",
+			want:       `repo "owner/repo" not tracked in /some/dir/fleet.local.json`,
+		},
+		{
+			name:       "both with paths",
+			loadedFrom: "/some/dir/fleet.json + /some/dir/fleet.local.json",
+			want:       `repo "owner/repo" not tracked in /some/dir/fleet.json or /some/dir/fleet.local.json`,
+		},
+		{
+			name:       "empty loadedFrom defaults to both",
+			loadedFrom: "",
+			want:       `repo "owner/repo" not tracked in fleet.json or fleet.local.json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ErrRepoNotTracked("owner/repo", tt.loadedFrom)
+			if got := err.Error(); got != tt.want {
+				t.Errorf("ErrRepoNotTracked() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Error surfaces from `deploy`, `sync`, and `upgrade` now name the config file(s) actually loaded (`fleet.json`, `fleet.local.json`, or both) instead of always pointing at `fleet.json`. Operators who keep real fleet state in `fleet.local.json` no longer get misdirected to the public-example file.
- Extracts a single `fleet.ErrRepoNotTracked(repo, loadedFrom)` helper and replaces three duplicated `fmt.Errorf` call sites — one source of truth for the wording.
- Adds regression-test coverage for the already-shipped issue #30 fix (`SilenceErrors: true` on root) so cobra can't silently start double-printing errors again.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/fleet/ -run TestErrRepoNotTracked` passes the seven-case table (base-only, local-only, both, each with absolute paths, plus empty `LoadedFrom`)
- [x] `go test ./cmd/ -run TestRoot` passes — both the field-level pin on `SilenceErrors`/`SilenceUsage` and the behavioral pin that captures stderr during `Execute()`
- [ ] `make ci` (fmt-check + vet + lint + test) — run before merge

## Changes

### New files

- `internal/fleet/errors.go` — `ErrRepoNotTracked` helper plus `parseLoadedFrom`, which uses `filepath.Base` so it handles directory-qualified `LoadedFrom` values like `/some/dir/fleet.json + /some/dir/fleet.local.json`.
- `internal/fleet/errors_test.go` — table-driven coverage of the three `LoadedFrom` states, path variants, and the empty-string fallback.
- `cmd/root_test.go` — two regression tests for issue #30: `TestRootSilenceFlagsSet` asserts both `SilenceErrors` and `SilenceUsage` remain `true` on `NewRootCmd()`, and `TestRootExecuteKeepsCobraErrorOffStderr` injects a sentinel-returning subcommand and asserts cobra writes neither the error text nor its `Error:` prefix to stderr while still propagating the error to the caller so `main.go` can print it exactly once.

### Modified files

- `cmd/deploy.go` — call `fleet.ErrRepoNotTracked(repo, cfg.LoadedFrom)` instead of inline `fmt.Errorf`.
- `cmd/sync.go` — same call-site swap.
- `cmd/upgrade.go` — same call-site swap inside `runUpgradeSingle`.

Closes #31
Closes #30