### PR TITLE
feat(deploy): resume --work-dir at commit or push gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,13 @@ A workflow uses a feature that is in upstream `gh-aw` `main` but not yet in your
 
 ### Resuming after a partial failure
 
-The `--work-dir <path>` flag points `deploy` / `upgrade` / `sync` at an existing clone instead of cloning fresh. Use it with the `/tmp/gh-aw-fleet-*` directory preserved from a failed run to re-attempt without re-cloning. Note: `--work-dir` does not yet *resume* mid-pipeline state (see Known Limitations).
+The `--work-dir <path>` flag points `deploy` / `upgrade` / `sync` at an existing clone instead of cloning fresh. Use it with the `/tmp/gh-aw-fleet-*` directory preserved from a failed run to re-attempt without re-cloning.
+
+When `deploy --apply --work-dir <path>` is run against a preserved clone that has staged workflow changes, the tool resumes at the commit gate (skipping clone, `gh aw init`, and `gh aw add`). If the user manually committed after a GPG failure, the tool detects the unpushed commits and resumes at the push gate, proceeding directly to `git push` and `gh pr create`.
 
 ## Known Limitations & Roadmap
 
 - **`status` command not yet implemented.** Planned. Will diff desired (`fleet.json`) vs actual repo state.
-- **No `--work-dir` mid-pipeline resume.** The `--work-dir` flag re-uses an existing clone but doesn't resume from arbitrary mid-pipeline state. A full retry re-runs the pipeline from the start.
 - **Sync dry-run doesn't do deploy preflight.** `sync --dry-run` computes the diff but doesn't pre-validate that the workflows would deploy successfully.
 - **No GitHub extension packaging yet.** `gh-aw-fleet` is distributed as a standalone CLI (release binary, `go install`, or build from source — see [Install](#install)), not as a `gh` extension. Extension packaging is planned.
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -63,7 +63,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 	cmd.Flags().StringVar(&flagPRTitle, "pr-title", "",
 		"PR title (default: auto-generated)")
 	cmd.Flags().StringVar(&flagWorkDir, "work-dir", "",
-		"Existing clone to deploy into (skips git clone + auto-cleanup)")
+		"Existing clone to deploy into (skips git clone + auto-cleanup; resumes at commit/push gate if staged changes or unpushed commits exist)")
 	return cmd
 }
 

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -77,6 +77,10 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 		defer os.RemoveAll(res.CloneDir)
 	}
 
+	if opts.WorkDir != "" {
+		return handleWorkDirResume(ctx, cfg, repo, res, opts)
+	}
+
 	res.InitWasRun, err = ensureInit(ctx, res.CloneDir)
 	if err != nil {
 		return res, fmt.Errorf("gh aw init: %w", err)
@@ -98,7 +102,69 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 	if len(res.Added) == 0 && !staged {
 		return res, nil
 	}
-	return createDeployPR(ctx, res, repo, opts)
+	return createDeployPR(ctx, res, repo, opts, "")
+}
+
+// handleWorkDirResume processes the --work-dir resume flow: validate the clone,
+// then resume at the commit gate (staged changes) or push gate (unpushed
+// commits). Always returns a final result; never falls through to a fresh
+// deploy.
+func handleWorkDirResume(
+	ctx context.Context, cfg *Config, repo string, res *DeployResult, opts DeployOpts,
+) (*DeployResult, error) {
+	branch, err := gitCurrentBranch(ctx, res.CloneDir)
+	if err != nil {
+		return res, fmt.Errorf("work-dir %q is not a valid git repository: %w", opts.WorkDir, err)
+	}
+	if isDefaultBranch(branch) {
+		return res, fmt.Errorf(
+			"work-dir is on default branch %q; refusing to resume on a protected branch. "+
+				"Switch to the deploy branch or omit --work-dir for a fresh clone",
+			branch,
+		)
+	}
+	if opts.Branch != "" && opts.Branch != branch {
+		return res, fmt.Errorf(
+			"--branch %q conflicts with current branch %q in work-dir; "+
+				"omit --branch to resume on the existing branch",
+			opts.Branch, branch,
+		)
+	}
+
+	staged, err := hasStagedOrUnstagedWorkflowChanges(ctx, res.CloneDir)
+	if err != nil {
+		return res, err
+	}
+	if staged {
+		fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at commit gate)\n", opts.WorkDir)
+		engine := cfg.EffectiveEngine(repo)
+		res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
+		if !opts.Apply {
+			return res, nil
+		}
+		return createDeployPR(ctx, res, repo, opts, branch)
+	}
+
+	hasCommits, err := gitHasUnpushedCommits(ctx, res.CloneDir)
+	if err != nil {
+		return res, err
+	}
+	if hasCommits {
+		fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at push gate)\n", opts.WorkDir)
+		engine := cfg.EffectiveEngine(repo)
+		res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
+		if !opts.Apply {
+			return res, nil
+		}
+		return pushAndCreatePR(ctx, res, repo, opts, branch, nil)
+	}
+
+	return res, fmt.Errorf(
+		"work-dir %s has no staged/unstaged workflow changes and no unpushed commits; "+
+			"nothing to resume. Run without --work-dir for a fresh deploy, or verify "+
+			"the prior run left changes in this directory",
+		opts.WorkDir,
+	)
 }
 
 // addResolvedWorkflows runs `gh aw add` for each resolved workflow, populating
