### PR TITLE
fix(sync): lock in resume-guard bypass on internally-prepared clones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,6 @@ Per-slice dependency and storage deltas:
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+[specs/008-fix-sync-resume-guard/plan.md](./specs/008-fix-sync-resume-guard/plan.md)
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,27 +20,40 @@ billing has shifted the near-term agenda: fleet operators need cross-repo cost
 visibility, and fleet — uniquely positioned to know which repo runs which
 profile pinned to which ref — is the natural layer to provide it.
 
-## Immediate Focus (v0.2 — billing-visibility prerequisites + correctness cleanup)
+## Release Composition Rule
 
-CLI completeness and the smallest billing-readiness pieces shipped in
-2026-Q2 (#10 status, #11 preflight, #52 HTTP 402 diagnostic, #56
-`api-consumption-report` profile). What remains for v0.2 is one correctness
-bug (#48) plus the two additive metadata prerequisites (#54, #55) that
-unlock the cross-fleet `consumption` subcommand (#57) in v0.3. #54 and #55
-are independent — land in any order.
+Each tagged release should include at least one **cost-visibility** item
+and at least one **security** item. Cost because the 2026-06-01
+usage-based Copilot billing transition makes cost a continuous operator
+concern; security because the prt-scan-era supply-chain landscape makes
+fleet-layer policy enforcement the natural defense. A release that ships
+only correctness work, or that lands one of the two domains without the
+other, drifts the project from the two mandates that justify a
+fleet-layer tool existing.
 
-### Billing-visibility prerequisites
+**Identifying candidates**:
 
-- [ ] [#54](https://github.com/rshade/gh-aw-fleet/issues/54) Add optional
-  `tier` annotation to profile definitions `[M]`
-  *Advisory `minimal | standard | premium` field on `Profile`. Surface in
-  `list` output. No enforcement — annotation only. Becomes the `--by tier`
-  group-by key for #57. Independent of #55; land in any order.*
-- [ ] [#55](https://github.com/rshade/gh-aw-fleet/issues/55) Add optional
-  `cost_center` field to `RepoSpec` `[M]`
-  *Free-form string per repo. Surface in `list`. Same shape as #54
-  (additive metadata, no enforcement). Becomes the `--by cost-center` key
-  for #57. Independent of #54; land in any order.*
+- **Cost**: items labeled `cost` on GitHub — currently #53, #57, #59,
+  #60.
+- **Security**: items labeled `security` on GitHub — currently #36
+  (EPIC) with children #38–#40, plus #49.
+
+**Status**: v0.1.x → v0.2 satisfied this (#54 / #55 / #56 cost
+prereqs, #37 Layer 1 security scanner). The v0.3 Near-Term lineup
+satisfies it (#57 cost, #49 security). Forward releases should keep one
+of each on the merge queue alongside any feature or correctness work.
+
+**Exception**: a release scoped as a single `fix:` hotfix (no feature
+changes) is exempt — the rule applies to feature-bearing releases.
+
+## Immediate Focus (v0.2 — correctness cleanup before v0.3 begins)
+
+The billing-visibility prerequisites (#54 `tier`, #55 `cost_center`) and the
+HuJson config-comments work (#73) all shipped together in PR #78 on
+2026-05-12. That clears the last data-shape blockers for `consumption`
+(#57). Only one correctness bug remains before the v0.2 release tag: the
+sync resume-guard misfire on internally-prepared clones (#48). Once that
+lands, v0.3 work (#57 first) opens.
 
 ### Correctness
 
@@ -53,13 +66,13 @@ are independent — land in any order.
 
 ## Near-Term Vision (v0.3 — billing visibility + operator quality)
 
-Once Immediate Focus closes, the headline v0.3 work is the cross-fleet
-consumption rollup (#57) — the fleet feature the new billing model
-justifies. #56 (workflow profile) shipped in v0.2; #54 + #55 (metadata
-prereqs) are in Immediate Focus, so by the time v0.3 opens, #57's
-prerequisites are all in place. Wrapped around that: a security default
-flip (#49), packaging (#43, gh-extension item), inline config docs (#73),
-and the existing operator-QoL items.
+The headline v0.3 work is the cross-fleet consumption rollup (#57) — the
+fleet feature the new billing model justifies. All of its prerequisites
+are now landed: #56 (the `api-consumption-report` profile) shipped in
+v0.2, and #54 + #55 (the `tier` / `cost_center` metadata fields) shipped
+in PR #78 on 2026-05-12. #57 is unblocked and is the largest piece in this
+phase. Wrapped around it: a security default flip (#49), packaging (#43,
+gh-extension item), and operator-QoL items.
 
 ### Billing visibility (consumption tracking)
 
@@ -93,16 +106,6 @@ and the existing operator-QoL items.
 
 ### Operator quality of life
 
-- [ ] [#73](https://github.com/rshade/gh-aw-fleet/issues/73) Support HuJson
-  for inline config documentation `[M]`
-  *Allow `//` comments and trailing commas in `fleet.json`,
-  `fleet.local.json`, `templates.json`, and `profiles/default.json` so pin
-  rationale and per-workflow eval notes live next to the data they
-  describe. Read path: `hujson.Standardize()` before `json.Unmarshal`;
-  write path: `hujson.Patch` preserves comments through tool-driven edits.
-  **Boundary note**: introduces a third-party dep (`tailscale/hujson`)
-  against Principle I — justify or vendor the minimal Standardize/Patch
-  surface before merging.*
 - [ ] `sync --dry-run` runs deploy preflight `[M]`
   *Today `sync --dry-run` computes the diff but doesn't validate that the
   resolved workflows would actually `gh aw add` cleanly (404s on bad pins,
@@ -296,6 +299,28 @@ were deferred at v1 to keep the initial command surface small.
 
 ### 2026-Q2
 
+- [x] [#73](https://github.com/rshade/gh-aw-fleet/issues/73) Support HuJson
+  for inline config documentation `[M]`
+  *Shipped 2026-05-12 in PR #78. `internal/fleet/load.go` runs every
+  config file (`fleet.json`, `fleet.local.json`, `templates.json`,
+  `profiles/default.json`) through `hujson.Standardize()` before
+  `json.Unmarshal`; writes use direct AST mutation (`Add`) or RFC 6902
+  patches (`SaveTemplates`) to preserve operator-authored comments. The
+  boundary note on third-party deps was resolved by Constitution v1.1.0
+  §Third-Party Dependencies, which adds `tailscale/hujson` as an
+  approved direct dependency.*
+- [x] [#55](https://github.com/rshade/gh-aw-fleet/issues/55) Add optional
+  `cost_center` field to `RepoSpec` `[M]`
+  *Shipped 2026-05-12 in PR #78. Free-form string per repo, surfaced as
+  an appended column in `gh-aw-fleet list`. Additive: no `SchemaVersion`
+  bump, no envelope change, silently accepted when absent. Becomes the
+  `--by cost-center` group-by key for #57.*
+- [x] [#54](https://github.com/rshade/gh-aw-fleet/issues/54) Add optional
+  `tier` annotation to profile definitions `[M]`
+  *Shipped 2026-05-12 in PR #78. Advisory `minimal | standard | premium`
+  field on `Profile`, surfaced as a parallel `TIERS` column in `list`.
+  No enforcement — annotation only. Becomes the `--by tier` group-by
+  key for #57.*
 - [x] [#56](https://github.com/rshade/gh-aw-fleet/issues/56) Add
   `api-consumption-report` workflow to a fleet profile `[S]`
   *Shipped 2026-05-10 as the new `observability-plus` opt-in profile in
@@ -403,13 +428,15 @@ Any roadmap item that violates these is rejected, not negotiated.
 - **GitHub issues**: <https://github.com/rshade/gh-aw-fleet/issues>
 - **Roadmap phase labels**: `roadmap/current`, `roadmap/next`, `roadmap/future`
 - **Effort labels**: `effort/small`, `effort/medium`, `effort/large`
+- **Release-composition labels**: `cost`, `security` (see Release
+  Composition Rule above)
 - **Contribution flags**: `community`, `cross-repo`, `spec-first`
 
-> Immediate Focus items (#48, #54, #55), the Near-Term billing-visibility
-> item (#57), Near-Term distribution / security / config items (#43, #49,
-> #73), the Future Vision security epic (#36 with remaining children
-> #38–#40), the Future Vision billing-deferred items (#53, #59, #60), and
-> the Status command refinements (#61, #62) are tracked as GitHub issues.
-> The unlinked Near-Term and Future items don't have issues yet — open
-> them as work picks up, then run `/roadmap sync` to keep this file
-> aligned.
+> The Immediate Focus correctness item (#48), the Near-Term
+> billing-visibility item (#57), the Near-Term distribution / security
+> items (#43, #49), the Future Vision security epic (#36 with remaining
+> children #38–#40), the Future Vision billing-deferred items (#53, #59,
+> #60), and the Status command refinements (#61, #62) are tracked as
+> GitHub issues. The unlinked Near-Term and Future items don't have
+> issues yet — open them as work picks up, then run `/roadmap sync` to
+> keep this file aligned.

--- a/internal/fleet/deploy_test.go
+++ b/internal/fleet/deploy_test.go
@@ -554,6 +554,45 @@ func newTestRepo(t *testing.T, setup func(dir string)) string {
 	return dir
 }
 
+func TestDeployUserSuppliedWorkDirTriggersResumeGuard(t *testing.T) {
+	dir := newTestRepo(t, func(d string) {
+		cmd := exec.Command("git", "branch", "-M", "main")
+		cmd.Dir = d
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("rename branch to main: %v", err)
+		}
+	})
+
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			"acme/widgets": {Profiles: []string{"default"}},
+		},
+	}
+
+	_, err := Deploy(context.Background(), cfg, "acme/widgets", DeployOpts{
+		Apply:         false,
+		WorkDir:       dir,
+		InternalClone: false,
+	})
+	if err == nil {
+		t.Fatal("Deploy returned nil error, want refusing to resume")
+	}
+	if !strings.Contains(err.Error(), "refusing to resume") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "refusing to resume")
+	}
+}
+
 func TestHasStagedOrUnstagedWorkflowChanges(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/fleet/sync_test.go
+++ b/internal/fleet/sync_test.go
@@ -3,14 +3,17 @@ package fleet
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
 
 func TestSyncDryRunPreflightTreatsPreparedCloneAsInternal(t *testing.T) {
 	repo := "rshade/sync-missing"
 	remote := newTestRepo(t, nil)
-	installFakeGhForSync(t, remote)
+	_ = installFakeGhForSync(t, remote)
 
 	cfg := &Config{
 		Version: SchemaVersion,
@@ -44,21 +47,338 @@ func TestSyncDryRunPreflightTreatsPreparedCloneAsInternal(t *testing.T) {
 	}
 }
 
-func installFakeGhForSync(t *testing.T, remote string) {
+func TestSyncApplyBypassesResumeGuard(t *testing.T) {
+	// Bypass proof rests on gh aw init leaving an untracked
+	// .github/agents/agentic-workflows.agent.md in the cloned work-dir on the
+	// default branch; a stale InternalClone=false would trip the resume guard
+	// at deploy.go:203 and never reach addResolvedWorkflows.
+	repo := "rshade/sync-missing"
+	remote := newTestRepo(t, nil)
+	logPath := installFakeGhForSync(t, remote)
+
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}},
+		},
+	}
+
+	res, _ := Sync(context.Background(), cfg, repo, SyncOpts{Apply: true})
+
+	if res == nil {
+		t.Fatal("Sync returned nil result")
+	}
+	if res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if len(res.Missing) != 1 || res.Missing[0] != "ci-doctor" {
+		t.Fatalf("Missing = %v, want [ci-doctor]", res.Missing)
+	}
+	if res.Deploy == nil {
+		t.Fatal("Deploy = nil, want non-nil (proves addResolvedWorkflows ran past resume guard)")
+	}
+	if !slices.ContainsFunc(res.Deploy.Added, func(w WorkflowOutcome) bool { return w.Name == "ci-doctor" }) {
+		t.Fatalf("Deploy.Added = %#v, want entry with Name=ci-doctor", res.Deploy.Added)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake-gh log: %v", err)
+	}
+	if len(logBytes) == 0 {
+		t.Fatal("fake-gh log is empty; Deploy aborted before addResolvedWorkflows")
+	}
+	var addLines []string
+	for line := range strings.SplitSeq(string(logBytes), "\n") {
+		if strings.HasPrefix(line, "add ") {
+			addLines = append(addLines, line)
+		}
+	}
+	if len(addLines) != 1 {
+		t.Fatalf("add-prefixed lines = %d, want 1; log:\n%s", len(addLines), logBytes)
+	}
+	if !strings.Contains(addLines[0], "githubnext/agentics/ci-doctor@v1.0.0") {
+		t.Fatalf("add line = %q, want spec suffix githubnext/agentics/ci-doctor@v1.0.0", addLines[0])
+	}
+}
+
+func TestSyncApplyPruneBypassesResumeGuard(t *testing.T) {
+	// Prune-then-deploy ordering is enforced by applyDeployOrPrune (sync.go:147–163),
+	// not by the SyncResult shape. Asserting res.Pruned and res.Deploy.Added both
+	// populated proves both phases ran on the same clone; the source order of those
+	// phases is the authoritative ordering signal.
+	repo := "rshade/sync-missing"
+	remote := newTestRepo(t, seedDriftedWorkflow)
+	logPath := installFakeGhForSync(t, remote)
+
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}},
+		},
+	}
+
+	res, _ := Sync(context.Background(), cfg, repo, SyncOpts{Apply: true, Prune: true})
+
+	if res == nil {
+		t.Fatal("Sync returned nil result")
+	}
+	if res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if !slices.Contains(res.Drift, "drifted") {
+		t.Fatalf("Drift = %v, want to contain drifted", res.Drift)
+	}
+	if !slices.Contains(res.Missing, "ci-doctor") {
+		t.Fatalf("Missing = %v, want to contain ci-doctor", res.Missing)
+	}
+	if !slices.Contains(res.Pruned, "drifted") {
+		t.Fatalf("Pruned = %v, want to contain drifted (proves pruneDriftFiles ran)", res.Pruned)
+	}
+	if res.Deploy == nil {
+		t.Fatal("Deploy = nil, want non-nil (proves Deploy ran past resume guard after prune)")
+	}
+	if !slices.ContainsFunc(res.Deploy.Added, func(w WorkflowOutcome) bool { return w.Name == "ci-doctor" }) {
+		t.Fatalf("Deploy.Added = %#v, want entry with Name=ci-doctor", res.Deploy.Added)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake-gh log: %v", err)
+	}
+	var addLines []string
+	for line := range strings.SplitSeq(string(logBytes), "\n") {
+		if strings.HasPrefix(line, "add ") {
+			addLines = append(addLines, line)
+		}
+	}
+	if len(addLines) != 1 {
+		t.Fatalf("add-prefixed lines = %d, want 1; log:\n%s", len(addLines), logBytes)
+	}
+}
+
+func TestSyncApplyWithoutPruneLeavesDriftUntouched(t *testing.T) {
+	repo := "rshade/sync-missing"
+	remote := newTestRepo(t, seedDriftedWorkflow)
+	_ = installFakeGhForSync(t, remote)
+
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}},
+		},
+	}
+
+	res, _ := Sync(context.Background(), cfg, repo, SyncOpts{Apply: true})
+
+	if res == nil {
+		t.Fatal("Sync returned nil result")
+	}
+	if res.CloneDir == "" {
+		t.Fatal("CloneDir is empty; Deploy aborted before prepareClone returned")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if len(res.Pruned) != 0 {
+		t.Fatalf("Pruned = %v, want empty (no --prune flag passed)", res.Pruned)
+	}
+	if res.Deploy == nil {
+		t.Fatal("Deploy = nil, want non-nil")
+	}
+	if !slices.ContainsFunc(res.Deploy.Added, func(w WorkflowOutcome) bool { return w.Name == "ci-doctor" }) {
+		t.Fatalf("Deploy.Added = %#v, want entry with Name=ci-doctor", res.Deploy.Added)
+	}
+	driftedPath := filepath.Join(res.CloneDir, ".github", "workflows", "drifted.md")
+	if _, err := os.Stat(driftedPath); err != nil {
+		t.Fatalf("drifted.md should remain on disk without --prune, got: %v", err)
+	}
+}
+
+func TestSyncPruneWithoutApplyErrors(t *testing.T) {
+	repo := "rshade/sync-missing"
+	remote := newTestRepo(t, nil)
+	_ = installFakeGhForSync(t, remote)
+
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}},
+		},
+	}
+
+	_, err := Sync(context.Background(), cfg, repo, SyncOpts{Prune: true, Apply: false})
+	if err == nil {
+		t.Fatal("Sync returned nil error, want --prune requires --apply")
+	}
+	if !strings.Contains(err.Error(), "--prune requires --apply") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "--prune requires --apply")
+	}
+}
+
+func TestSyncNoMissingNoDriftShortCircuits(t *testing.T) {
+	repo := "rshade/sync-missing"
+	remote := newTestRepo(t, seedDeclaredWorkflow)
+	logPath := installFakeGhForSync(t, remote)
+
+	// cfg is shared across subtests; Sync is contractually read-only on it
+	// (ResolveRepoWorkflows builds fresh slices, EffectiveEngine reads only).
+	cfg := &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources: map[string]SourcePin{
+					"githubnext/agentics": {Ref: "v1.0.0"},
+				},
+				Workflows: []ProfileWorkflow{
+					{Name: "ci-doctor", Source: "githubnext/agentics"},
+				},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}},
+		},
+	}
+
+	cases := []struct {
+		name string
+		opts SyncOpts
+	}{
+		{"dry-run", SyncOpts{Apply: false}},
+		{"apply", SyncOpts{Apply: true}},
+		{"apply-prune", SyncOpts{Apply: true, Prune: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Sync(context.Background(), cfg, repo, tc.opts)
+			if err != nil {
+				t.Fatalf("Sync returned error: %v", err)
+			}
+			if res.CloneDir != "" {
+				t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+			}
+			if res.Deploy != nil {
+				t.Fatalf("Deploy = %#v, want nil (repo is in-state)", res.Deploy)
+			}
+			if res.DeployPreflight != nil {
+				t.Fatalf("DeployPreflight = %#v, want nil (repo is in-state)", res.DeployPreflight)
+			}
+			if len(res.Pruned) != 0 {
+				t.Fatalf("Pruned = %v, want empty", res.Pruned)
+			}
+
+			logBytes, readErr := os.ReadFile(logPath)
+			if readErr != nil && !os.IsNotExist(readErr) {
+				t.Fatalf("read fake-gh log: %v", readErr)
+			}
+			for line := range strings.SplitSeq(string(logBytes), "\n") {
+				if strings.HasPrefix(line, "add ") {
+					t.Fatalf("fake-gh log contains add line %q; want none for in-state repo", line)
+				}
+			}
+		})
+	}
+}
+
+// seedDeclaredWorkflow seeds the test repo with .github/workflows/ci-doctor.md
+// whose frontmatter source matches the declared githubnext/agentics/ci-doctor@v1.0.0
+// spec, so the repo is in-state relative to the fleet config used by
+// TestSyncNoMissingNoDriftShortCircuits.
+func seedDeclaredWorkflow(dir string) {
+	wf := filepath.Join(dir, ".github", "workflows", "ci-doctor.md")
+	if err := os.MkdirAll(filepath.Dir(wf), 0o755); err != nil {
+		panic(err)
+	}
+	content := "---\nsource: githubnext/agentics/ci-doctor@v1.0.0\n---\n"
+	if err := os.WriteFile(wf, []byte(content), 0o644); err != nil {
+		panic(err)
+	}
+	gitInDir(dir, "add", ".github/workflows/ci-doctor.md")
+	gitInDir(dir, "commit", "-m", "seed declared workflow")
+}
+
+// seedDriftedWorkflow seeds a drift workflow file in the test repo so that
+// the resulting clone presents .github/workflows/drifted.md as undeclared
+// drift relative to a fleet config that declares only ci-doctor.
+func seedDriftedWorkflow(dir string) {
+	wf := filepath.Join(dir, ".github", "workflows", "drifted.md")
+	if err := os.MkdirAll(filepath.Dir(wf), 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(wf, []byte("---\nsource: legacy/drifted@v0\n---\n"), 0o644); err != nil {
+		panic(err)
+	}
+	gitInDir(dir, "add", ".github/workflows/drifted.md")
+	gitInDir(dir, "commit", "-m", "seed drift")
+}
+
+func gitInDir(dir string, arg ...string) {
+	cmd := exec.Command("git", arg...)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+}
+
+func installFakeGhForSync(t *testing.T, remote string) string {
 	t.Helper()
 	binDir := t.TempDir()
 	ghPath := filepath.Join(binDir, "gh")
+	logPath := filepath.Join(binDir, "fake-gh.log")
 	script := `#!/bin/sh
 set -eu
 
 if [ "$1" = "repo" ] && [ "$2" = "clone" ]; then
 	git clone "$FLEET_TEST_REMOTE" "$4"
-	exit $?
+	git -C "$4" config commit.gpgsign false
+	git -C "$4" config user.email test@example.com
+	git -C "$4" config user.name Test
+	exit 0
 fi
 
 if [ "$1" = "aw" ] && [ "$2" = "init" ]; then
 	mkdir -p .github/agents
 	printf '%s\n' 'agent setup' > .github/agents/agentic-workflows.agent.md
+	printf 'init\n' >> "${FAKE_GH_LOG:?}"
 	exit 0
 fi
 
@@ -69,6 +389,7 @@ if [ "$1" = "aw" ] && [ "$2" = "add" ]; then
 	name="${name%.md}"
 	mkdir -p .github/workflows
 	printf '%s\n' '---' "source: $spec" '---' > ".github/workflows/$name.md"
+	printf 'add %s\n' "$spec" >> "${FAKE_GH_LOG:?}"
 	exit 0
 fi
 
@@ -79,5 +400,7 @@ exit 1
 		t.Fatalf("write fake gh: %v", err)
 	}
 	t.Setenv("FLEET_TEST_REMOTE", remote)
+	t.Setenv("FAKE_GH_LOG", logPath)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
 }

--- a/specs/008-fix-sync-resume-guard/checklists/requirements.md
+++ b/specs/008-fix-sync-resume-guard/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Sync Resume-Guard Regression Coverage (Issue #48)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This spec is bug-fix regression coverage rather than greenfield. The field-level fix already landed in PR #66 (commit `0694ae9`, 2026-04-30). Issue #48 stays open because the apply and apply+prune call sites have no dedicated tests.
+- Some FRs name specific Go symbols (`DeployOpts.InternalClone`, file paths under `internal/fleet/`). For a bug-fix spec these are *acceptance anchors*, not implementation details — they identify the contract the regression tests must pin. The non-technical reader still gets the user-visible behavior from FR-002 through FR-007 and US1–US3.
+- FR-009 names the Conventional Commits scope explicitly because the project enforces it via commitlint and release-please. This is an operational requirement of the codebase, not an implementation detail of the feature.
+- Tradeoff acknowledged: a stricter "no code references in spec" reading would push FR-001 and the Key Entities section into the plan. They live here because issue #48 cited those exact symbols and operators reading this spec from the issue will expect to see them.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`. All items currently pass.

--- a/specs/008-fix-sync-resume-guard/data-model.md
+++ b/specs/008-fix-sync-resume-guard/data-model.md
@@ -1,0 +1,60 @@
+# Phase 1 — Data Model
+
+**Feature**: Sync Resume-Guard Regression Coverage (Issue #48)
+**Branch**: `008-fix-sync-resume-guard`
+**Date**: 2026-05-12
+
+## Summary
+
+**No new entities, no new fields, no schema changes.** This is a test-coverage slice; every identifier under test is pre-existing. This document catalogs the existing entities the new tests assert against and pins the godoc that SC-006 promises stays accurate.
+
+## Entities under test (all pre-existing)
+
+### `DeployOpts.InternalClone` *(internal-only signal)*
+
+- **Location**: `internal/fleet/deploy.go:42`
+- **Type**: `bool`
+- **Origin**: PR #66 (commit `0694ae9`, merged 2026-04-30).
+- **Contract**: `true` when the caller (i.e., `Sync`) prepared the `WorkDir` clone in this process and the resume guard should not fire; `false` (zero value) when the operator supplied `--work-dir <path>` and a genuine resume attempt should be detected. The guard at `deploy.go:203` is `opts.WorkDir != "" && !opts.InternalClone`.
+- **Godoc invariant (SC-006)**: The existing comment — `// WorkDir was prepared by this process; not a user resume request.` — accurately captures the disambiguator. `make lint` (revive + staticcheck under the no-suppression `.golangci.yml` policy per AGENTS.md) MUST stay clean post-change. No edit planned.
+
+### `SyncOpts.WorkDir` *(operator-facing flag value)*
+
+- **Location**: `internal/fleet/sync.go:19`
+- **Type**: `string`
+- **Contract**: Empty when the operator omits `--work-dir` (common case → Sync prepares a `/tmp/gh-aw-fleet-*` clone and sets `InternalClone=true` on the downstream `DeployOpts`). Non-empty when the operator passes `--work-dir <path>` (Sync re-uses the directory and sets `InternalClone=false` so a genuine resume is detectable).
+- **Wiring sites** (the two-line propagation contract): `sync.go:158` (`applyDeployOrPrune`) and `sync.go:206` (`runPreflight`), both `InternalClone: opts.WorkDir == ""`.
+
+### `SyncResult` fields the tests assert against
+
+| Field | Source line | When populated | Assertion used by |
+|---|---|---|---|
+| `Missing []string` | `sync.go:28` | After `computeDriftAndMissing` (`sync.go:63`) when the on-disk dir lacks a desired workflow. | All three tests (US1/US2/US3) — sanity check that the test fixture set up the missing condition correctly. |
+| `Drift []string` | `sync.go:29` | After `computeDriftAndMissing` when an on-disk `.md` is not in the desired set and not extra/`copilot-setup-steps`. | US3 only — confirms the drift seed produced the expected drift entry. |
+| `Pruned []string` | `sync.go:31` | Each entry appended in `pruneDriftFiles` (`sync.go:172`) after `os.Remove`. | US3 only — proves prune ran before Deploy under combined-flag path. |
+| `Deploy *DeployResult` | `sync.go:30` | Set by `applyDeployOrPrune` (`sync.go:161`) only when `Apply=true && len(Missing)>0`. Stays nil for prune-only or already-in-state repos. | US2 + US3 — `res.Deploy.Added` is the proof-of-life that `Deploy` ran past `handleWorkDirResume`. |
+| `DeployPreflight *DeployResult` | `sync.go:32` | Set by `runPreflight` (`sync.go:209`) only when `Apply=false && len(Missing)>0`. | US1 — already covered by `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal`. |
+
+### `DeployResult.Added` *(populated by `addResolvedWorkflows`)*
+
+- **Why it's the load-bearing assertion target**: Spec FR-008(b) defines "the fix held" as `addResolvedWorkflows` (`deploy.go:218`) executing past the resume guard. `Added` being populated is the observable signal — the test does not need to assert on `MissingSecret`, `ActionsDisabled`, `SecurityFindings`, or any other field downstream of the guard. (Clarifications Session 2026-05-12.)
+
+## State transitions
+
+No new state. The behavior under test is a *guard bypass*, which from the caller's perspective is a no-op (the guard correctly does nothing) and from the test's perspective is observable only via "the next branch ran" assertions. There is no transition graph to draw.
+
+## JSON envelope
+
+Unchanged. `cmd.SchemaVersion` does not bump (no new fields exposed to stdout — this is a test slice, not a feature add per the cmd-envelope contract documented in AGENTS.md).
+
+## `fleet.SchemaVersion` (on-disk config schema)
+
+Unchanged. No new fields in `Config`, `Profile`, `RepoSpec`, or `SourcePin`.
+
+## Test-harness data (transient, not "model" data — recorded here for completeness)
+
+| Identifier | Type | Lifetime | Purpose |
+|---|---|---|---|
+| `$FAKE_GH_LOG` (env var, new) | `string` (filepath) | Single test invocation; cleaned by `t.TempDir()` | Append-only log of fake-gh events; read back by tests for count + order assertions. Decision recorded in [research.md](./research.md#decision-1--how-to-record-aw-add-invocations-in-the-fake-gh-shim). |
+
+This is local test scaffolding, not a tool-visible identifier — it never appears in production code, in JSON output, or in any config file.

--- a/specs/008-fix-sync-resume-guard/plan.md
+++ b/specs/008-fix-sync-resume-guard/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Sync Resume-Guard Regression Coverage (Issue #48)
+
+**Branch**: `008-fix-sync-resume-guard` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/008-fix-sync-resume-guard/spec.md`
+
+## Summary
+
+The field-level fix for issue #48 already shipped in PR #66: `DeployOpts.InternalClone` (a bool) disambiguates an internally-prepared clone (Sync handing its scratch clone to Deploy) from a user-initiated resume (`--work-dir <path>`). `internal/fleet/deploy.go:203` gates `handleWorkDirResume` on `opts.WorkDir != "" && !opts.InternalClone`, so internally-prepared clones now bypass the protected-branch refusal that was blocking dry-run, `--apply`, and `--apply --prune` paths for repos with `Missing > 0`.
+
+What this slice delivers is **regression coverage**: two new tests in `internal/fleet/sync_test.go` (apply, apply+prune) plus a small extension to `installFakeGhForSync` so the fake `gh` shim records `aw add` invocations and order-of-operations relative to staged prune deletions. Tests stop at the commit gate per Clarifications Session 2026-05-12 — no fake `gh pr create`, no `res.Deploy.PRURL` assertions; push/PR coverage already lives in `deploy_test.go`. The merge commit uses `fix(sync):` so release-please surfaces the closure under "Fixed" in CHANGELOG.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.8 (per `go.mod`).
+**Primary Dependencies**: `github.com/spf13/cobra` v1.10.2 (existing, not exercised by this slice), `github.com/rs/zerolog` v1.35.1 (existing, not exercised), `testing` (stdlib), `os/exec` for the fake-gh shim install (already used by existing tests). **No new direct dependencies** (per SC-004 and Constitution §Third-Party Dependencies).
+**Storage**: N/A — tests construct an in-process `*Config` literal; the fake `gh` shim writes inside `t.TempDir()` directories that the test runtime garbage-collects.
+**Testing**: Go's `testing` package via `make test`. The existing test `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` (sync_test.go:10) is the template — same helpers (`newTestRepo` from `deploy_test.go:530`, `installFakeGhForSync` from `sync_test.go:47`).
+**Target Platform**: Linux/macOS developer workstations and CI; identical to existing test surface. No platform-specific behavior added.
+**Project Type**: Go single-project CLI (`cmd/` + `internal/`). Tests live next to the package under test.
+**Performance Goals**: New tests collectively add ≤ 200ms wall-clock to `make test` (SC-003). Each new case targets ≤ 50ms by reusing `newTestRepo` + `installFakeGhForSync` and stopping at the commit gate (no push, no PR-creation simulation).
+**Constraints**: `make ci` (= `fmt-check vet lint test`) MUST pass. The merge commit subject MUST start with `fix(sync):` (Conventional Commits + release-please mapping). `go.mod` and `go.sum` MUST be unchanged (SC-004). Issue #48 MUST be closed in the same change set (SC-005).
+**Scale/Scope**: Test surface expansion only — two new `Test*` functions (~30–50 lines each) and ~10 lines of incremental fake-gh shell. Zero non-test files modified.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The repo constitution is at `.specify/memory/constitution.md` (v1.1.0, ratified 2026-04-18, last amended 2026-05-10).
+
+| Principle / Section | Outcome | Justification |
+|---|---|---|
+| I. Thin-Orchestrator Code Quality | ✅ PASS | No production code changes. Tests exercise the existing orchestration path. The fake-gh shim continues to *stub*, not *re-implement*, `gh aw add`. |
+| II. Testing Standards (Build-Green + Real-World Dry-Run) | ✅ PASS | This slice IS adding tests; `make ci` must stay green per FR-008 + SC-001. Constitution Principle II also notes "Unit tests are not currently required" — i.e., adding them is allowed and welcome; no policy conflict. |
+| III. UX Consistency (Three-Turn Mutation Pattern) | ✅ PASS | N/A — no CLI surface change, no new flag, no new error message, no help text edit. The fix being pinned is already in the shipped binary's behavior. |
+| IV. Performance (5-Minute Ceiling, Parallelism, Cache) | ✅ PASS | New tests cap at ~200ms total (SC-003). No new commands, no new network calls, no new fetched state. |
+| Declarative Reconcile Invariants | ✅ PASS | No change to `fleet.json` semantics, no change to commit-signing posture, no `git add`/`git commit`/`git push` invoked from anywhere new — the existing `Deploy` path (the one legitimate `exec.Command("git", ...)` site) is unchanged; the fake `gh` shim doesn't drive git directly because tests stop at the commit gate. |
+| Third-Party Dependencies | ✅ PASS | Zero new direct deps. `go.mod` / `go.sum` unchanged (SC-004). |
+| Development Workflow | ✅ PASS | One PR, `fix(sync):` Conventional Commits subject, release-please will categorize under "Fixed". Issue closure noted in `applyComplete` step (per FR-009). |
+
+**Result**: No violations. Complexity Tracking table below is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-fix-sync-resume-guard/
+├── plan.md              # This file (/speckit-plan command output)
+├── spec.md              # Feature specification (already authored)
+├── research.md          # Phase 0 output — fake-gh shim extension decision
+├── data-model.md        # Phase 1 output — existing entity touchpoints (no new entities)
+├── quickstart.md        # Phase 1 output — how to run the new tests locally
+└── checklists/          # /speckit-checklist artifacts (pre-existing)
+```
+
+`contracts/` is **intentionally omitted**. The feature changes no external interface — no new CLI flag, no new JSON envelope field, no new exported Go API. Per the speckit plan template guidance ("Skip if project is purely internal"), this slice qualifies because the *feature scope* is internal even though the *project* has external CLI contracts that remain unchanged.
+
+### Source Code (repository root)
+
+```text
+internal/fleet/
+├── deploy.go              # UNCHANGED — InternalClone field & resume guard already shipped (PR #66)
+├── deploy_test.go         # UNCHANGED — provides newTestRepo helper consumed by sync_test.go
+├── sync.go                # UNCHANGED — applyDeployOrPrune and runPreflight already pass InternalClone=true
+└── sync_test.go           # MODIFIED — extend installFakeGhForSync to record aw-add calls;
+                            # add TestSyncApplyBypassesResumeGuard and
+                            # TestSyncApplyPruneBypassesResumeGuard
+```
+
+No files added; one file modified. No `go.mod` / `go.sum` touched.
+
+**Structure Decision**: Single Go project, tests co-located with the package under test (`internal/fleet/`). The only file modified is `internal/fleet/sync_test.go`; the rest of the repo is untouched. This is the smallest possible footprint that satisfies FR-008 (a, b, c) and SC-001/SC-002.
+
+## Phase 0 — Research
+
+See [research.md](./research.md) for the full record. Single decision captured:
+
+- **How to extend `installFakeGhForSync` to support the new test assertions** — chosen approach: append-only invocation log written by the fake `gh` shell script to a file inside `binDir` (`$FAKE_GH_LOG`), read back from Go via `os.ReadFile`. Rejected alternatives: replacing the shim with a Go-level harness (over-engineering for two tests), exposing a counter via env-var arithmetic in the shim (fragile under `set -eu`), upgrading to a per-call JSON record (test depth doesn't need structured data — order + count of `aw add` invocations is enough).
+
+No `NEEDS CLARIFICATION` markers remain. The spec's Session 2026-05-12 already resolved the only two open questions (test depth → "stop at commit gate"; commit type → `fix(sync):`).
+
+## Phase 1 — Design Artifacts
+
+### data-model.md
+
+See [data-model.md](./data-model.md). Summary: the spec's Key Entities are all pre-existing fields. No new types, no new fields, no JSON envelope changes. The document catalogs which existing identifiers each new test asserts against and notes the unchanged godoc on `DeployOpts.InternalClone` per SC-006.
+
+### contracts/
+
+Omitted (rationale above).
+
+### quickstart.md
+
+See [quickstart.md](./quickstart.md). Reproduction recipe is a single `go test -run TestSync ./internal/fleet/...` invocation plus the full `make ci` gate. Local-loop time target: < 5 seconds for the targeted run, < 60 seconds for the full suite (SC-003).
+
+### Agent context update
+
+CLAUDE.md's `<!-- SPECKIT START -->`/`<!-- SPECKIT END -->` block is updated to point to this plan file (`specs/008-fix-sync-resume-guard/plan.md`).
+
+## Re-evaluation of Constitution Check (post-design)
+
+Re-checked after Phase 1: no gates flipped. The Phase 0/1 outputs do not introduce any production code, any dependency, any schema field, or any CLI surface. All seven principle/section rows above remain ✅ PASS. **Result**: cleared for `/speckit-tasks`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+(empty — no violations)

--- a/specs/008-fix-sync-resume-guard/quickstart.md
+++ b/specs/008-fix-sync-resume-guard/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart — Sync Resume-Guard Regression Coverage (Issue #48)
+
+**Branch**: `008-fix-sync-resume-guard`
+**Date**: 2026-05-12
+
+## What this slice does
+
+Pins the existing `DeployOpts.InternalClone` fix (PR #66) with two new regression tests in `internal/fleet/sync_test.go`. No production code change.
+
+## Prereqs
+
+- Go 1.25.8+ (matches `go.mod`).
+- `git` on `$PATH` (the test creates real temp git repos via `newTestRepo`).
+- The repo cloned at `008-fix-sync-resume-guard`.
+
+No `gh` CLI install required for the tests — `installFakeGhForSync` writes a POSIX shell script to a temp dir and prepends it to `$PATH`.
+
+## Run just the new tests
+
+After `/speckit-tasks` lands the test bodies:
+
+```bash
+go test -run TestSync ./internal/fleet/...
+```
+
+Expected: three tests pass.
+
+- `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` (pre-existing — must keep passing)
+- `TestSyncApplyBypassesResumeGuard` (new — US2 / FR-008b)
+- `TestSyncApplyPruneBypassesResumeGuard` (new — US3 / FR-008c)
+
+Wall-clock target: under 5 seconds for the targeted run (SC-003 budget for the new cases is +200ms cumulative on top of the existing suite).
+
+## Run the full CI gate
+
+```bash
+make ci
+```
+
+This runs `fmt-check vet lint test` per AGENTS.md. **All four must pass before claiming done.**
+
+- `make fmt-check` — gofmt-aligned (no `\t`/space mismatch).
+- `make vet` — `go vet ./...` clean.
+- `make lint` — `golangci-lint` clean. Note from AGENTS.md: can run > 5 min locally; use extended timeouts; do **not** skip. `revive`/`staticcheck` will reject any missing exported-comment regression on `DeployOpts.InternalClone` per SC-006.
+- `make test` — full suite passes, including the new cases.
+
+## Manual smoke (optional, against a real repo)
+
+Once `make ci` is green, the historical reproduction recipe from issue #48 should now produce a clean dry-run instead of the "refusing to resume" fatal. Example against any repo with `Missing > 0`:
+
+```bash
+go run . sync rshade/finfocus           # dry-run; expect 0 exit, no "refusing to resume"
+go run . sync --apply rshade/finfocus   # apply; expect normal deploy pipeline (clone → branch → aw add → commit → push → PR)
+```
+
+This is **not** required for the slice to ship — the regression tests are the durable proof. The manual smoke is here only if a reviewer wants extra confidence before merging.
+
+## Closing the issue
+
+Per FR-009 and SC-005:
+
+1. Merge the PR with a `fix(sync):` Conventional Commits subject (e.g., `fix(sync): close resume-guard regression coverage gap (#48)`).
+2. release-please will pick up `fix:` and put the entry under "Fixed" in `CHANGELOG.md` on the next release PR.
+3. Close issue #48 with a comment linking to the merge commit and identifying PR #66 as the original field-level fix.
+
+## Troubleshooting
+
+- **`FAKE_GH_LOG` unset / log file missing**: the shim uses `${FAKE_GH_LOG:?}` so this fails loudly. Check `t.Setenv("FAKE_GH_LOG", ...)` was called before `Sync`.
+- **`aw add` count mismatch**: confirm the fake `gh` script's `add` branch appends to `$FAKE_GH_LOG` before `exit 0`, not after (after-exit code is unreachable).
+- **`make lint` complaining about a comment on `DeployOpts.InternalClone`**: nothing in this slice should touch that field. If the lint regression appears, re-read PR #66's diff — the godoc must remain on the existing field definition at `internal/fleet/deploy.go:42`.

--- a/specs/008-fix-sync-resume-guard/research.md
+++ b/specs/008-fix-sync-resume-guard/research.md
@@ -1,0 +1,69 @@
+# Phase 0 — Research
+
+**Feature**: Sync Resume-Guard Regression Coverage (Issue #48)
+**Branch**: `008-fix-sync-resume-guard`
+**Date**: 2026-05-12
+
+## Scope
+
+The implementation already exists. The only open design question is how the new tests (apply and apply+prune) observe `aw add` invocations and their ordering relative to staged prune deletions. The spec's Session 2026-05-12 clarification fixed test depth ("stop at commit gate") and commit type (`fix(sync):`), so no `NEEDS CLARIFICATION` markers were carried into this phase.
+
+## Decision 1 — How to record `aw add` invocations in the fake `gh` shim
+
+### Decision
+
+Extend `installFakeGhForSync` so the shell shim **appends** one line per significant invocation (`aw init`, `aw add <spec>`) to a log file whose path is exported via `$FAKE_GH_LOG`. The Go test creates the log path under `t.TempDir()`, sets the env var alongside `FLEET_TEST_REMOTE` and `PATH`, and reads the file back with `os.ReadFile` after `Sync` returns.
+
+Log format (one event per line, space-separated):
+
+```text
+init
+add githubnext/agentics/ci-doctor@v1.0.0
+```
+
+This gives both **count** (line count where the first field is `add`) and **order** (line index relative to other events the test cares about — specifically the `git add` Sync.go performs at `pruneDriftFiles` time, which the prune test will observe via a sibling `git` shim entry or by inspecting the workflows dir state at known points).
+
+### Rationale
+
+- **`set -eu` safe**: the shim already runs under `set -eu`; appending to a file (`printf >> "$FAKE_GH_LOG"`) cannot fail in a way that breaks the strict mode contract (and if the var is unset, `${FAKE_GH_LOG:?}` errors cleanly with a useful message).
+- **Test depth match**: spec FR-008(b) requires "the fake `gh` shim recorded one `aw add` invocation per missing workflow." A line-per-call log is the minimum data shape that supports both the count assertion and the prune+add ordering assertion in FR-008(c). Anything richer (per-call JSON, separate stdout/stderr capture) would exceed the documented test depth.
+- **Reuses existing infrastructure**: the shim already lives in `installFakeGhForSync` (sync_test.go:47); adding a `printf >>` line is a one-token edit. No new helper functions, no new Go-level harness.
+- **Single read site**: `os.ReadFile` + `strings.Split(..., "\n")` is the same pattern `deploy_test.go` uses for inspecting captured output; reviewers will recognize it.
+
+### Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Replace the shim with a Go-level test harness that intercepts `exec.Command` | Over-engineered for two tests. Would require either an injectable command runner in `Deploy` (production-code surface change for test convenience — Principle I says no) or a vendored `os/exec` wrapper. Cost vastly exceeds value at this scope. |
+| Counter env var (`COUNT=$((COUNT+1)); export COUNT`) | Fragile under `set -eu` if the var isn't pre-seeded; export-to-parent doesn't survive subshell boundaries in some shells; and the prune-ordering assertion (FR-008c) wants more than a count. |
+| One-file-per-call (`touch $TMP/aw-add-$N`) | Awkward to enumerate (need `ls | sort -n`) and adds filesystem noise; no benefit over a single append-only log. |
+| Per-call JSON record (`printf '{"cmd":"add",...}\n'`) | Test depth does not need structured data; line-based parsing is shorter and faster to write/read for the two cases we add. |
+
+### Implementation notes (deferred to `/speckit-tasks`)
+
+- Pre-create the log file path in Go via `filepath.Join(binDir, "fake-gh.log")` and `t.Setenv("FAKE_GH_LOG", logPath)`.
+- In the shim, after the existing branch decision but before `exit 0`, append the canonical event line. Keep `set -eu` and `${FAKE_GH_LOG:?}` so a missing setenv fails the test loudly instead of producing a silent-pass false positive.
+- Tests assert via `strings.Count(string(log), "\nadd ")` for counts and `strings.Index` for ordering.
+
+## Decision 2 — Where the negative-case coverage for `--work-dir` (FR-005) lives
+
+### Decision
+
+Cover FR-005 (operator-supplied `--work-dir` keeps `InternalClone=false` and the resume guard active) in `internal/fleet/deploy_test.go`, not `sync_test.go`. Spec FR-008 explicitly authorizes this placement: "Coverage for the negative case (operator-supplied `--work-dir` preserves the guard, FR-005) is desirable but may live in `deploy_test.go` if more natural there."
+
+### Rationale
+
+- The behavior under test is a `Deploy`-side branch (`opts.WorkDir != "" && !opts.InternalClone` at deploy.go:203). The closest existing test neighborhood is `deploy_test.go`'s resume-related cases, not `sync_test.go`'s orchestration cases.
+- Sync-side wiring for FR-005 is mechanical (`InternalClone: opts.WorkDir == ""` at sync.go:158 and sync.go:206) — a unit test of `Sync` would be testing two-line plumbing rather than the actual guard contract.
+
+### Alternatives considered
+
+- Put it in `sync_test.go` with an operator-supplied `WorkDir` — possible but couples a Sync test to a Deploy-side branch, increasing setup cost (need a clone on a non-default branch with staged changes) for no extra signal beyond a deploy_test.go case would already provide.
+
+### Scope note
+
+Whether to actually add a new `deploy_test.go` case is a *task-time* decision (see `/speckit-tasks`). If equivalent coverage already exists in `deploy_test.go` (around the `handleWorkDirResume` cases), the new test may be marked redundant. If it doesn't exist, `/speckit-tasks` will emit a task for it. Either way, the resume-guard regression closure (the load-bearing deliverable) is the apply and apply+prune cases in `sync_test.go`.
+
+## Open Questions
+
+None. All `NEEDS CLARIFICATION` are resolved.

--- a/specs/008-fix-sync-resume-guard/spec.md
+++ b/specs/008-fix-sync-resume-guard/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Sync Resume-Guard Regression Coverage (Issue #48)
+
+**Feature Branch**: `008-fix-sync-resume-guard`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description: Issue #48 — `bug(sync): preflight + apply mis-trigger "refusing to resume" check on internally-prepared clones`. The operator observes that `gh-aw-fleet sync` aborts with `fatal: work-dir is on default branch "main"; refusing to resume on a protected branch` on any repo with `Missing > 0` workflows, blocking dry-run preflight, `--apply`, and `--apply --prune` paths.
+
+## Clarifications
+
+### Session 2026-05-12
+
+- Q: How thick should the new apply-path regression test be (FR-008b, US2)? → A: Stop at the commit gate. Assert `res.Deploy.Added` is populated and the fake `gh` shim recorded one `aw add` per missing workflow; do not fake `gh pr create`. Push/PR coverage already lives in `deploy_test.go`; this test pins only the resume-guard bypass.
+- Q: Which Conventional Commits type should the merge commit closing #48 use (`fix(sync):` vs `test(sync):`)? → A: `fix(sync):`. release-please surfaces `fix:` under "Fixed" in CHANGELOG; `test:` is hidden. Even though the diff is test-only, the user-facing delivery is the bug closure and belongs in release notes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator dry-runs `sync` for a repo with missing workflows (Priority: P1)
+
+A fleet operator is onboarding a repo (e.g., `rshade/finfocus`) into declared state. The repo's `.github/workflows/` directory lacks one or more workflows declared by its profile in `fleet.json`. The operator runs `gh-aw-fleet sync <repo>` (no `--apply`) to see what would change. They expect a clean dry-run summary listing the missing workflows and a successful exit code; they do **not** expect the tool to abort with a "refusing to resume" error message that refers to internal mechanics they did not invoke.
+
+**Why this priority**: The bug originally manifested most visibly here — the dry-run still printed its summary, then a fatal log line caused a non-zero exit. This was the gateway error operators hit first; if dry-run is broken, they have no confidence to run `--apply`. The fix scaffolding (the `InternalClone` field on `DeployOpts` and its plumbing through `runPreflight`) already shipped in PR #66, and one regression test exists. This story confirms that path stays covered and the behavior is what the issue requires.
+
+**Independent Test**: Construct a fleet config declaring one workflow that does not exist in the target's workflows directory. Invoke `Sync` with `SyncOpts{}` (Apply=false). Assert: returns nil error, `res.Missing` contains the workflow, `res.DeployPreflight` is non-nil, and `res.DeployPreflight.Added` contains the workflow (proving the preflight pipeline actually ran rather than aborting at the resume guard).
+
+**Acceptance Scenarios**:
+
+1. **Given** a fleet config where the target repo's profile declares workflows not present on disk, **When** the operator runs `gh-aw-fleet sync <repo>` without `--apply`, **Then** the command exits 0, prints the missing/expected/drift summary, and emits no `level=fatal` log line referencing "refusing to resume".
+2. **Given** the same setup, **When** Sync hands its internally-prepared clone to `Deploy` for preflight compilation, **Then** `Deploy` does not invoke the `handleWorkDirResume` branch and continues into `ensureInit`/`addResolvedWorkflows`, producing a populated `DeployPreflight` result on `SyncResult`.
+
+---
+
+### User Story 2 - Operator applies `sync` for a repo with missing workflows (Priority: P1)
+
+The operator confirmed the dry-run, then runs `gh-aw-fleet sync --apply <repo>` to open a PR adding the missing workflows. They expect the standard deploy flow — clone, switch to a new branch, `gh aw add` for each missing workflow, commit, push, open PR — to proceed normally. They do not expect the apply path to fail with the same protected-branch error that the dry-run preflight no longer triggers.
+
+**Why this priority**: This is the operator's actual goal. The dry-run is reconnaissance; the `--apply` path is the value delivery. If P1 (dry-run) is covered but P2 (apply) regresses silently, the operator loses the ability to onboard repos through `sync` and is forced into the documented workaround (`deploy --apply`), which is itself only partially functional (no prune support).
+
+**Independent Test**: Construct the same fleet config as US1 plus a fake `gh` shim that records every invocation. Invoke `Sync` with `SyncOpts{Apply: true}`. Assert: returns nil error, `res.Deploy` is non-nil, `res.Deploy.Added` contains the missing workflow, the fake `gh` shim recorded one `aw add` invocation per missing workflow, and no fatal error referencing "refusing to resume" surfaced. The test stops at the commit gate — it does not fake `gh pr create` and does not assert on `res.Deploy.PRURL`, because PR creation is already covered by `deploy_test.go` and is not under test for the resume-guard regression.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fleet config with one missing workflow declared, **When** the operator runs `gh-aw-fleet sync --apply <repo>`, **Then** `Sync` calls `Deploy` with `InternalClone=true`, the resume guard at `internal/fleet/deploy.go:203` is bypassed, and the apply pipeline runs through `addResolvedWorkflows` and reaches the commit gate with `res.Deploy.Added` populated (the regression test stops at this point per the Clarifications session; downstream push/PR steps are out of scope for this test).
+2. **Given** an operator runs `--apply` against a repo that is `Missing == 0`, **When** the command runs, **Then** behavior is unchanged from before this spec — no `Deploy` call, no resume guard interaction, no error — proving the fix does not regress repos already in declared state.
+
+---
+
+### User Story 3 - Operator runs `sync --apply --prune` in a single shot (Priority: P2)
+
+The operator has a repo with both drift (workflow files present that fleet.json does not declare) and missing workflows. They want one PR that removes the drift files and adds the missing workflows. They run `gh-aw-fleet sync --apply --prune <repo>` and expect a single PR containing both the deletions and the additions.
+
+**Why this priority**: This combination is the one path with no documented workaround in the issue. `deploy --apply` covers the additive case but does not prune, so a repo requiring both operations currently cannot be reconciled in a single PR. Covering it as an acceptance scenario both validates the fix and protects the orchestration in `applyDeployOrPrune` (prune first, then call `Deploy` with the prepared clone) against future regressions.
+
+**Independent Test**: Construct a fleet config declaring workflow A; seed the on-disk workflows directory with workflow B (drift) but not A (missing). Invoke `Sync` with `SyncOpts{Apply: true, Prune: true}`. Assert: returns nil error, `res.Pruned` contains B, `res.Deploy.Added` contains A, and the fake `gh` shim records the staged deletion before the add — proving both operations occurred under one `Deploy` invocation that bypassed the resume guard.
+
+**Acceptance Scenarios**:
+
+1. **Given** a target repo with `Drift > 0` (workflow B on disk, not declared) and `Missing > 0` (workflow A declared, not on disk), **When** the operator runs `gh-aw-fleet sync --apply --prune <repo>`, **Then** `applyDeployOrPrune` removes B and stages the deletion, then calls `Deploy` with `InternalClone=true` to add A, and both changes land in the result without the resume guard firing.
+2. **Given** the same drift+missing setup, **When** `--prune` is omitted (just `--apply`), **Then** only A is added and B remains untouched on disk, confirming prune is opt-in and the InternalClone propagation does not accidentally enable prune behavior.
+
+---
+
+### Edge Cases
+
+- **Repo already at declared state (Missing == 0, Drift == 0).** Sync must not invoke `Deploy` at all (`sync.go` short-circuits before both `runPreflight` and `applyDeployOrPrune`'s `Deploy` call). The fix must not regress this path — no `InternalClone` propagation issues can arise if `Deploy` is never called.
+- **Operator-supplied `--work-dir <existing-clone>`.** When `SyncOpts.WorkDir != ""`, `InternalClone` must remain `false` on the `DeployOpts` passed downstream so a genuine user-initiated resume still triggers `handleWorkDirResume`. The wiring in `sync.go:158` and `sync.go:206` (`InternalClone: opts.WorkDir == ""`) encodes this contract; the spec covers it as a negative test.
+- **`Sync` called with `--prune` but without `--apply`.** Already errors with `"--prune requires --apply"` at `sync.go:66` — the spec must not relax this validation while adding coverage to the apply+prune path.
+- **`Sync` with `Apply=true` but `Missing == 0` and `Drift > 0` (prune-only).** Goes through `commitAndPushPrune` (`sync.go:165–167`), never calling `Deploy`. The fix must not perturb this path; if a future refactor routes prune-only through `Deploy`, the InternalClone propagation must be re-evaluated.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `Sync` MUST hand its internally-prepared clone to `Deploy` in a way that distinguishes it from a user-supplied `--work-dir` resume request, so `Deploy`'s resume-on-protected-branch safety check does not fire on those calls. (Already implemented via `DeployOpts.InternalClone`; this spec pins the behavior with regression tests.)
+- **FR-002**: When `Sync` is invoked without `--apply` and the target repo has at least one missing workflow, `Sync` MUST return successfully (nil error) after populating `SyncResult.DeployPreflight`, and MUST NOT surface any error message containing "refusing to resume".
+- **FR-003**: When `Sync` is invoked with `--apply` and the target repo has at least one missing workflow, `Sync` MUST drive `Deploy` through its add → commit → push → PR pipeline using the internally-prepared clone, and MUST NOT surface any error message containing "refusing to resume".
+- **FR-004**: When `Sync` is invoked with `--apply --prune` and the target repo has both drift and missing workflows, `Sync` MUST remove the drift files first, then call `Deploy` to add the missing workflows on the same clone, producing a single result containing both `Pruned` and `Deploy.Added` populated.
+- **FR-005**: When `Sync` is invoked with `SyncOpts.WorkDir` explicitly set by the operator (`--work-dir <path>`), `Sync` MUST propagate `InternalClone=false` so `Deploy`'s resume detection still runs and the protected-branch guard remains in force for genuine user-initiated resume attempts.
+- **FR-006**: The `--prune` flag without `--apply` MUST continue to error with the message `"--prune requires --apply"` — this validation predates the spec and is unchanged.
+- **FR-007**: Repos already in declared state (`Missing == 0`, `Drift == 0`) MUST NOT trigger any `Deploy` invocation under any combination of `Sync` flags that this spec covers, preserving the existing short-circuit semantics in `sync.go`.
+- **FR-008**: Test coverage in `internal/fleet/sync_test.go` MUST include at minimum: (a) the existing dry-run preflight case (P1), (b) a new apply case proving the resume guard is bypassed (P1) — depth: stop at the commit gate, assert `res.Deploy.Added` populated and fake `gh` recorded one `aw add` per missing workflow, do not fake `gh pr create`, (c) a new apply+prune case proving both operations execute on the same internal clone (P2) — same depth as (b), with the added assertion that the staged prune deletion is observable before the `aw add` calls. Coverage for the negative case (operator-supplied `--work-dir` preserves the guard, FR-005) is desirable but may live in `deploy_test.go` if more natural there.
+- **FR-009**: Issue #48 on GitHub MUST be referenced from the merge commit, and the commit subject MUST use Conventional Commits type `fix(sync):` (e.g., `fix(sync): close resume-guard regression coverage gap (#48)`). `test(sync):` is rejected because release-please hides `test:` from `CHANGELOG.md`, which would invisibilize the bug closure to users reading release notes. Once tests merge and `make ci` is green, issue #48 must be closed with a comment linking to the merge commit.
+
+### Key Entities
+
+- **`SyncOpts.WorkDir`** — operator-facing flag value. Empty when omitted (the common case). Non-empty when the operator explicitly resumes an interrupted apply.
+- **`DeployOpts.InternalClone`** — internal-only signal added in PR #66. `true` whenever `Sync` is the caller and the clone was prepared by `prepareClone` in this process. The disambiguator that makes FR-001 implementable without renaming the `WorkDir` field.
+- **`SyncResult.DeployPreflight`** — populated when `Apply=false` and `Missing > 0`; the assertion target proving the preflight call site bypassed the resume guard.
+- **`SyncResult.Deploy`** — populated when `Apply=true` and `Missing > 0`; the assertion target proving the apply call site bypassed the resume guard.
+- **`SyncResult.Pruned`** — populated when `Apply=true && Prune=true && Drift > 0`; the assertion target proving prune ran before `Deploy` under the combined-flag path.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Fleet operator dry-run, apply, and apply+prune `sync` invocations against repos with `Missing > 0` complete without any `"refusing to resume"` error reaching the operator — measured by the existing test `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` continuing to pass *and* the new `TestSyncApplyBypassesResumeGuard` + `TestSyncApplyPruneBypassesResumeGuard` cases passing; each case asserts the absence of the substring on the returned error and on captured logs.
+- **SC-002**: An operator can reconcile a repo requiring both drift removal and missing-workflow additions in **one** invocation of `gh-aw-fleet sync --apply --prune <repo>`, producing **one** PR — measured by a new test demonstrating that `applyDeployOrPrune` calls `Deploy` exactly once when both `Pruned` and `Missing` are non-empty, and by the operator's ability to run the command against a real repo without falling back to the two-PR workaround.
+- **SC-003**: The new sync test cases are *cheap* — observable indirectly via `make test` wall-clock not regressing materially from the pre-slice baseline. This is **not CI-enforced** (no per-test timing gate exists); the goal is design discipline (reuse `newTestRepo` + `installFakeGhForSync`, stop at the commit gate, avoid network calls) rather than a measured ceiling. If a future test breaches this design, it should be split rather than retroactively wired into a CI timer.
+- **SC-004**: Zero new external dependencies introduced by this change — measured by `go.mod` and `go.sum` being unchanged after the spec is implemented (per project Constitution Principle I; the work is test-coverage-only against an already-shipped fix).
+- **SC-005**: Issue #48 is closed on GitHub within the same change set that lands the new tests, with a closing comment that links to the merge commit and identifies PR #66 as the original fix — measured by the issue state being `CLOSED` and the comment present.
+- **SC-006**: The `DeployOpts.InternalClone` field's godoc remains accurate and self-explanatory after this work — measured by `make lint` (which runs `revive`/`staticcheck` with no `exported X should have comment` suppressions per `AGENTS.md`) staying clean.
+
+## Assumptions
+
+- The field-level fix described in the issue's "Suggested fix — Option 1" already landed in PR #66 (commit `0694ae9`, merged 2026-04-30). This spec's primary deliverable is therefore the regression-coverage gap, not a fresh implementation of `InternalClone`. The issue remained open because the apply and apply+prune call sites lacked dedicated tests proving the fix held.
+- The user explicitly preferred Option 1 (single field addition) over Option 2 (split `CloneDir` vs. `WorkDir` params) in the issue body. This spec honors that preference and does not include a follow-on refactor to rename or split the field. If the codebase later outgrows the single-flag approach, that becomes a separate spec.
+- Test infrastructure (`newTestRepo`, `installFakeGhForSync`) already exists in `internal/fleet/sync_test.go` and is sufficient for the new cases. The fake `gh` script may need a small extension to record `aw add` invocations more strictly (e.g., counting them) for the apply-path assertions; that's an in-test edit, not a new helper.
+- The new tests for the apply and apply+prune paths stop at the commit gate. They do **not** fake `gh pr create`, do **not** drive a real `git push`, and do **not** assert on `res.Deploy.PRURL`. The success condition is that `Deploy` executes past `handleWorkDirResume` and reaches `addResolvedWorkflows` — observable through `res.Deploy.Added` being populated and the fake `gh` shim recording one `aw add` per missing workflow. PR-creation coverage already exists in `deploy_test.go` and is not under test for the resume-guard regression. This depth choice keeps the per-test wall-clock under ~50ms and avoids growing the fake `gh` shim into a PR-creation fixture.
+- The Conventional Commits type for the merge commit is `fix(sync):` (clarified in Session 2026-05-12). `test(sync):` and `ci(workflows):` are both rejected: `test:` is hidden from `CHANGELOG.md` by release-please and would invisibilize the bug closure; `ci(workflows):` is reserved for changes that modify generated workflow files in target repos per `AGENTS.md`. release-please will categorize `fix(sync):` under "Fixed" in `CHANGELOG.md`, surfacing the issue #48 closure in the next release notes.
+- The operator does not need any user-facing CLI documentation update for this change. `gh-aw-fleet sync` retains its existing flags and exit-code contract; the fix restores the documented behavior. No `--help` text, README, or skill file needs to change.

--- a/specs/008-fix-sync-resume-guard/tasks.md
+++ b/specs/008-fix-sync-resume-guard/tasks.md
@@ -1,0 +1,195 @@
+---
+description: "Task list for Sync Resume-Guard Regression Coverage (Issue #48)"
+---
+
+# Tasks: Sync Resume-Guard Regression Coverage (Issue #48)
+
+**Input**: Design documents from `/specs/008-fix-sync-resume-guard/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: This slice **IS** the tests. The production fix (`DeployOpts.InternalClone`) already shipped in PR #66 (commit `0694ae9`, merged 2026-04-30). All implementation tasks below are test-only edits to `internal/fleet/sync_test.go` (plus one optional case in `internal/fleet/deploy_test.go`). No production source file is modified.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing. US1 is "verify the pre-existing test still passes" (no new code); US2 and US3 are the two new tests that close the regression coverage gap.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single Go project. All source under repository root. Tests co-located with the package under test in `internal/fleet/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify the working environment can run the new tests at all.
+
+- [X] T001 Run `go test -run TestSyncDryRunPreflightTreatsPreparedCloneAsInternal ./internal/fleet/...` from repo root to confirm the existing sync test passes on the current branch before any edits. Captures the green baseline so any subsequent failure is attributable to this slice's edits.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extend the fake-`gh` shim so both new tests can assert on `aw add` invocation count and ordering. Per [research.md Decision 1](./research.md), the shim writes an append-only log to `$FAKE_GH_LOG`.
+
+**⚠️ CRITICAL**: This shim extension blocks both US2 and US3. Complete this phase before starting either user story.
+
+- [X] T002 In `internal/fleet/sync_test.go` extend `installFakeGhForSync` (currently lines 47–83) to: (a) accept the log path implicitly via the existing `t.TempDir()` `binDir` — create `logPath := filepath.Join(binDir, "fake-gh.log")` and call `t.Setenv("FAKE_GH_LOG", logPath)`; (b) in the shell script, in each existing branch (`aw init`, `aw add`), append a canonical event line to `${FAKE_GH_LOG:?}` *before* `exit 0` — format: `init\n` for the init branch and `add <spec>\n` for the add branch (where `<spec>` is the unmodified `$3`); (c) keep `set -eu` and use `${FAKE_GH_LOG:?}` so a missing setenv fails the test loudly. Do **not** alter the existing `repo clone` branch — it has nothing to log for the cases under test. Return the log path from the helper (change signature to `installFakeGhForSync(t *testing.T, remote string) (logPath string)`) so each caller can `os.ReadFile(logPath)` without re-deriving the path.
+
+- [X] T003 [P] In `internal/fleet/sync_test.go` update the existing `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` (line 10) to capture the new return value from `installFakeGhForSync` with `_ = installFakeGhForSync(t, remote)` — the dry-run test does not need to assert on the log, but the call site must compile after T002 changes the signature. This is a pure mechanical edit; it must not change the existing assertions.
+
+**Checkpoint**: Foundation ready — `go test -run TestSyncDryRunPreflightTreatsPreparedCloneAsInternal ./internal/fleet/...` still passes, and US2/US3 can now consume `$FAKE_GH_LOG`.
+
+---
+
+## Phase 3: User Story 1 — Operator dry-runs `sync` for a repo with missing workflows (Priority: P1)
+
+**Goal**: Pin the dry-run preflight path — `Sync` with `Apply=false` and `Missing > 0` returns nil, populates `DeployPreflight`, and never triggers the resume guard.
+
+**Independent Test**: `go test -run TestSyncDryRunPreflightTreatsPreparedCloneAsInternal ./internal/fleet/...` returns PASS.
+
+This story is **already covered** by the pre-existing `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` (sync_test.go:10). The only US1 task is verifying that coverage survives the Phase 2 shim signature change.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] After T002/T003 land, run `go test -run TestSyncDryRunPreflightTreatsPreparedCloneAsInternal ./internal/fleet/...` and confirm PASS. If it fails, the Phase 2 edits regressed the dry-run path — fix the shim change before proceeding to US2.
+
+**Checkpoint**: US1 is green and the dry-run regression coverage from PR #66 remains intact.
+
+---
+
+## Phase 4: User Story 2 — Operator applies `sync` for a repo with missing workflows (Priority: P1) 🎯 MVP
+
+**Goal**: Prove `Sync` with `Apply=true` and `Missing > 0` drives `Deploy` past the resume guard (`internal/fleet/deploy.go:203`) and into `addResolvedWorkflows`. This is the load-bearing deliverable per spec FR-008(b) and the gate for closing issue #48.
+
+**Independent Test**: `go test -run TestSyncApplyBypassesResumeGuard ./internal/fleet/...` returns PASS, demonstrating `res.Deploy.Added` is populated and the fake-`gh` log recorded one `add` line per missing workflow.
+
+### Implementation for User Story 2
+
+- [X] T005 [US2] In `internal/fleet/sync_test.go` add a new test function `TestSyncApplyBypassesResumeGuard`. Construct the same fixture shape as `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` (one repo, profile `default`, source `githubnext/agentics` pinned to `v1.0.0`, one workflow `ci-doctor`). Set `remote := newTestRepo(t, nil)` (helper at `internal/fleet/deploy_test.go:530`). Capture `logPath := installFakeGhForSync(t, remote)`. Invoke `Sync(context.Background(), cfg, repo, SyncOpts{Apply: true})`. The test stops at the commit gate per Clarifications Session 2026-05-12 — accept that `Sync` may return a non-nil error from the downstream `git push` / `gh pr create` steps that the fake shim does not simulate. **Assert on observable state regardless of return error**: (a) `res.Missing` contains `ci-doctor` (sanity), (b) `res.Deploy != nil` and `res.Deploy.Added` contains a workflow whose `Name == "ci-doctor"` — proving `addResolvedWorkflows` ran past the resume guard, (c) read `logPath` and assert it contains exactly one line starting with the literal prefix `"add "` whose suffix is `githubnext/agentics/ci-doctor@v1.0.0` — proving the fake `gh aw add` shim was invoked once with the fleet-pinned spec, (d) the log MUST NOT be missing or empty (would mean Deploy aborted before `addResolvedWorkflows`). Count occurrences by splitting the log on `"\n"` and counting lines whose `strings.HasPrefix(line, "add ")` returns true — do **not** use `strings.Count(string(log), "\nadd ")`, which misses the first line when it is the very first record written (no preceding newline). Use `strings.Contains` for the per-spec substring assertion. Do **not** assert on `res.Deploy.PRURL`, `res.Deploy.MissingSecret`, `res.Deploy.ActionsDisabled`, or `res.Deploy.SecurityFindings` — those are downstream of the guard and out of scope per spec FR-008(b).
+
+- [X] T006 [US2] Run `go test -run TestSyncApplyBypassesResumeGuard ./internal/fleet/...` and confirm PASS. If it fails with a `"refusing to resume"` fatal in the test output, the resume guard regressed — re-read `internal/fleet/deploy.go:203` and `internal/fleet/sync.go:158` to verify the `InternalClone: opts.WorkDir == ""` wiring is unbroken on the current branch.
+
+**Checkpoint**: US2 is green. This single test is sufficient to close issue #48 from the operator's perspective — `sync --apply` against a `Missing > 0` repo is provably back to working.
+
+---
+
+## Phase 5: User Story 3 — Operator runs `sync --apply --prune` in a single shot (Priority: P2)
+
+**Goal**: Prove `Sync` with `Apply=true && Prune=true` against a repo that has both drift and missing workflows runs prune first and then `Deploy` on the same clone, producing a single result with both `Pruned` and `Deploy.Added` populated. Protects `applyDeployOrPrune`'s prune-then-deploy orchestration against future regressions.
+
+**Independent Test**: `go test -run TestSyncApplyPruneBypassesResumeGuard ./internal/fleet/...` returns PASS, demonstrating `res.Pruned` contains the seeded drift workflow, `res.Deploy.Added` contains the declared-but-missing workflow, and the order of events in the fake-`gh` log is consistent with prune-before-add.
+
+### Implementation for User Story 3
+
+- [X] T007 [US3] In `internal/fleet/sync_test.go` add a new test function `TestSyncApplyPruneBypassesResumeGuard`. Construct the same config shape as T005 but with the additional drift fixture. `newTestRepo` at `internal/fleet/deploy_test.go:530` has signature `func(t *testing.T, setup func(dir string)) string` — pass a setup callback (NOT a map) that creates `.github/workflows/drifted.md` inside the test repo with placeholder frontmatter (e.g., `"---\nsource: legacy/drifted@v0\n---\n"`) and commits it via `exec.Command("git", "add", "...")` + `exec.Command("git", "commit", "-m", "seed drift")` (mirror the file-write + `git add` + `git commit` pattern used elsewhere in `deploy_test.go`). The test repo itself acts as the remote that the fake `gh repo clone` consumes, so the seeded file must be present in HEAD before `Sync` runs. Declared workflows: only `ci-doctor` (so `drifted.md` is drift; `ci-doctor.md` is missing). Capture `logPath := installFakeGhForSync(t, remote)`. Invoke `Sync(context.Background(), cfg, repo, SyncOpts{Apply: true, Prune: true})`. Stop at the commit gate per Clarifications Session 2026-05-12. **Assertions** (made regardless of return error from downstream push/PR): (a) `res.Drift` contains `drifted` and `res.Missing` contains `ci-doctor` (sanity), (b) `res.Pruned` contains `drifted` — proving `pruneDriftFiles` ran, (c) `res.Deploy != nil` and `res.Deploy.Added` contains a workflow whose `Name == "ci-doctor"` — proving `Deploy` ran past the resume guard on the same clone after prune, (d) read `logPath` and assert exactly one line with the literal `"add "` prefix and exactly one line with the literal `"init"` prefix if init fires before add (otherwise just one `add`-prefixed line) — the count assertion is the load-bearing one; the order-of-operations assertion for prune-before-add is observable via `res.Pruned` being non-empty when `res.Deploy.Added` is non-empty in the same `*SyncResult` (the data structure encodes the order in code). Do **not** add a separate observation channel for git-add-after-prune; the existing assertions on `res.Pruned` plus `res.Deploy.Added` are sufficient per spec FR-008(c).
+
+- [X] T008 [US3] In `internal/fleet/sync_test.go` add a second test function `TestSyncApplyWithoutPruneLeavesDriftUntouched` covering the negative case from spec Acceptance Scenario US3.2: same fixture as T007 but invoke `Sync` with `SyncOpts{Apply: true}` (no `Prune`). Assert in this order: (a) `res.CloneDir != ""` (sanity — if empty, `Deploy` aborted before `prepareClone` returned, and the subsequent file-existence check below would `Stat` an invalid path with a misleading error), (b) `res.Pruned` is empty (drift remained untouched), (c) `res.Deploy.Added` still contains `ci-doctor` (missing got added), (d) `drifted.md` still exists on disk at `filepath.Join(res.CloneDir, ".github", "workflows", "drifted.md")`. This pins the `--prune` opt-in contract from the spec's US3 acceptance scenario; FR-007's broader Missing==0/Drift==0 short-circuit is covered separately in T016.
+
+- [X] T009 [US3] Run `go test -run TestSyncApplyPrune ./internal/fleet/...` and confirm both new cases pass.
+
+**Checkpoint**: US3 is green. The only path with no documented workaround (`--apply --prune` against a drift+missing repo) is now regression-tested.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Pin the two negative-case FRs (FR-006, FR-007), run the full CI gate, optionally cover FR-005 in `deploy_test.go`, and close issue #48 per FR-009 / SC-005.
+
+- [X] T015 [P] [Polish] **FR-006 negative-case coverage.** In `internal/fleet/sync_test.go` add `TestSyncPruneWithoutApplyErrors`: invoke `Sync(context.Background(), cfg, repo, SyncOpts{Prune: true, Apply: false})` with any valid `cfg`/`repo` shape (the existing US1 fixture works — no fake `gh` needed because validation fires at `sync.go:66` before any `gh` invocation). Assert the returned `err` is non-nil and its `Error()` contains the substring `"--prune requires --apply"`. ~5 lines of test code. Pins the validation gate against silent removal by future refactors.
+
+- [X] T016 [P] [Polish] **FR-007 short-circuit coverage.** In `internal/fleet/sync_test.go` add `TestSyncNoMissingNoDriftShortCircuits`: construct a fleet config whose declared workflow already exists on disk in the test repo's `.github/workflows/` (seed it via `newTestRepo`'s `setup func(dir string)` callback — same shape as T007, but the seeded file's frontmatter `source:` matches the declared `githubnext/agentics/ci-doctor@v1.0.0` exactly so it counts as in-state, not drift). Capture `logPath := installFakeGhForSync(t, remote)`. Run the matrix `SyncOpts{Apply: false}`, `SyncOpts{Apply: true}`, and `SyncOpts{Apply: true, Prune: true}` in a table-driven loop. For each case assert: (a) `err == nil`, (b) `res.Deploy == nil` AND `res.DeployPreflight == nil` (no `Deploy` invocation under any flag combo), (c) `res.Pruned` is empty, (d) the fake-`gh` log at `logPath` contains zero `"add "`-prefixed lines. Pins FR-007 against any future refactor that accidentally routes a repo-at-declared-state through `Deploy`.
+
+- [X] T010 [P] Investigate whether `internal/fleet/deploy_test.go` already covers FR-005 (operator-supplied `--work-dir` keeps `InternalClone=false` and the resume guard active). Grep for `InternalClone` in `internal/fleet/deploy_test.go`; if any existing case constructs `DeployOpts{WorkDir: "...", InternalClone: false}` against a clone on a default branch and asserts the `"refusing to resume"` error, mark FR-005 as already covered and skip T011. If not, proceed to T011. Per [research.md Decision 2](./research.md), this coverage belongs in `deploy_test.go`, not `sync_test.go`.
+
+- [X] T011 [P] (Conditional on T010 finding no existing coverage.) In `internal/fleet/deploy_test.go` add `TestDeployUserSuppliedWorkDirTriggersResumeGuard`: prepare a temp directory that looks like a fresh clone of a repo on its default branch (no feature branch checked out), call `Deploy(ctx, cfg, repo, DeployOpts{Apply: false, WorkDir: tempDir, InternalClone: false})`, assert the returned error contains the substring `"refusing to resume"` and is a non-nil error. This pins the negative case for the field's contract.
+
+- [X] T012 Run `make ci` from repo root. All four steps (`fmt-check vet lint test`) MUST pass. Per AGENTS.md, `make lint` can run over 5 minutes locally — do not skip and do not bypass with `--no-verify`. `revive`/`staticcheck` MUST stay clean on `DeployOpts.InternalClone`'s godoc per SC-006 (the field's godoc was not edited; if a lint complains, re-read PR #66's diff).
+
+- [ ] T013 Run the manual smoke (optional, per [quickstart.md](./quickstart.md#manual-smoke-optional-against-a-real-repo)): `go run . sync rshade/finfocus` should exit 0 with no `"refusing to resume"` line on stderr. Not required for the slice to ship — included for reviewer confidence.
+
+- [ ] T014 After the PR merges (separate PR-merge turn, not part of this slice's commit), close issue #48 with `gh issue close 48 --repo rshade/gh-aw-fleet --comment "Fixed by PR #66 (field-level fix, merged 2026-04-30); regression coverage added in <merge-commit-sha> via PR #<this-pr>."` per FR-009 and SC-005. The commit subject MUST start with `fix(sync):` so release-please surfaces the closure under "Fixed" in `CHANGELOG.md`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1, T001)**: No dependencies — run first to confirm green baseline.
+- **Foundational (Phase 2, T002–T003)**: Depends on Setup. T002 is the load-bearing shim extension; T003 is the mechanical signature-fix follow-up. **Blocks US2 and US3.**
+- **US1 (Phase 3, T004)**: Depends on Phase 2 (because the existing test now consumes the new `installFakeGhForSync` return).
+- **US2 (Phase 4, T005–T006)**: Depends on Phase 2. Independent of US1 verification (US1 just confirms no regression).
+- **US3 (Phase 5, T007–T009)**: Depends on Phase 2. Independent of US2 — but if doing serial MVP-first, US2 is the priority gate for closing #48.
+- **Polish (Phase 6, T010–T016)**: T015 (FR-006) and T016 (FR-007) are independent negative-case coverage tasks; they share `sync_test.go` with US1/US2/US3 so they cannot literally run `[P]` against T002/T005/T007 but can land in either order relative to each other. Both depend on Phase 2's signature change so the `installFakeGhForSync` return value is consumable. T010/T011 are optional FR-005 coverage and can run any time after Phase 2. T012 (`make ci`) depends on all US tasks AND on T015/T016. T013 is optional. T014 happens post-merge.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Already covered by `TestSyncDryRunPreflightTreatsPreparedCloneAsInternal` — Phase 3 only re-verifies.
+- **US2 (P1)**: Independent; this is the MVP for closing #48.
+- **US3 (P2)**: Independent; protects `applyDeployOrPrune` but not strictly required to close #48.
+
+### Within Each User Story
+
+- US2 (T005, T006): T005 writes the test, T006 runs it. Sequential.
+- US3 (T007, T008, T009): T007 and T008 write different test functions in the same file (cannot mark `[P]` because they share `sync_test.go`); T009 runs both.
+
+### Parallel Opportunities
+
+- **T002 and T005 cannot run in parallel** (same file: `sync_test.go`). T005 depends on T002's signature change.
+- **T003 must follow T002** (also `sync_test.go`).
+- **US2 and US3 are independent in design** but the test functions share `sync_test.go`, so coding them in parallel is impractical — sequential is faster than rebasing twice.
+- **T010 and T011** can run in parallel with T012 only if the developer is comfortable splitting `deploy_test.go` (T011) and the `make ci` run (T012); typical workflow runs T012 last.
+- **The pre-existing US1 test (T004) and the new US2 test (T006) can be run in parallel** as separate `go test -run` invocations — both consume `installFakeGhForSync` but at different test-function granularity.
+
+---
+
+## Parallel Example
+
+```bash
+# Phase 6 (after US tasks land), confirm individual test functions before make ci:
+go test -run TestSyncDryRunPreflightTreatsPreparedCloneAsInternal ./internal/fleet/... &
+go test -run TestSyncApplyBypassesResumeGuard ./internal/fleet/... &
+go test -run TestSyncApplyPruneBypassesResumeGuard ./internal/fleet/... &
+wait
+```
+
+(`make test` runs everything serially via `go test ./...` and is the real CI gate.)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 verification + US2)
+
+1. T001: confirm green baseline.
+2. T002, T003: extend the fake-`gh` shim and fix the pre-existing test's call site.
+3. T004: confirm US1 still green.
+4. T005, T006: add and run `TestSyncApplyBypassesResumeGuard`.
+5. **STOP and VALIDATE**: at this point, issue #48 is technically closable — the apply path (operator's actual workflow) is regression-tested. T007–T009 (US3) are nice-to-have polish but not required for the bug closure.
+
+### Incremental Delivery
+
+1. Setup + Foundational (T001–T003) → fake-gh shim emits a log.
+2. US1 verification (T004) → MVP baseline holds.
+3. US2 (T005–T006) → apply-path regression test green → **issue #48 closable**.
+4. US3 (T007–T009) → apply+prune path locked in.
+5. Polish (T010–T014) → optional FR-005 negative case, full `make ci`, issue close.
+
+### Single-Developer Strategy
+
+Recommended order: T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 → T015 → T016 → T010 → T011 → T012 → T013 → T014. All edits land in one PR with subject `fix(sync): close resume-guard regression coverage gap (#48)`. T015 and T016 are inserted *before* T010/T011 because they target sync_test.go (already the open editor for US1/US2/US3) — finishing all sync_test.go edits before pivoting to deploy_test.go keeps file-context churn minimal.
+
+---
+
+## Notes
+
+- **No production source files are modified.** All edits target `internal/fleet/sync_test.go` (load-bearing) and optionally `internal/fleet/deploy_test.go` (FR-005 negative case). `go.mod` and `go.sum` MUST be unchanged after this slice (SC-004).
+- **Commit subject**: `fix(sync): close resume-guard regression coverage gap (#48)` per FR-009. `test(sync):` is rejected because release-please hides `test:` from `CHANGELOG.md`.
+- **The tests stop at the commit gate** per Clarifications Session 2026-05-12 — do not fake `gh pr create`, do not assert on `res.Deploy.PRURL`, do not extend the fake-`gh` shim to handle `pr` invocations.
+- **Wall-clock budget**: each new test ≤ 50ms, cumulative ≤ 200ms (SC-003). Reuse `newTestRepo` and `installFakeGhForSync` to stay under budget.
+- **`gpg` signing must not be bypassed** anywhere — irrelevant to this slice (no commits made by the tool path under test), but a standing invariant per AGENTS.md.
+- **Issue closure (T014) is a post-merge action**, not part of the implementation commit. Sequence: merge PR → release-please picks up `fix(sync):` → close #48 with comment linking merge commit and PR #66.


### PR DESCRIPTION
## Summary

- Pin the bug-#48 fix that shipped scaffolding in PR #66 with five new sync regression tests so `gh-aw-fleet sync --apply` and `sync --apply --prune` cannot silently regress to aborting with `refusing to resume on a protected branch` on repos that have missing workflows.
- Capture the inverse contract: a user-supplied `--work-dir` with `InternalClone=false` still trips the resume guard, so the bypass cannot leak to operator-driven flows.
- Roadmap housekeeping: mark #54, #55, and #73 shipped under 2026-Q2, narrow Immediate Focus to #48 alone, and document a Release Composition Rule (each feature-bearing release ships at least one `cost` and at least one `security` item).

## Test plan

- [x] `make ci` passes (fmt-check, vet, golangci-lint, full test suite) with zero issues.
- [x] All six new tests pass: `TestDeployUserSuppliedWorkDirTriggersResumeGuard`, `TestSyncApplyBypassesResumeGuard`, `TestSyncApplyPruneBypassesResumeGuard`, `TestSyncApplyWithoutPruneLeavesDriftUntouched`, `TestSyncPruneWithoutApplyErrors`, `TestSyncNoMissingNoDriftShortCircuits`.
- [x] Apply-path tests assert on a deterministic fake-`gh` call transcript (`$FAKE_GH_LOG`), proving `addResolvedWorkflows` ran past the resume guard rather than only inspecting `SyncResult`.

## Changes

### New files

- `specs/008-fix-sync-resume-guard/spec.md` - User stories (US1 dry-run, US2 apply, US3 apply+prune) and acceptance scenarios for the resume-guard regression.
- `specs/008-fix-sync-resume-guard/plan.md` - Implementation plan; records the `fix(sync):` commit-type clarification (the diff is test-only but the user-facing delivery is the bug closure).
- `specs/008-fix-sync-resume-guard/tasks.md` - Task breakdown.
- `specs/008-fix-sync-resume-guard/data-model.md`, `research.md`, `quickstart.md`, `checklists/requirements.md` - Supporting design notes.

### Modified files

- `internal/fleet/sync_test.go` - Add five sync regression tests covering apply, apply+prune, apply-without-prune, prune-without-apply, and no-missing-no-drift short-circuit. Expand `installFakeGhForSync` to record each `aw init` / `aw add` invocation to `$FAKE_GH_LOG` and return the log path. Add `seedDeclaredWorkflow`, `seedDriftedWorkflow`, and `gitInDir` helpers.
- `internal/fleet/deploy_test.go` - Add `TestDeployUserSuppliedWorkDirTriggersResumeGuard` proving the resume guard still fires when an operator supplies `--work-dir` directly (`InternalClone=false`).
- `ROADMAP.md` - Mark #54, #55, and #73 shipped under 2026-Q2; narrow Immediate Focus to #48; document the cost-plus-security Release Composition Rule and add `cost` / `security` to the labels glossary.
- `CLAUDE.md` - Link the speckit plan pointer to `specs/008-fix-sync-resume-guard/plan.md`.

Closes #48