### PR TITLE
feat(billing): observability-plus profile + HTTP 402 diagnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ The CLI has two config files: `fleet.json` (public, committed, example tracking 
 
 **Framing that shapes everything**: `github/gh-aw` ships the compiler + dogfooding tests; `githubnext/agentics` ships the curated library. When adding workflows to profiles, prefer agentics unless no equivalent exists. `github/gh-aw`'s `main` often contains unreleased features (like `mount-as-clis`) that break the installed CLI — always pin gh-aw sources to tags, never to `main`.
 
+**`*-plus` profiles are opt-in, cost-aware bundles**: `quality-plus`, `security-plus`, `docs-plus`, `community-plus`, and `observability-plus` are layered onto `default` per-repo via the repo's `profiles` list. `observability-plus` ships `api-consumption-report` (daily) — pair it with the planned `gh-aw-fleet consumption` subcommand for fleet-wide billing rollups, but note that opting a repo in incurs recurring Copilot-credit cost since the report is itself an LLM workflow.
+
 **Critical asymmetry**: `gh aw add` uses `fleet.json` pins (via `ResolvedWorkflow.Spec()`). `gh aw update` follows the workflow's *own* frontmatter `source:` line, not `fleet.json`. This means fleet.json edits don't propagate through `upgrade` — they need a `fleet sync --apply --force <repo>` to re-pin workflows to current fleet.json refs.
 
 **`gh aw` path conventions differ by source**: agentics uses 3-part specs (`githubnext/agentics/<name>@ref`, implicit `workflows/` dir); gh-aw needs 4-part (`github/gh-aw/.github/workflows/<name>.md@ref`). `internal/fleet/fetch.go`'s `SourceLayout` map encodes this; `ResolvedWorkflow.Spec()` consumes it. Adding a third source means adding a `SourceLayout` entry.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,34 +15,19 @@ is biased toward *operator ergonomics* (resume, preflight, packaging) over
 *feature surface area* (new commands, new abstractions). When in doubt: less
 code, more delegation.
 
-The project is at **v0.1.1**. The 2026-06-01 transition to usage-based Copilot
+The project is at **v0.1.3**. The 2026-06-01 transition to usage-based Copilot
 billing has shifted the near-term agenda: fleet operators need cross-repo cost
 visibility, and fleet — uniquely positioned to know which repo runs which
 profile pinned to which ref — is the natural layer to provide it.
 
-## Immediate Focus (v0.2 — CLI completeness + billing readiness)
+## Immediate Focus (v0.2 — billing readiness + correctness cleanup)
 
-The CLI surface advertises seven subcommands but `status` (#10) remains a
-stub. Closing that gap removes user surprise. Bundled in this milestone: a
-deploy-time preflight (#11), one billing-readiness diagnostic (#52, the
-smallest billing-related ship), and one freshly-discovered correctness bug
-(#48).
-
-### CLI completeness
-
-- [ ] [#10](https://github.com/rshade/gh-aw-fleet/issues/10) Implement
-  `status [repo]` subcommand `[M]`
-  *Diff desired (`fleet.json`) vs actual (per-repo workflow set + pins)
-  WITHOUT cloning. Reuses `fetch.go` to read upstream + target via `gh api`.
-  Output: human-readable drift report + non-zero exit if drift exists.
-  `--json` mode for CI integration.*
-- [ ] [#11](https://github.com/rshade/gh-aw-fleet/issues/11) Preflight
-  check for Actions enabled and workflow write permissions `[M]`
-  *Two repo-level settings (Actions toggle, workflow token permissions)
-  silently break every deployed workflow if mis-set. Add
-  `checkActionsSettings()` alongside the existing `checkEngineSecret()`
-  call; surface warnings with direct links to the settings page. Pure
-  preflight — no auto-remediation.*
+CLI completeness shipped in 2026-Q2 (#10 status, #11 preflight). What
+remains for v0.2 is the smallest billing-readiness diagnostic (#52, ahead
+of the 2026-06-01 transition) and one correctness bug surfaced after #8
+landed (#48). Both are `[S]` — this milestone is intentionally small so
+the next reasonable promotion is the billing-visibility chain (#54/#55/#56
+→ #57) from Near-Term.
 
 ### Billing readiness (2026-06-01 transition)
 
@@ -161,10 +146,11 @@ layer to enforce fleet-wide policy that per-repo tools cannot.
   Add security scanning to `upgrade`/`sync`/`deploy` pipeline `[L]`
   *Umbrella: insert a scanner layer that catches secrets, dangerous
   compiled-YAML patterns, and fleet-structural violations before PRs merge.
-  Scoped into four sub-issues (#37–#40) that ship independently; promote
-  to Near-Term once #37 has a landing PR.*
-  - [ ] [#37](https://github.com/rshade/gh-aw-fleet/issues/37) Layer 1
+  Layer 1 (#37) shipped 2026-05-07 — by the epic's own promotion rule, the
+  remaining children (#38–#40) are eligible for Near-Term in the next sync.*
+  - [x] [#37](https://github.com/rshade/gh-aw-fleet/issues/37) Layer 1
     scanner: secrets + compiled-YAML + fleet-structural rules `[L]`
+    (shipped 2026-05-07)
   - [ ] [#38](https://github.com/rshade/gh-aw-fleet/issues/38) `--strict`
     flag: promote HIGH Layer 1 findings from advisory to blocking `[S]`
   - [ ] [#39](https://github.com/rshade/gh-aw-fleet/issues/39)
@@ -291,10 +277,47 @@ ideas close the loop without becoming a daemon.
   so a human reviewer can navigate the rollout. Pure formatting; no schema
   change.*
 
+### Status command refinements
+
+Both follow-ups extend the v1 `status` command (#10, shipped 2026-Q2). They
+were deferred at v1 to keep the initial command surface small.
+
+- [ ] [#61](https://github.com/rshade/gh-aw-fleet/issues/61) Opt-in
+  `--ref <branch>` flag for `status` non-default-branch checks `[S]`
+  *Today `status` reads each repo's default branch. Some operators stage
+  workflow changes on a feature branch; an opt-in `--ref` flag would let
+  `status` diff against an arbitrary ref. Trigger: real demand from at
+  least one external operator.*
+- [ ] [#62](https://github.com/rshade/gh-aw-fleet/issues/62) Opt-in
+  SHA-resolution drift mode for `status` to reduce false positives `[S]`
+  *Today `status` does strict string comparison: a SHA pin pointing to the
+  same commit as a tag is reported as drifted. Optional flag would resolve
+  both refs to commit SHAs via `gh api` (2N extra calls per drifted
+  candidate). Trigger: operators report content-identical false positives.*
+
 ## Completed Milestones
 
 ### 2026-Q2
 
+- [x] [#37](https://github.com/rshade/gh-aw-fleet/issues/37) Layer 1
+  security scanner: secrets + compiled-YAML + fleet-structural rules `[L]`
+  *First foundation of the security epic (#36): added `internal/security`
+  scanner that runs against the resolved workflow set and surfaces findings
+  on `DeployResult` / `SyncResult` / `UpgradeResult`. Advisory-only at this
+  layer; promotion to blocking arrives with #38's `--strict` flag.*
+- [x] [#11](https://github.com/rshade/gh-aw-fleet/issues/11) Preflight
+  check for Actions enabled and workflow write permissions `[M]`
+  *`checkActionsSettings()` runs alongside `checkEngineSecret()` during
+  deploy preflight; surfaces direct settings-page links when either repo-
+  level setting would silently break deployed workflows. Pure preflight,
+  no auto-remediation.*
+- [x] [#10](https://github.com/rshade/gh-aw-fleet/issues/10) Implement
+  `status [repo]` subcommand `[M]`
+  *Diffs desired (`fleet.json`) vs actual (per-repo workflow set + pins)
+  via `gh api` without cloning. Human-readable drift report by default,
+  `--output json` envelope for CI/LLM consumption, non-zero exit on drift.
+  Strict-string comparison; SHA-resolution mode tracked separately as
+  #62.*
 - [x] [#32](https://github.com/rshade/gh-aw-fleet/issues/32) `upgrade`
   first changed-file missing leading dot (TrimSpace eats porcelain status
   char) `[S]`
@@ -371,10 +394,10 @@ Any roadmap item that violates these is rejected, not negotiated.
 - **Effort labels**: `effort/small`, `effort/medium`, `effort/large`
 - **Contribution flags**: `community`, `cross-repo`, `spec-first`
 
-> Immediate Focus items (#10, #11, #48, #52), Near-Term billing-visibility
-> items (#54, #55, #56, #57), Near-Term distribution / security items (#43,
-> #49), the Future Vision security epic (#36 with children #37–#40), and the
-> Future Vision billing-deferred items (#53, #59, #60) are tracked as GitHub
-> issues. The unlinked Near-Term and Future items don't have issues yet —
-> open them as work picks up, then run `/roadmap sync` to keep this file
-> aligned.
+> Immediate Focus items (#48, #52), Near-Term billing-visibility items
+> (#54, #55, #56, #57), Near-Term distribution / security items (#43, #49),
+> the Future Vision security epic (#36 with remaining children #38–#40),
+> the Future Vision billing-deferred items (#53, #59, #60), and the Status
+> command refinements (#61, #62) are tracked as GitHub issues. The
+> unlinked Near-Term and Future items don't have issues yet — open them
+> as work picks up, then run `/roadmap sync` to keep this file aligned.

--- a/fleet.json
+++ b/fleet.json
@@ -72,6 +72,15 @@
         { "name": "archie",               "source": "githubnext/agentics" },
         { "name": "repo-ask",             "source": "githubnext/agentics" }
       ]
+    },
+    "observability-plus": {
+      "description": "Daily consumption-report workflows for cross-fleet billing visibility. Pair with `gh-aw-fleet consumption` for rollups. Each running repo consumes Copilot credits daily — opt in consciously.",
+      "sources": {
+        "github/gh-aw": { "ref": "v0.68.3" }
+      },
+      "workflows": [
+        { "name": "api-consumption-report", "source": "github/gh-aw" }
+      ]
     }
   },
   "repos": {

--- a/internal/fleet/diagnostics.go
+++ b/internal/fleet/diagnostics.go
@@ -32,7 +32,7 @@ const (
 	DiagUnknownProperty       = fleetdiag.DiagUnknownProperty
 	DiagHTTP404               = fleetdiag.DiagHTTP404
 	DiagGPGFailure            = fleetdiag.DiagGPGFailure
-	DiagPaymentRequired       = fleetdiag.DiagPaymentRequired
+	DiagBillingQuotaExceeded  = fleetdiag.DiagBillingQuotaExceeded
 	DiagRateLimited           = fleetdiag.DiagRateLimited
 	DiagRepoInaccessible      = fleetdiag.DiagRepoInaccessible
 	DiagNetworkUnreachable    = fleetdiag.DiagNetworkUnreachable
@@ -57,11 +57,15 @@ type Hint struct {
 	Code    string
 }
 
-// paymentRequiredHint is shared by the "HTTP 402" and "Payment Required"
-// entries. The status is generic, so the remediation stays provider-agnostic.
-const paymentRequiredHint = "Upstream returned HTTP 402 / Payment Required. " +
-	"This is a billing, quota, entitlement, or plan rejection, not a workflow syntax error. " +
-	"Check the billing or access settings for the account, organization, or provider behind the failed request."
+// billingQuotaHint is shared by the "HTTP 402" and "Payment Required"
+// entries. Names GitHub spending controls as the primary remediation and
+// forward-references the planned `gh-aw-fleet consumption` subcommand for
+// cross-repo cost attribution (#52).
+const billingQuotaHint = "Upstream returned HTTP 402 / Payment Required — a billing-quota or spending-cap rejection " +
+	"from GitHub Copilot's usage-based billing, not a workflow syntax error. " +
+	"Raise or review the cap at https://github.com/settings/billing/spending_limit " +
+	"(or the org-level equivalent under Organization → Settings → Billing). " +
+	"Cross-repo cost attribution will be available via `gh-aw-fleet consumption` once that subcommand ships."
 
 // Ordered most-specific first; only the first match per input text is emitted.
 //
@@ -89,13 +93,13 @@ var hints = []Hint{
 	},
 	{
 		Pattern: "HTTP 402",
-		Message: paymentRequiredHint,
-		Code:    DiagPaymentRequired,
+		Message: billingQuotaHint,
+		Code:    DiagBillingQuotaExceeded,
 	},
 	{
 		Pattern: "Payment Required",
-		Message: paymentRequiredHint,
-		Code:    DiagPaymentRequired,
+		Message: billingQuotaHint,
+		Code:    DiagBillingQuotaExceeded,
 	},
 	{
 		Pattern: "API rate limit exceeded",

--- a/internal/fleet/diagnostics.go
+++ b/internal/fleet/diagnostics.go
@@ -32,6 +32,7 @@ const (
 	DiagUnknownProperty       = fleetdiag.DiagUnknownProperty
 	DiagHTTP404               = fleetdiag.DiagHTTP404
 	DiagGPGFailure            = fleetdiag.DiagGPGFailure
+	DiagPaymentRequired       = fleetdiag.DiagPaymentRequired
 	DiagRateLimited           = fleetdiag.DiagRateLimited
 	DiagRepoInaccessible      = fleetdiag.DiagRepoInaccessible
 	DiagNetworkUnreachable    = fleetdiag.DiagNetworkUnreachable
@@ -56,6 +57,12 @@ type Hint struct {
 	Code    string
 }
 
+// paymentRequiredHint is shared by the "HTTP 402" and "Payment Required"
+// entries. The status is generic, so the remediation stays provider-agnostic.
+const paymentRequiredHint = "Upstream returned HTTP 402 / Payment Required. " +
+	"This is a billing, quota, entitlement, or plan rejection, not a workflow syntax error. " +
+	"Check the billing or access settings for the account, organization, or provider behind the failed request."
+
 // Ordered most-specific first; only the first match per input text is emitted.
 //
 //nolint:gochecknoglobals // immutable hint table; Go has no const slice of structs
@@ -79,6 +86,16 @@ var hints = []Hint{
 		Message: "Source path not found. Check the spec — `github/gh-aw` workflows live under `.github/workflows/`; " +
 			"`githubnext/agentics` workflows live under `workflows/`.",
 		Code: DiagHTTP404,
+	},
+	{
+		Pattern: "HTTP 402",
+		Message: paymentRequiredHint,
+		Code:    DiagPaymentRequired,
+	},
+	{
+		Pattern: "Payment Required",
+		Message: paymentRequiredHint,
+		Code:    DiagPaymentRequired,
 	},
 	{
 		Pattern: "API rate limit exceeded",

--- a/internal/fleet/diagnostics_test.go
+++ b/internal/fleet/diagnostics_test.go
@@ -61,7 +61,7 @@ func TestCollectHintDiagnostics_UnknownProperty(t *testing.T) {
 	}
 }
 
-func TestCollectHintDiagnostics_PaymentRequired(t *testing.T) {
+func TestCollectHintDiagnostics_BillingQuotaExceeded(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
@@ -75,15 +75,20 @@ func TestCollectHintDiagnostics_PaymentRequired(t *testing.T) {
 			if len(got) != 1 {
 				t.Fatalf("len(got) = %d; want 1; got=%+v", len(got), got)
 			}
-			if got[0].Code != DiagPaymentRequired {
-				t.Errorf("Code = %q; want %q", got[0].Code, DiagPaymentRequired)
+			if got[0].Code != DiagBillingQuotaExceeded {
+				t.Errorf("Code = %q; want %q", got[0].Code, DiagBillingQuotaExceeded)
 			}
 			if got[0].Fields["hint"] != got[0].Message {
 				t.Errorf("Fields[hint] = %v; want = Message %q", got[0].Fields["hint"], got[0].Message)
 			}
-			if strings.Contains(got[0].Message, "Copilot") ||
-				strings.Contains(got[0].Message, "GitHub spending controls") {
-				t.Errorf("Message = %q; want provider-agnostic remediation", got[0].Message)
+			if !strings.Contains(got[0].Message, "Copilot") {
+				t.Errorf("Message = %q; want GitHub-specific remediation naming Copilot", got[0].Message)
+			}
+			if !strings.Contains(got[0].Message, "github.com/settings/billing/spending_limit") {
+				t.Errorf("Message = %q; want pointer to GitHub spending controls URL", got[0].Message)
+			}
+			if !strings.Contains(got[0].Message, "gh-aw-fleet consumption") {
+				t.Errorf("Message = %q; want forward-reference to `gh-aw-fleet consumption` subcommand", got[0].Message)
 			}
 		})
 	}

--- a/internal/fleet/diagnostics_test.go
+++ b/internal/fleet/diagnostics_test.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"encoding/json"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,34 @@ func TestCollectHintDiagnostics_UnknownProperty(t *testing.T) {
 	}
 	if got[0].Fields["hint"] != got[0].Message {
 		t.Errorf("Fields[hint] = %v; want = Message %q", got[0].Fields["hint"], got[0].Message)
+	}
+}
+
+func TestCollectHintDiagnostics_PaymentRequired(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"http_402", "gh: HTTP 402: spending limit reached"},
+		{"payment_required", "gh: 402 Payment Required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CollectHintDiagnostics(tc.in)
+			if len(got) != 1 {
+				t.Fatalf("len(got) = %d; want 1; got=%+v", len(got), got)
+			}
+			if got[0].Code != DiagPaymentRequired {
+				t.Errorf("Code = %q; want %q", got[0].Code, DiagPaymentRequired)
+			}
+			if got[0].Fields["hint"] != got[0].Message {
+				t.Errorf("Fields[hint] = %v; want = Message %q", got[0].Fields["hint"], got[0].Message)
+			}
+			if strings.Contains(got[0].Message, "Copilot") ||
+				strings.Contains(got[0].Message, "GitHub spending controls") {
+				t.Errorf("Message = %q; want provider-agnostic remediation", got[0].Message)
+			}
+		})
 	}
 }
 

--- a/internal/fleet/fleetdiag/diag.go
+++ b/internal/fleet/fleetdiag/diag.go
@@ -30,7 +30,7 @@ const (
 	DiagUnknownProperty               = "unknown_property"
 	DiagHTTP404                       = "http_404"
 	DiagGPGFailure                    = "gpg_failure"
-	DiagPaymentRequired               = "payment_required"
+	DiagBillingQuotaExceeded          = "billing_quota_exceeded"
 	DiagRateLimited                   = "rate_limited"
 	DiagRepoInaccessible              = "repo_inaccessible"
 	DiagNetworkUnreachable            = "network_unreachable"

--- a/internal/fleet/fleetdiag/diag.go
+++ b/internal/fleet/fleetdiag/diag.go
@@ -30,6 +30,7 @@ const (
 	DiagUnknownProperty               = "unknown_property"
 	DiagHTTP404                       = "http_404"
 	DiagGPGFailure                    = "gpg_failure"
+	DiagPaymentRequired               = "payment_required"
 	DiagRateLimited                   = "rate_limited"
 	DiagRepoInaccessible              = "repo_inaccessible"
 	DiagNetworkUnreachable            = "network_unreachable"

--- a/skills/fleet-build-profile/SKILL.md
+++ b/skills/fleet-build-profile/SKILL.md
@@ -15,7 +15,7 @@ Profiles are the *intent layer* of the fleet. `templates.json` says what exists 
 
 Two other facts shape the flow:
 
-- `fleet.json` is the public, committed declarative state (five profiles today: `default`, `quality-plus`, `security-plus`, `docs-plus`, `community-plus`). `fleet.local.json` layers on top, is gitignored, and is where private / experimental profiles live. The user picks which to write — usually `fleet.local.json` for new or one-off profiles, `fleet.json` only when the profile is stable and meant to be shared.
+- `fleet.json` is the public, committed declarative state (six profiles today: `default`, `quality-plus`, `security-plus`, `docs-plus`, `community-plus`, `observability-plus`). `fleet.local.json` layers on top, is gitignored, and is where private / experimental profiles live. The user picks which to write — usually `fleet.local.json` for new or one-off profiles, `fleet.json` only when the profile is stable and meant to be shared.
 - `profiles/<name>.json` is a separate, human-readable mirror. Only `profiles/default.json` exists today, and no Go code reads it — it's a documentation convention. CLAUDE.md still requires `profiles/default.json` to match `fleet.json`'s `default` profile verbatim, so any write that touches the `default` profile has to update both files in the same turn.
 
 ## When to use
@@ -76,6 +76,7 @@ Call out anything the user should sanity-check:
 - Any gh-aw workflow included → flag the source stability note.
 - Pin ref differs from `default` profile → mention it and why.
 - Any workflow with `safe_outputs: create-pull-request` or `push-to-pull-request-branch` → note the noise profile, since the whole bundle's character is set by its heaviest safe-outputs.
+- Any workflow that runs an LLM on a daily schedule (e.g., `api-consumption-report` in `observability-plus`) → flag the recurring Copilot-credit cost. Daily LLM workflows multiplied across N opted-in repos can be ~$1–2/day/repo; bake a sentence about the cost into the profile description so the trade-off is visible at opt-in.
 
 Stop. Wait for explicit approval ("go", "apply", "looks good") before writing.
 


### PR DESCRIPTION
## Summary

- Lands the two smallest billing-readiness pieces ahead of the 2026-06-01 Copilot usage-based-billing transition: a fleet profile that ships `api-consumption-report` for cross-fleet visibility, and a deploy/sync/upgrade diagnostic hint that classifies HTTP 402 / `Payment Required` as a billing rejection (not a workflow bug) and forward-points at the planned `gh-aw-fleet consumption` subcommand.
- Adds `observability-plus` as the fifth `*-plus` opt-in bundle. The profile description bakes in the recurring-Copilot-credit cost so the trade-off is visible at opt-in, and `fleet-build-profile` gains a heuristic so future daily-LLM profiles get the same treatment.
- Refreshes `ROADMAP.md` to v0.1.3, marks #10 / #11 / #37 as shipped under 2026-Q2, and records two deferred `status` follow-ups (#61, #62) under Future Vision.

## Test plan

- [x] `make fmt-check` clean
- [x] `make vet` clean
- [x] `make lint` clean (golangci-lint)
- [x] `make test` — new `TestCollectHintDiagnostics_BillingQuotaExceeded` passes both pattern variants (`HTTP 402`, `Payment Required`)
- [x] Existing `TestHints_AllHaveSnakeCaseCode` validates the new `DiagBillingQuotaExceeded` code constant automatically
- [x] `make ci` passes locally (project hard-gate per `AGENTS.md`)

## Changes

### Modified files

- `internal/fleet/fleetdiag/diag.go` — adds `DiagBillingQuotaExceeded = "billing_quota_exceeded"` alongside the existing diagnostic-code constants.
- `internal/fleet/diagnostics.go` — re-exports the new constant and appends two `Hint` entries (`HTTP 402`, `Payment Required`) that point at GitHub spending controls and forward-reference the planned `gh-aw-fleet consumption` subcommand.
- `internal/fleet/diagnostics_test.go` — table-driven test mirroring `TestCollectHintDiagnostics_UnknownProperty`; covers both pattern variants and asserts `Code == DiagBillingQuotaExceeded` plus the `Fields["hint"] == Message` envelope contract.
- `fleet.json` — new `observability-plus` profile pinning `api-consumption-report` to `github/gh-aw@v0.68.3`. Description names the recurring-credit cost so the opt-in trade-off is surfaced before the repo is added.
- `AGENTS.md` — documents `*-plus` profiles as opt-in cost-aware bundles and explains the `observability-plus` / `consumption` pairing so future agents understand the framing.
- `skills/fleet-build-profile/SKILL.md` — bumps "five profiles" to "six profiles" and adds a sanity-check heuristic: any daily LLM workflow added to a profile gets a cost note in its description.
- `ROADMAP.md` — version bump to v0.1.3; moves #10 (status), #11 (preflight), and #37 (Layer 1 scanner) into Completed Milestones / 2026-Q2; tightens the v0.2 Immediate Focus narrative around the remaining billing work; adds a "Status command refinements" Future-Vision section tracking #61 and #62.

Closes #52
Closes #56