@@ -131,17 +197,28 @@ func addResolvedWorkflows(
 
 // createDeployPR branches, commits, pushes, and opens a PR for a deploy that
 // has pending workflow changes staged in res.CloneDir.
-func createDeployPR(ctx context.Context, res *DeployResult, repo string, opts DeployOpts) (*DeployResult, error) {
+// If resumeBranch is non-empty, the branch already exists and changes are staged.
+func createDeployPR(
+	ctx context.Context, res *DeployResult, repo string, opts DeployOpts, resumeBranch string,
+) (*DeployResult, error) {
 	branch := opts.Branch
 	if branch == "" {
-		branch = fmt.Sprintf("fleet/deploy-%s", time.Now().UTC().Format("2006-01-02-150405"))
+		if resumeBranch != "" {
+			branch = resumeBranch
+		} else {
+			branch = fmt.Sprintf("fleet/deploy-%s", time.Now().UTC().Format("2006-01-02-150405"))
+		}
 	}
-	if branchErr := gitCmd(ctx, res.CloneDir, "checkout", "-b", branch); branchErr != nil {
-		return res, fmt.Errorf("create branch: %w", branchErr)
+
+	if resumeBranch == "" {
+		if branchErr := gitCmd(ctx, res.CloneDir, "checkout", "-b", branch); branchErr != nil {
+			return res, fmt.Errorf("create branch: %w", branchErr)
+		}
+		if addErr := gitCmd(ctx, res.CloneDir, "add", ".github/"); addErr != nil {
+			return res, fmt.Errorf("git add: %w", addErr)
+		}
 	}
-	if addErr := gitCmd(ctx, res.CloneDir, "add", ".github/"); addErr != nil {
-		return res, fmt.Errorf("git add: %w", addErr)
-	}
+
 	stagedNames, err := stagedWorkflowNames(ctx, res.CloneDir)
 	if err != nil {
 		return res, fmt.Errorf("git diff --cached: %w", err)
@@ -149,24 +226,40 @@ func createDeployPR(ctx context.Context, res *DeployResult, repo string, opts De
 	msg := commitMessage(res, stagedNames)
 	if commitErr := gitCmdInteractive(ctx, res.CloneDir, "commit", "-m", msg); commitErr != nil {
 		return res, fmt.Errorf(
-			"git commit: %w\n\nTo finish manually:\n  cd %s\n  git commit -m %q\n  git push -u origin %s",
+			"git commit: %w\n\nTo finish manually:\n  cd %s\n"+
+				"  git commit -m \"$(cat <<'EOF'\n%s\nEOF\n)\"\n"+
+				"  git push -u origin %s",
 			commitErr, res.CloneDir, msg, branch,
 		)
 	}
+
+	return pushAndCreatePR(ctx, res, repo, opts, branch, stagedNames)
+}
+
+// pushAndCreatePR pushes the current branch to origin and opens a PR.
+func pushAndCreatePR(
+	ctx context.Context, res *DeployResult, repo string, opts DeployOpts,
+	branch string, stagedNames []string,
+) (*DeployResult, error) {
 	if pushErr := gitCmd(ctx, res.CloneDir, "push", "-u", "origin", branch); pushErr != nil {
 		return res, fmt.Errorf("git push: %w", pushErr)
 	}
 	res.BranchPushed = branch
 
+	addedCount := len(res.Added)
+	if addedCount == 0 {
+		addedCount = len(stagedNames)
+	}
+	if addedCount == 0 {
+		committed, _ := committedWorkflowNames(ctx, res.CloneDir)
+		addedCount = len(committed)
+	}
+
 	title := opts.PRTitle
 	if title == "" {
-		n := len(res.Added)
-		if n == 0 {
-			n = len(stagedNames)
-		}
-		title = fmt.Sprintf("ci(workflows): add %d agentic workflows via gh-aw-fleet", n)
+		title = fmt.Sprintf("ci(workflows): add %d agentic workflows via gh-aw-fleet", addedCount)
 	}
-	prURL, prErr := ghPRCreate(ctx, res.CloneDir, title, prBody(res, repo))
+	prURL, prErr := ghPRCreate(ctx, res.CloneDir, title, prBody(res, repo, addedCount))
 	if prErr != nil {
 		return res, fmt.Errorf("gh pr create: %w", prErr)
 	}
@@ -268,14 +361,61 @@ func stagedWorkflowNames(ctx context.Context, dir string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("git diff --cached: %w", err)
 	}
+	return filterWorkflowMarkdownNames(out), nil
+}
+
+// committedWorkflowNames returns the names (without .md) of workflow markdown
+// files in the most recent commit. Used as a fallback for PR title/body when
+// resuming after a manual commit.
+func committedWorkflowNames(ctx context.Context, dir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff-tree: %w", err)
+	}
+	return filterWorkflowMarkdownNames(out), nil
+}
+
+// filterWorkflowMarkdownNames extracts basenames (without .md) of paths under
+// .github/workflows/ from newline-delimited git output (one path per line).
+func filterWorkflowMarkdownNames(out []byte) []string {
 	var names []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, ".github/workflows/") && strings.HasSuffix(line, ".md") {
 			names = append(names, strings.TrimSuffix(filepath.Base(line), ".md"))
 		}
 	}
-	return names, nil
+	return names
+}
+
+// gitCurrentBranch returns the name of the current branch in dir.
+func gitCurrentBranch(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isDefaultBranch reports whether branch is a protected default branch name.
+func isDefaultBranch(branch string) bool {
+	return branch == "main" || branch == "master"
+}
+
+// gitHasUnpushedCommits reports whether the current HEAD has commits that are
+// not present on any remote branch.
+func gitHasUnpushedCommits(ctx context.Context, dir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "branch", "-r", "--contains", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git branch -r --contains HEAD: %w", err)
+	}
+	return len(strings.TrimSpace(string(out))) == 0, nil
 }
 
 // ghAPIExists returns true if `gh api <path>` returns success (exit 0).
@@ -358,11 +498,11 @@ func commitMessage(res *DeployResult, stagedFallback []string) string {
 	return fmt.Sprintf("%s\n\n%s", subject, body)
 }
 
-func prBody(res *DeployResult, repo string) string {
+func prBody(res *DeployResult, repo string, addedCount int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b,
 		"Deploys %d agentic workflows to `%s` via [gh-aw-fleet](https://github.com/rshade/gh-aw-fleet).\n\n",
-		len(res.Added), repo,
+		addedCount, repo,
 	)
 	if res.InitWasRun {
 		b.WriteString("This repo was not yet initialized for gh-aw; `gh aw init` was run as part of this PR.\n\n")

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -78,7 +78,12 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 	}
 
 	if opts.WorkDir != "" {
-		return handleWorkDirResume(ctx, cfg, repo, res, opts)
+		resumed, handled, resumeErr := handleWorkDirResume(ctx, cfg, repo, res, opts)
+		if handled {
+			return resumed, resumeErr
+		}
+		fmt.Fprintf(os.Stderr,
+			"(--work-dir %s has no resume signals; running fresh pipeline)\n", opts.WorkDir)
 	}
 
 	res.InitWasRun, err = ensureInit(ctx, res.CloneDir)
@@ -105,66 +110,69 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 	return createDeployPR(ctx, res, repo, opts, "")
 }
 
-// handleWorkDirResume processes the --work-dir resume flow: validate the clone,
-// then resume at the commit gate (staged changes) or push gate (unpushed
-// commits). Always returns a final result; never falls through to a fresh
-// deploy.
+// handleWorkDirResume tries to resume a prior --work-dir run at the commit
+// gate (staged .github/ changes) or push gate (unpushed commits). Returns
+// (result, handled, err): handled=true means the caller should return
+// immediately with (result, err); handled=false means no resume signals
+// were found and the caller should fall through to a fresh-pipeline deploy.
+// Resume-only safety checks (refuse-on-default-branch, conflicting --branch)
+// fire only when a resume action is about to occur, so a clean work-dir on
+// main can still be used as a fresh-clone target.
 func handleWorkDirResume(
 	ctx context.Context, cfg *Config, repo string, res *DeployResult, opts DeployOpts,
-) (*DeployResult, error) {
+) (*DeployResult, bool, error) {
 	branch, err := gitCurrentBranch(ctx, res.CloneDir)
 	if err != nil {
-		return res, fmt.Errorf("work-dir %q is not a valid git repository: %w", opts.WorkDir, err)
+		return res, true, fmt.Errorf("work-dir %q is not a valid git repository: %w", opts.WorkDir, err)
 	}
+
+	staged, err := hasStagedOrUnstagedWorkflowChanges(ctx, res.CloneDir)
+	if err != nil {
+		return res, true, err
+	}
+	hasCommits, err := gitHasUnpushedCommits(ctx, res.CloneDir)
+	if err != nil {
+		return res, true, err
+	}
+
+	if !staged && !hasCommits {
+		return res, false, nil
+	}
+
 	if isDefaultBranch(branch) {
-		return res, fmt.Errorf(
-			"work-dir is on default branch %q; refusing to resume on a protected branch. "+
-				"Switch to the deploy branch or omit --work-dir for a fresh clone",
+		return res, true, fmt.Errorf(
+			"work-dir is on default branch %q with pending changes; refusing to resume on a "+
+				"protected branch. Switch to the deploy branch or omit --work-dir for a fresh clone",
 			branch,
 		)
 	}
 	if opts.Branch != "" && opts.Branch != branch {
-		return res, fmt.Errorf(
+		return res, true, fmt.Errorf(
 			"--branch %q conflicts with current branch %q in work-dir; "+
 				"omit --branch to resume on the existing branch",
 			opts.Branch, branch,
 		)
 	}
 
-	staged, err := hasStagedOrUnstagedWorkflowChanges(ctx, res.CloneDir)
-	if err != nil {
-		return res, err
-	}
 	if staged {
 		fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at commit gate)\n", opts.WorkDir)
 		engine := cfg.EffectiveEngine(repo)
 		res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
 		if !opts.Apply {
-			return res, nil
+			return res, true, nil
 		}
-		return createDeployPR(ctx, res, repo, opts, branch)
+		out, prErr := createDeployPR(ctx, res, repo, opts, branch)
+		return out, true, prErr
 	}
 
-	hasCommits, err := gitHasUnpushedCommits(ctx, res.CloneDir)
-	if err != nil {
-		return res, err
+	fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at push gate)\n", opts.WorkDir)
+	engine := cfg.EffectiveEngine(repo)
+	res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
+	if !opts.Apply {
+		return res, true, nil
 	}
-	if hasCommits {
-		fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at push gate)\n", opts.WorkDir)
-		engine := cfg.EffectiveEngine(repo)
-		res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
-		if !opts.Apply {
-			return res, nil
-		}
-		return pushAndCreatePR(ctx, res, repo, opts, branch, nil)
-	}
-
-	return res, fmt.Errorf(
-		"work-dir %s has no staged/unstaged workflow changes and no unpushed commits; "+
-			"nothing to resume. Run without --work-dir for a fresh deploy, or verify "+
-			"the prior run left changes in this directory",
-		opts.WorkDir,
-	)
+	out, prErr := pushAndCreatePR(ctx, res, repo, opts, branch, nil)
+	return out, true, prErr
 }
 
 // addResolvedWorkflows runs `gh aw add` for each resolved workflow, populating
@@ -211,12 +219,11 @@ func createDeployPR(
 	}
 
 	if resumeBranch == "" {
-		if branchErr := gitCmd(ctx, res.CloneDir, "checkout", "-b", branch); branchErr != nil {
-			return res, fmt.Errorf("create branch: %w", branchErr)
+		if err := branchAndStageGithub(ctx, res.CloneDir, branch); err != nil {
+			return res, err
 		}
-		if addErr := gitCmd(ctx, res.CloneDir, "add", ".github/"); addErr != nil {
-			return res, fmt.Errorf("git add: %w", addErr)
-		}
+	} else if err := assertResumeStagedScopedToGithub(ctx, res.CloneDir); err != nil {
+		return res, err
 	}
 
 	stagedNames, err := stagedWorkflowNames(ctx, res.CloneDir)
@@ -251,7 +258,10 @@ func pushAndCreatePR(
 		addedCount = len(stagedNames)
 	}
 	if addedCount == 0 {
-		committed, _ := committedWorkflowNames(ctx, res.CloneDir)
+		committed, committedErr := committedWorkflowNames(ctx, res.CloneDir)
+		if committedErr != nil {
+			return res, fmt.Errorf("git diff-tree HEAD: %w", committedErr)
+		}
 		addedCount = len(committed)
 	}
 
@@ -364,6 +374,59 @@ func stagedWorkflowNames(ctx context.Context, dir string) ([]string, error) {
 	return filterWorkflowMarkdownNames(out), nil
 }
 
+// branchAndStageGithub creates the deploy branch and stages everything under
+// .github/. Used on the fresh-deploy path of createDeployPR.
+func branchAndStageGithub(ctx context.Context, dir, branch string) error {
+	if err := gitCmd(ctx, dir, "checkout", "-b", branch); err != nil {
+		return fmt.Errorf("create branch: %w", err)
+	}
+	if err := gitCmd(ctx, dir, "add", ".github/"); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	return nil
+}
+
+// assertResumeStagedScopedToGithub returns an error if the index in dir has
+// any staged path outside .github/. Used at the resume commit gate to refuse
+// committing unrelated edits a preserved work-dir might still hold.
+func assertResumeStagedScopedToGithub(ctx context.Context, dir string) error {
+	extras, err := stagedNonGithubPaths(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if len(extras) > 0 {
+		return fmt.Errorf(
+			"refusing to resume: %d staged path(s) outside .github/ would be committed: %s. "+
+				"Unstage them with `git restore --staged <path>` before retrying",
+			len(extras), strings.Join(extras, ", "),
+		)
+	}
+	return nil
+}
+
+// stagedNonGithubPaths returns paths in the index that are NOT under
+// .github/. Used at the resume commit gate to refuse committing unrelated
+// staged edits that may have been left in a preserved work-dir.
+func stagedNonGithubPaths(ctx context.Context, dir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff --cached: %w", err)
+	}
+	var paths []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, ".github/") {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
+}
+
 // committedWorkflowNames returns the names (without .md) of workflow markdown
 // files in the most recent commit. Used as a fallback for PR title/body when
 // resuming after a manual commit.
@@ -445,9 +508,13 @@ func checkEngineSecret(ctx context.Context, repo, engine string) (string, string
 	return info.SecretName, info.KeyURL
 }
 
-// Returns true if .github/ has staged or unstaged modifications.
+// hasStagedOrUnstagedWorkflowChanges reports whether dir has staged or
+// unstaged modifications under .github/. The pathspec scope matches the
+// helper's name and the resume-gate semantics: only changes the deploy
+// pipeline would commit (workflow markdown, agentic infrastructure) should
+// trigger a resume. Unrelated edits in the work-dir do not.
 func hasStagedOrUnstagedWorkflowChanges(ctx context.Context, dir string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain", "--", ".github/")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/fleet/deploy_test.go
+++ b/internal/fleet/deploy_test.go
@@ -176,7 +176,7 @@ func TestHasStagedOrUnstagedWorkflowChanges(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "staged non-workflow file",
+			name: "staged non-workflow file is ignored",
 			setup: func(dir string) {
 				p := filepath.Join(dir, "foo.txt")
 				if err := os.WriteFile(p, []byte("foo\n"), 0o644); err != nil {
@@ -188,13 +188,32 @@ func TestHasStagedOrUnstagedWorkflowChanges(t *testing.T) {
 					t.Fatalf("git add: %v", err)
 				}
 			},
+			want: false,
+		},
+		{
+			name: "non-workflow change alongside .github change still detects",
+			setup: func(dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("foo\n"), 0o644); err != nil {
+					t.Fatalf("write foo: %v", err)
+				}
+				wp := filepath.Join(dir, ".github", "workflows", "test.md")
+				if err := os.MkdirAll(filepath.Dir(wp), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(wp, []byte("workflow\n"), 0o644); err != nil {
+					t.Fatalf("write workflow: %v", err)
+				}
+			},
 			want: true,
 		},
 		{
-			name: "mixed staged and unstaged",
+			name: "mixed staged and unstaged workflow",
 			setup: func(dir string) {
-				p := filepath.Join(dir, "foo.txt")
-				if err := os.WriteFile(p, []byte("foo\n"), 0o644); err != nil {
+				p := filepath.Join(dir, ".github", "workflows", "mix.md")
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(p, []byte("v1\n"), 0o644); err != nil {
 					t.Fatalf("write: %v", err)
 				}
 				cmd := exec.Command("git", "add", p)
@@ -202,8 +221,8 @@ func TestHasStagedOrUnstagedWorkflowChanges(t *testing.T) {
 				if err := cmd.Run(); err != nil {
 					t.Fatalf("git add: %v", err)
 				}
-				if err := os.WriteFile(p, []byte("bar\n"), 0o644); err != nil {
-					t.Fatalf("write: %v", err)
+				if err := os.WriteFile(p, []byte("v2\n"), 0o644); err != nil {
+					t.Fatalf("rewrite: %v", err)
 				}
 			},
 			want: true,

--- a/internal/fleet/deploy_test.go
+++ b/internal/fleet/deploy_test.go
@@ -2,6 +2,9 @@ package fleet
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -97,5 +100,218 @@ func TestCheckEngineSecret(t *testing.T) {
 				t.Errorf("API calls = %v, want %v", calls, tt.wantCalls)
 			}
 		})
+	}
+}
+
+// newTestRepo creates a temp git repo with an initial commit and optional setup.
+func newTestRepo(t *testing.T, setup func(dir string)) string {
+	t.Helper()
+	dir := t.TempDir()
+	git := func(arg ...string) {
+		t.Helper()
+		cmd := exec.Command("git", arg...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v in %s: %v", arg, dir, err)
+		}
+	}
+	git("init")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "Test")
+	git("config", "commit.gpgsign", "false")
+	readme := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readme, []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	git("add", "README.md")
+	git("commit", "-m", "init")
+	if setup != nil {
+		setup(dir)
+	}
+	return dir
+}
+
+func TestHasStagedOrUnstagedWorkflowChanges(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		setup func(dir string)
+		want  bool
+	}{
+		{
+			name:  "clean repo",
+			setup: nil,
+			want:  false,
+		},
+		{
+			name: "staged workflow file",
+			setup: func(dir string) {
+				p := filepath.Join(dir, ".github", "workflows", "test.md")
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(p, []byte("workflow\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				cmd := exec.Command("git", "add", p)
+				cmd.Dir = dir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git add: %v", err)
+				}
+			},
+			want: true,
+		},
+		{
+			name: "unstaged workflow file",
+			setup: func(dir string) {
+				p := filepath.Join(dir, ".github", "workflows", "test.md")
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(p, []byte("workflow\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			},
+			want: true,
+		},
+		{
+			name: "staged non-workflow file",
+			setup: func(dir string) {
+				p := filepath.Join(dir, "foo.txt")
+				if err := os.WriteFile(p, []byte("foo\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				cmd := exec.Command("git", "add", p)
+				cmd.Dir = dir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git add: %v", err)
+				}
+			},
+			want: true,
+		},
+		{
+			name: "mixed staged and unstaged",
+			setup: func(dir string) {
+				p := filepath.Join(dir, "foo.txt")
+				if err := os.WriteFile(p, []byte("foo\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				cmd := exec.Command("git", "add", p)
+				cmd.Dir = dir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git add: %v", err)
+				}
+				if err := os.WriteFile(p, []byte("bar\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := newTestRepo(t, tt.setup)
+			got, err := hasStagedOrUnstagedWorkflowChanges(ctx, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitCurrentBranch(t *testing.T) {
+	ctx := context.Background()
+
+	if _, err := gitCurrentBranch(ctx, t.TempDir()); err == nil {
+		t.Error("expected error for non-git repo")
+	}
+
+	dir := newTestRepo(t, nil)
+	branch, err := gitCurrentBranch(ctx, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch == "" {
+		t.Error("expected non-empty branch name")
+	}
+}
+
+func TestIsDefaultBranch(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{"main", true},
+		{"master", true},
+		{"Main", false},
+		{"fleet/deploy-2024-01-01-000000", false},
+		{"feature/foo", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			if got := isDefaultBranch(tt.branch); got != tt.want {
+				t.Errorf("isDefaultBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommittedWorkflowNames(t *testing.T) {
+	ctx := context.Background()
+	dir := newTestRepo(t, nil)
+
+	names, err := committedWorkflowNames(ctx, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("got %v, want empty", names)
+	}
+
+	wp := filepath.Join(dir, ".github", "workflows", "ci.md")
+	if err := os.MkdirAll(filepath.Dir(wp), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(wp, []byte("workflow\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for _, args := range [][]string{
+		{"add", wp},
+		{"commit", "-m", "add workflow"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if runErr := cmd.Run(); runErr != nil {
+			t.Fatalf("git %v: %v", args, runErr)
+		}
+	}
+
+	names, err = committedWorkflowNames(ctx, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 1 || names[0] != "ci" {
+		t.Errorf("got %v, want [ci]", names)
+	}
+}
+
+func TestGitHasUnpushedCommits(t *testing.T) {
+	ctx := context.Background()
+
+	// Repo with no remote: HEAD is not on any remote branch.
+	dir := newTestRepo(t, nil)
+
+	has, err := gitHasUnpushedCommits(ctx, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Error("expected true for repo with no remotes")
 	}
 }

--- a/internal/fleet/upgrade.go
+++ b/internal/fleet/upgrade.go
@@ -234,16 +234,23 @@ func getChangedFiles(ctx context.Context, dir string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseGitStatusPorcelain(string(out)), nil
+}
 
+func parseGitStatusPorcelain(out string) []string {
+	const porcelainPrefixLen = 3 // XY + space status prefix
 	var files []string
-	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
-		file := strings.TrimSpace(line[3:])
+		if len(line) <= porcelainPrefixLen {
+			continue
+		}
+		file := strings.TrimSpace(line[porcelainPrefixLen:])
 		files = append(files, file)
 	}
-	return files, nil
+	return files
 }
 
 func upgradeCommitMessage(res *UpgradeResult) string {

--- a/internal/fleet/upgrade_test.go
+++ b/internal/fleet/upgrade_test.go
@@ -1,0 +1,67 @@
+package fleet
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseGitStatusPorcelain(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "leading space on first line preserved",
+			in:   " M .github/workflows/ci-doctor.lock.yml\n M .github/workflows/pr-fix.lock.yml\n",
+			want: []string{
+				".github/workflows/ci-doctor.lock.yml",
+				".github/workflows/pr-fix.lock.yml",
+			},
+		},
+		{
+			name: "no trailing newline",
+			in:   " M .github/a\n M .github/b",
+			want: []string{".github/a", ".github/b"},
+		},
+		{
+			name: "empty output",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "only newline",
+			in:   "\n",
+			want: nil,
+		},
+		{
+			name: "root-level file",
+			in:   " M README.md\n",
+			want: []string{"README.md"},
+		},
+		{
+			name: "added file (A in index column)",
+			in:   "A  .github/workflows/new.yml\n",
+			want: []string{".github/workflows/new.yml"},
+		},
+		{
+			name: "modified in both index and worktree",
+			in:   "MM .github/workflows/both.yml\n",
+			want: []string{".github/workflows/both.yml"},
+		},
+		{
+			name: "short line skipped",
+			in:   " M\n M .github/ok.yml\n",
+			want: []string{".github/ok.yml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGitStatusPorcelain(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseGitStatusPorcelain(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/skills/fleet-deploy/SKILL.md
+++ b/skills/fleet-deploy/SKILL.md
@@ -69,14 +69,16 @@ go run . deploy <owner>/<repo> --apply
 Expected outcomes:
 
 - **Clean success**: output ends with `PR: https://github.com/...`. Report the URL to the user; declare the deploy complete.
-- **gpg signing failure**: exit status 1, output contains `gpg failed to sign the data` or `gpg: signing failed`. The tool preserves the clone dir (`/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>`) with all files staged on the deploy branch. Compose a manual-finish paste (next section).
+- **gpg signing failure**: exit status 1, output contains `gpg failed to sign the data` or `gpg: signing failed`. The tool preserves the clone dir (`/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>`) with all files staged on the deploy branch. Two recovery options exist:
+  1. **Resume via `--work-dir`** (preferred): re-run `go run . deploy <owner>/<repo> --apply --work-dir <clone-dir>`. The tool detects the staged changes, skips clone/init/add, and re-enters at the commit gate.
+  2. **Manual-finish paste**: compose the shell paste below for the user to run in their own terminal where gpg-agent can prompt. Use this when the user explicitly asks for manual steps or when `--work-dir` resume is not desired.
 - **Other failures**: report honestly — don't auto-retry.
 
 ## The gpg-failure manual-finish paste
 
 When `--apply` fails on gpg signing, the deploy has already done the hard work: cloned the target, run `gh aw init` (if needed), run `gh aw add` for each workflow, created the deploy branch, staged all changes. Only the commit is blocked, because the git signing operation couldn't prompt for a passphrase.
 
-The fix is to hand the user a copy-paste block they run in their own shell, where gpg-agent can prompt them interactively. **Never** add `--no-gpg-sign` or `-c commit.gpgsign=false` to any git invocation — CLAUDE.md forbids it, and the rule exists because signing bypasses can mask real security incidents.
+If the user chooses manual finish (or `--work-dir` resume fails with the same gpg issue), hand them a copy-paste block they run in their own shell, where gpg-agent can prompt them interactively. **Never** add `--no-gpg-sign` or `-c commit.gpgsign=false` to any git invocation — CLAUDE.md forbids it, and the rule exists because signing bypasses can mask real security incidents.
 
 ### How to compose the paste
 
@@ -138,9 +140,11 @@ ci(workflows): add <N> agentic workflows via gh-aw-fleet
 
 No scope abbreviations. No trailing period. Under 72 chars (this template is 54 chars + `<N>` digits). `ci` is the type (GH Actions workflows live in `.github/workflows/`); `workflows` is the scope.
 
-### After handing the paste
+### After handing the paste (or after `--work-dir` resume)
 
 Stop. Wait for the user to report the PR URL or the merge. Don't try to run git commands yourself — the user's shell is where gpg-agent lives.
+
+If the user used `--work-dir` resume and it succeeded, the output ends with `PR: https://github.com/...` just like a clean deploy. Report the URL and mark complete.
 
 ## When deploys fail across many repos — structured logs as a debugging aid
 


### PR DESCRIPTION
## Summary

- `deploy --apply --work-dir <preserved-clone>` now short-circuits clone, `gh aw init`, and `gh aw add` when the work-dir already has staged or unstaged workflow changes, re-entering the pipeline at the commit gate instead of redoing work that already landed on the preserved clone.
- Adds a second re-entry point — the push gate — for the case where the operator manually finished `git commit -S` after a gpg-agent failure; `git branch -r --contains HEAD` detects the unpushed commit and the tool proceeds directly to `git push` + `gh pr create`.
- Refuses to resume on a protected default branch (`main`/`master`) and rejects a `--branch` flag that conflicts with the clone's current branch, so a misaligned retry fails loudly rather than pushing to the wrong ref.
- Drive-by fix: `getChangedFiles` in `upgrade` no longer drops the leading `.` from the first path in `changed: N file(s)` output. Root cause was `strings.TrimSpace` on the whole porcelain blob eating the significant leading-space byte of the first line; the fix switches to `strings.TrimRight(..., "\n")` and guards against lines shorter than the 3-char status prefix.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/fleet/...` passes — new `TestHasStagedOrUnstagedWorkflowChanges` fixture covers clean/staged/unstaged/non-workflow cases, and `TestParseGitStatusPorcelain` covers leading-space, no-trailing-newline, short-line, root-level, and mixed index/worktree status cases
- [x] Manual `go run . deploy <repo> --dry-run --work-dir <dir>` behavior: empty dir → usual clone; preserved clone with staged changes → resume at commit gate; preserved clone on `main` → refusal
- [ ] `make ci` (fmt-check + vet + lint + test) — run before merge

## Changes

### New files

- `internal/fleet/upgrade_test.go` — table-driven tests for `parseGitStatusPorcelain` covering the regression from issue #32 and additional porcelain-format edge cases (added files, mixed index/worktree status, short lines).

### Modified files

- `internal/fleet/deploy.go` — adds `handleWorkDirResume` orchestrator; extracts `pushAndCreatePR` from `createDeployPR` so both gates share the push/PR path; new helpers `gitCurrentBranch`, `isDefaultBranch`, `gitHasUnpushedCommits`, and `committedWorkflowNames`; `createDeployPR` accepts a `resumeBranch` parameter to skip branch/stage steps when resuming; `prBody` takes an explicit `addedCount` for the manual-commit fallback where `res.Added` is empty.
- `internal/fleet/deploy_test.go` — `TestHasStagedOrUnstagedWorkflowChanges` builds real temp git repos via `t.TempDir()` + `exec.Command` to exercise the staged / unstaged / non-workflow / clean matrix.
- `internal/fleet/upgrade.go` — extracts `parseGitStatusPorcelain` as a pure function; replaces outer `TrimSpace` with `TrimRight(..., "\n")` so the first line's leading status byte is preserved; guards against lines shorter than the 3-char porcelain prefix.
- `cmd/deploy.go` — updates `--work-dir` flag help to describe the commit/push gate resume behavior.
- `skills/fleet-deploy/SKILL.md` — gpg-failure recovery section now lists `--work-dir` resume as the preferred path and keeps the manual-finish paste as the fallback; adds a "After handing the paste (or after `--work-dir` resume)" follow-up clause.
- `README.md` — removes the "No `--work-dir` mid-pipeline resume" bullet from Known Limitations; expands the "Resuming after a partial failure" section to document the commit-gate and push-gate resume flows.

Closes #8
Closes #32