### PR TITLE
feat(install): add install.sh and install.ps1 one-liner installers

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -1,0 +1,217 @@
+name: install-script
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+      - '.github/workflows/install-script.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+      - '.github/workflows/install-script.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ github.token }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: shellcheck install.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: shellcheck
+        run: shellcheck install.sh
+
+  psscriptanalyzer:
+    name: PSScriptAnalyzer install.ps1
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          $results = Invoke-ScriptAnalyzer -Path install.ps1 -Severity @('Warning', 'Error')
+          if ($results) {
+            $results | Format-List
+            throw "PSScriptAnalyzer reported $($results.Count) issue(s)."
+          }
+
+  smoke-posix:
+    name: smoke install.sh (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install (latest, default dir)
+        run: bash install.sh
+
+      - name: Verify default-dir binary runs
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          gh-aw-fleet --help >/dev/null
+          echo "ok: default-dir install runs"
+
+      - name: Install (custom INSTALL_DIR)
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/bin
+        run: bash install.sh
+
+      - name: Verify custom-dir binary runs
+        run: |
+          "${RUNNER_TEMP}/bin/gh-aw-fleet" --help >/dev/null
+          echo "ok: custom-dir install runs"
+
+      - name: Tamper test (corrupted checksums.txt -> non-zero exit)
+        run: |
+          set -uo pipefail
+          version=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/rshade/gh-aw-fleet/releases/latest \
+            | grep -E '^[[:space:]]*"tag_name":' | head -n1 \
+            | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+          version_strip="${version#v}"
+
+          uname_s=$(uname -s); uname_m=$(uname -m)
+          case "$uname_s" in Linux) os=linux ;; Darwin) os=darwin ;; *) exit 1 ;; esac
+          case "$uname_m" in x86_64|amd64) arch=amd64 ;; aarch64|arm64) arch=arm64 ;; *) exit 1 ;; esac
+          archive="gh-aw-fleet_${version_strip}_${os}_${arch}.tar.gz"
+          checksums="gh-aw-fleet_${version_strip}_checksums.txt"
+
+          srv="${RUNNER_TEMP}/tamper-srv"
+          rm -rf "$srv"
+          mkdir -p "$srv/${version}"
+          (cd "$srv/${version}" && \
+            curl -fsSL "https://github.com/rshade/gh-aw-fleet/releases/download/${version}/${archive}" -o "${archive}" && \
+            curl -fsSL "https://github.com/rshade/gh-aw-fleet/releases/download/${version}/${checksums}" -o "${checksums}")
+          sed -i.bak -E "s|^[0-9a-f]+([[:space:]]+${archive})|0000000000000000000000000000000000000000000000000000000000000000\1|" "$srv/${version}/${checksums}"
+          rm -f "$srv/${version}/${checksums}.bak"
+
+          python3 -m http.server -d "$srv" 8765 >/dev/null 2>&1 &
+          srv_pid=$!
+          trap 'kill $srv_pid 2>/dev/null || true' EXIT
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsSL "http://127.0.0.1:8765/${version}/${checksums}" -o /dev/null 2>&1; then break; fi
+            sleep 0.5
+          done
+
+          set +e
+          RELEASE_BASE_URL="http://127.0.0.1:8765" \
+          INSTALL_DIR="${RUNNER_TEMP}/tamper-install" \
+            bash install.sh 2>"${RUNNER_TEMP}/tamper.stderr"
+          rc=$?
+          set -e
+
+          echo "install.sh exit: $rc"
+          cat "${RUNNER_TEMP}/tamper.stderr"
+          if [ "$rc" -eq 0 ]; then
+            echo "FAIL: tampered checksum did not cause non-zero exit"
+            exit 1
+          fi
+          if ! grep -qi checksum "${RUNNER_TEMP}/tamper.stderr"; then
+            echo "FAIL: error message did not mention checksum"
+            exit 1
+          fi
+          echo "ok: tamper test rejected"
+
+  smoke-windows:
+    name: smoke install.ps1
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install (latest, default dir, -NoPath)
+        shell: pwsh
+        run: .\install.ps1 -NoPath
+
+      - name: Verify default-dir binary runs
+        shell: pwsh
+        run: |
+          $exe = Join-Path $env:LOCALAPPDATA 'gh-aw-fleet\bin\gh-aw-fleet.exe'
+          & $exe --help | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "gh-aw-fleet --help exit=$LASTEXITCODE" }
+          Write-Host 'ok: default-dir install runs'
+
+      - name: Install (custom -InstallDir)
+        shell: pwsh
+        run: .\install.ps1 -NoPath -InstallDir "$env:RUNNER_TEMP\bin"
+
+      - name: Verify custom-dir binary runs
+        shell: pwsh
+        run: |
+          $exe = Join-Path $env:RUNNER_TEMP 'bin\gh-aw-fleet.exe'
+          & $exe --help | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "gh-aw-fleet --help exit=$LASTEXITCODE" }
+          Write-Host 'ok: custom-dir install runs'
+
+      - name: Tamper test (corrupted checksums.txt -> non-zero exit)
+        shell: pwsh
+        run: |
+          $headers = @{}
+          if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+          $resp = Invoke-RestMethod -Uri 'https://api.github.com/repos/rshade/gh-aw-fleet/releases/latest' -Headers $headers
+          $version = $resp.tag_name
+          $verStrip = $version.TrimStart('v')
+          $arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+            'X64'   { 'amd64' }
+            'Arm64' { 'arm64' }
+          }
+          $archive   = "gh-aw-fleet_${verStrip}_windows_${arch}.zip"
+          $checksums = "gh-aw-fleet_${verStrip}_checksums.txt"
+
+          $srv = Join-Path $env:RUNNER_TEMP "tamper-srv\$version"
+          New-Item -ItemType Directory -Path $srv -Force | Out-Null
+          $base = "https://github.com/rshade/gh-aw-fleet/releases/download/$version"
+          Invoke-WebRequest -Uri "$base/$archive"   -OutFile (Join-Path $srv $archive)   -UseBasicParsing
+          Invoke-WebRequest -Uri "$base/$checksums" -OutFile (Join-Path $srv $checksums) -UseBasicParsing
+
+          $cksPath = Join-Path $srv $checksums
+          $content = Get-Content -LiteralPath $cksPath -Raw
+          $pattern = '(?m)^[0-9a-f]+(\s+' + [regex]::Escape($archive) + ')'
+          $replaced = [regex]::Replace($content, $pattern, ('0' * 64 + '$1'))
+          Set-Content -LiteralPath $cksPath -Value $replaced -NoNewline
+
+          $srvRoot = Join-Path $env:RUNNER_TEMP 'tamper-srv'
+          $py = Get-Command python -ErrorAction SilentlyContinue
+          if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+          if (-not $py) { throw 'python not available for tamper test http server' }
+          $proc = Start-Process -FilePath $py.Source -ArgumentList @('-m','http.server','8765') -WorkingDirectory $srvRoot -PassThru -WindowStyle Hidden
+          try {
+            for ($i = 0; $i -lt 20; $i++) {
+              try {
+                Invoke-WebRequest -Uri "http://127.0.0.1:8765/$version/$checksums" -OutFile $env:TEMP\probe -UseBasicParsing -ErrorAction Stop
+                break
+              } catch { Start-Sleep -Milliseconds 500 }
+            }
+
+            $tamperInstall = Join-Path $env:RUNNER_TEMP 'tamper-install'
+            $rejected = $false
+            $errMsg = ''
+            try {
+              & .\install.ps1 -NoPath -BaseUrl 'http://127.0.0.1:8765' -InstallDir $tamperInstall
+            } catch {
+              $rejected = $true
+              $errMsg = $_.Exception.Message
+              Write-Host "install.ps1 threw: $errMsg"
+            }
+            if (-not $rejected) { throw 'FAIL: tampered checksum did not cause failure' }
+            if ($errMsg -notmatch '(?i)checksum') { throw "FAIL: error did not mention checksum: $errMsg" }
+            Write-Host 'ok: tamper test rejected'
+          }
+          finally {
+            $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+          }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,9 @@ snapshot:
 # attaches binary artifacts + checksums to that existing release.
 release:
   mode: append
+  extra_files:
+    - glob: ./install.sh
+    - glob: ./install.ps1
 
 changelog:
   disable: true

--- a/README.md
+++ b/README.md
@@ -172,8 +172,66 @@ and `gh`.
 
 ### Install
 
-**Option 1 — Download a release binary (recommended).** Pre-built binaries
-are published for Linux, macOS, and Windows on amd64 and arm64:
+**Option 1 — One-liner installer (recommended).** Fetches the installer
+from the latest release's assets (immutable, pinned to a tagged version);
+the installer downloads the matching release archive for your OS/arch,
+verifies its SHA-256 against the release's `checksums.txt`, and drops the
+binary in your install directory.
+
+```bash
+# Linux / macOS — installs to $HOME/.local/bin
+curl -sSfL \
+  https://github.com/rshade/gh-aw-fleet/releases/latest/download/install.sh \
+  | bash
+```
+
+```powershell
+# Windows (PowerShell) — installs to %LOCALAPPDATA%\gh-aw-fleet\bin
+iwr -UseBasicParsing https://github.com/rshade/gh-aw-fleet/releases/latest/download/install.ps1 `
+  | iex
+```
+
+The release-asset URL is the recommended path — it pins to a tagged
+installer, not a moving `main`. If you're on a release that predates the
+installer assets and `releases/latest/download/install.*` 404s, fall back
+to the `main`-branch installer:
+
+```bash
+# Fallback — fetches install.sh from main
+curl -sSfL \
+  https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.sh \
+  | bash
+```
+
+```powershell
+# Fallback — fetches install.ps1 from main
+iwr -UseBasicParsing https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.ps1 `
+  | iex
+```
+
+Either way, the installer still installs a tagged release binary by
+default: the latest release unless you pin one.
+
+Customizing the install:
+
+- POSIX env vars — `VERSION=v0.2.0` pins a specific release (default:
+  latest); `INSTALL_DIR=/usr/local/bin` overrides the default location.
+- PowerShell parameters — `-Version v0.2.0` pins a release;
+  `-InstallDir <path>` overrides the install directory; `-NoPath` skips the
+  user-scope PATH update.
+
+PowerShell parameters require invoking the downloaded script as a
+`ScriptBlock`:
+
+```powershell
+$installer = [ScriptBlock]::Create(
+  (iwr -UseBasicParsing https://github.com/rshade/gh-aw-fleet/releases/latest/download/install.ps1).Content
+)
+& $installer -Version v0.2.0 -InstallDir "$env:LOCALAPPDATA\gh-aw-fleet\bin" -NoPath
+```
+
+**Option 2 — Manual release download.** Pre-built binaries are published
+for Linux, macOS, and Windows on amd64 and arm64:
 
 ```bash
 # Example: Linux amd64
@@ -186,13 +244,13 @@ See the
 [latest release](https://github.com/rshade/gh-aw-fleet/releases/latest)
 for all available platform archives and checksums.
 
-**Option 2 — `go install`.** Installs into `$(go env GOPATH)/bin`:
+**Option 3 — `go install`.** Installs into `$(go env GOPATH)/bin`:
 
 ```bash
 go install github.com/rshade/gh-aw-fleet@latest
 ```
 
-**Option 3 — Build from source.** For contributors and anyone working off
+**Option 4 — Build from source.** For contributors and anyone working off
 `main`:
 
 ```bash
@@ -202,10 +260,13 @@ go build -o gh-aw-fleet .
 ```
 
 > **Note on examples below:** all command examples use bare `gh-aw-fleet`
-> (assumes the binary is on your `PATH`, which is the case for Options 1
-> and 2). If you built from source via Option 3 and didn't install the
-> binary, prefix every `gh-aw-fleet` command with `./` to run it from the
-> build directory.
+> and assume the binary is on your `PATH`. Option 1 installs to
+> `$HOME/.local/bin` by default — make sure that's on your PATH. Option 3
+> installs to `$(go env GOPATH)/bin`, which is not automatically on PATH —
+> add it yourself if `which gh-aw-fleet` comes back empty. Option 2 lets
+> you pick the destination. If you built from source via Option 4 and
+> didn't install the binary, prefix every `gh-aw-fleet` command with `./`
+> to run it from the build directory.
 
 ### Example Workflow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,11 +40,12 @@ fleet-layer tool existing.
 
 **Status**: v0.1.x → v0.2 satisfied this (#54 / #55 / #56 cost
 prereqs, #37 Layer 1 security scanner). v0.3's cost half landed
-2026-05-15 (#57 consumption rollup); #49 covers the security half and
-is the headline remaining Near-Term item. v0.4 needs a fresh cost +
-security pair — the most likely candidates are the security-epic
-children (#38–#40) on the security side and a real-failure-triggered
-diagnostic refresh (#53) on the cost side.
+2026-05-15 (#57 consumption rollup); v0.3's security half landed
+2026-05-21 (#49 `--strict` default on public repos) — both
+composition slots filled, release-please cut imminent. v0.4 needs a
+fresh cost + security pair — the most likely candidates are the
+security-epic children (#38–#40) on the security side and a
+real-failure-triggered diagnostic refresh (#53) on the cost side.
 
 **Exception**: a release scoped as a single `fix:` hotfix (no feature
 changes) is exempt — the rule applies to feature-bearing releases.
@@ -52,37 +53,29 @@ changes) is exempt — the rule applies to feature-bearing releases.
 ## Immediate Focus (v0.3 in progress)
 
 v0.2 is tagged (release-please commit `c416f89`, 2026-05-15). v0.3's
-headline feature — the cross-fleet consumption rollup (#57) — merged in
-PR #83 on 2026-05-15 and is now in `main` awaiting the next release-please
-cut. Two items are now actively in flight: the security default flip
-(#49) closes v0.3's release-composition security half; the one-liner
-installers (#43) advance the contributor pipeline. Promoted together
-on 2026-05-17 via the gate's multi-select path (composition bump
-opened a second slot).
+release-composition pair both landed: cost half via #57 (consumption
+rollup, 2026-05-15) and security half via #49 (`--strict` default on
+public repos, 2026-05-21, PR #88). The release-please cut is queued.
+The one-liner installers (#43) remain in flight — the contributor-
+pipeline lever that advances v0.3's community-leverage half.
 
-- [ ] [#49](https://github.com/rshade/gh-aw-fleet/issues/49) Compile
-  workflows with `--strict` on public repos by default `[S]` `security`
-  *Public repos benefit from the upstream `gh aw` strict-mode validations
-  (e.g., `permissions:` defaults, action-pin checks). Default to
-  `--strict` when the target repo is public; document the auto-flip in
-  the deploy output. Operators on private repos opt in via flag.
-  Promoted by `/roadmap sync` on 2026-05-17 — composition: fills the
-  v0.3 release-composition security half (cost half landed via #57).*
 - [ ] [#43](https://github.com/rshade/gh-aw-fleet/issues/43) Add
   `install.sh` and `install.ps1` one-liner installers `[M]` `community`
   *Replace the four-step manual `gh release download` flow with curl/iwr
   one-liners. Ship both scripts as release assets (via
   `.goreleaser.yml` `extra_files`) and on `main` for a fallback URL.
-  Acceptance: checksum-verified install of `v0.1.0` on
-  ubuntu/macos/windows CI runners. Complements, does not replace, the
-  `gh extension` packaging item below. Promoted by `/roadmap sync` on
-  2026-05-17 — slot rationale: highest community-leverage with v0.3
-  composition pair filled.*
+  Acceptance: checksum-verified install on ubuntu/macos/windows CI
+  runners; tamper test asserts non-zero exit on corrupted
+  `checksums.txt`. Complements, does not replace, the `gh extension`
+  packaging item below. Promoted by `/roadmap sync` on 2026-05-17 —
+  slot rationale: highest community-leverage with v0.3 composition
+  pair filled.*
 
 ## Near-Term Vision (v0.3 — operator quality of life backlog)
 
-Both v0.3 release-composition items (#49 security, #43 community-leverage)
-are now in Immediate Focus. Near-Term is the unlinked operator-QoL
+v0.3's release-composition pair has landed: #49 (security, 2026-05-21)
+and #57 (cost, 2026-05-15). #43 (community-leverage, install scripts)
+remains in Immediate Focus. Near-Term is the unlinked operator-QoL
 backlog — open GitHub issues as work picks up, then `/roadmap sync`
 will rank them alongside any new `roadmap/next` items.
 
@@ -281,6 +274,13 @@ were deferred at v1 to keep the initial command surface small.
 
 ### 2026-Q2
 
+- [x] [#49](https://github.com/rshade/gh-aw-fleet/issues/49) Compile
+  workflows with `--strict` on public repos by default `[S]` `security`
+  *Shipped 2026-05-21 in PR #88. Auto-flips `gh aw compile --strict`
+  on when the target repo is public (queried via `gh api`); operators
+  on private repos remain opt-in via flag. Closes v0.3's release-
+  composition security half. Pairs with #57 on the cost half — the
+  composition pair the v0.3 release-please cut now ships.*
 - [x] [#57](https://github.com/rshade/gh-aw-fleet/issues/57) Add
   `gh-aw-fleet consumption` subcommand for cross-fleet billing rollups
   `[L]`

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+    One-liner installer for gh-aw-fleet on Windows.
+
+.DESCRIPTION
+    Downloads the matching gh-aw-fleet release archive for the current
+    architecture (amd64 / arm64), verifies its SHA-256 checksum against the
+    release's checksums.txt, and extracts the binary into the install
+    directory. Optionally adds the install directory to the user-scope PATH.
+
+.PARAMETER Version
+    Release tag to install (e.g. "v0.2.0"). Defaults to the latest release.
+
+.PARAMETER InstallDir
+    Directory to install gh-aw-fleet.exe into. Defaults to
+    $env:LOCALAPPDATA\gh-aw-fleet\bin.
+
+.PARAMETER NoPath
+    Skip the user-scope PATH update.
+
+.PARAMETER BaseUrl
+    Internal-only override for the release asset base URL. Used by CI for
+    the checksum-tamper test. Not part of the public interface.
+
+.EXAMPLE
+    iwr -UseBasicParsing https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.ps1 | iex
+
+.EXAMPLE
+    $installer = [ScriptBlock]::Create((iwr -UseBasicParsing https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.ps1).Content)
+    & $installer -Version v0.2.0 -InstallDir "$env:LOCALAPPDATA\gh-aw-fleet\bin" -NoPath
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$InstallDir = (Join-Path $env:LOCALAPPDATA 'gh-aw-fleet\bin'),
+    [switch]$NoPath,
+    [Parameter(DontShow)]
+    [string]$BaseUrl
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$Repo    = 'rshade/gh-aw-fleet'
+$Project = 'gh-aw-fleet'
+$DefaultBaseUrl = "https://github.com/$Repo/releases/download"
+
+function Get-Arch {
+    $a = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($a) {
+        'X64'   { return 'amd64' }
+        'Arm64' { return 'arm64' }
+        default { throw "unsupported architecture: $a" }
+    }
+}
+
+function Resolve-ReleaseVersion {
+    param([string]$Requested)
+    if ($Requested) { return $Requested }
+    $api = "https://api.github.com/repos/$Repo/releases/latest"
+    $headers = @{}
+    $token = if ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } elseif ($env:GH_TOKEN) { $env:GH_TOKEN } else { $null }
+    if ($token) { $headers['Authorization'] = "Bearer $token" }
+    $resp = Invoke-RestMethod -Uri $api -Headers $headers -UseBasicParsing
+    if (-not $resp.tag_name) {
+        throw "could not parse tag_name from $api"
+    }
+    return $resp.tag_name
+}
+
+function Get-Archive {
+    param(
+        [Parameter(Mandatory)] [string]$Ver,
+        [Parameter(Mandatory)] [string]$Arch,
+        [Parameter(Mandatory)] [string]$TmpDir,
+        [string]$BaseUrl
+    )
+    $verStrip  = $Ver.TrimStart('v')
+    $archive   = "${Project}_${verStrip}_windows_${Arch}.zip"
+    $checksums = "${Project}_${verStrip}_checksums.txt"
+    $base      = "$( if ($BaseUrl) { $BaseUrl } else { $DefaultBaseUrl } )/$Ver"
+
+    $archivePath   = Join-Path $TmpDir $archive
+    $checksumsPath = Join-Path $TmpDir $checksums
+
+    Write-Information "Downloading $archive" -InformationAction Continue
+    Invoke-WebRequest -Uri "$base/$archive"   -OutFile $archivePath   -UseBasicParsing
+    Write-Information "Downloading $checksums" -InformationAction Continue
+    Invoke-WebRequest -Uri "$base/$checksums" -OutFile $checksumsPath -UseBasicParsing
+
+    Write-Information 'Verifying SHA-256' -InformationAction Continue
+    $line = Select-String -Path $checksumsPath -Pattern ([regex]::Escape($archive)) | Select-Object -First 1
+    if (-not $line) {
+        throw "no checksum entry for $archive in $checksums"
+    }
+    $expected = ($line.Line -split '\s+')[0].ToLowerInvariant()
+    $actual   = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($expected -ne $actual) {
+        throw "checksum verification failed for ${archive}: expected $expected, got $actual"
+    }
+
+    return $archivePath
+}
+
+function Install-Binary {
+    param(
+        [Parameter(Mandatory)] [string]$ArchivePath,
+        [Parameter(Mandatory)] [string]$Dest
+    )
+    New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+    Expand-Archive -Path $ArchivePath -DestinationPath $Dest -Force
+    Write-Information "Installed $(Join-Path $Dest "$Project.exe")" -InformationAction Continue
+}
+
+function Update-UserPath {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string]$Dest,
+        [switch]$SkipPath
+    )
+    if ($SkipPath) { return }
+
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ([string]::IsNullOrEmpty($current)) { $current = '' }
+
+    $entries = $current.Split(';', [StringSplitOptions]::RemoveEmptyEntries)
+    foreach ($e in $entries) {
+        if ($e.TrimEnd('\') -ieq $Dest.TrimEnd('\')) {
+            return
+        }
+    }
+
+    $newPath = if ($current) { "$current;$Dest" } else { $Dest }
+    if ($PSCmdlet.ShouldProcess($Dest, 'Add to user PATH')) {
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        Write-Information '' -InformationAction Continue
+        Write-Information "Added $Dest to user PATH." -InformationAction Continue
+        Write-Information 'Open a new shell to pick it up (current session uses the old PATH).' -InformationAction Continue
+    }
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+
+try {
+    $arch = Get-Arch
+    $ver  = Resolve-ReleaseVersion -Requested $Version
+    Write-Information "Installing $Project $ver (windows_$arch) into $InstallDir" -InformationAction Continue
+    $archivePath = Get-Archive -Ver $ver -Arch $arch -TmpDir $tmp -BaseUrl $BaseUrl
+    Install-Binary -ArchivePath $archivePath -Dest $InstallDir
+    Update-UserPath -Dest $InstallDir -SkipPath:$NoPath
+    Write-Information '' -InformationAction Continue
+    Write-Information "Run '$Project --help' to get started." -InformationAction Continue
+}
+finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# install.sh — one-liner installer for gh-aw-fleet on Linux and macOS.
+#
+# Usage:
+#   curl -sSfL https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.sh | bash
+#
+# Environment variables:
+#   VERSION       Release tag to install (default: latest, e.g. "v0.2.0").
+#   INSTALL_DIR   Directory to install the binary into
+#                 (default: $HOME/.local/bin).
+#
+# Internal-only (used by CI for the checksum-tamper test; not part of the
+# public interface):
+#   RELEASE_BASE_URL  Override the release asset base URL. Defaults to
+#                     https://github.com/rshade/gh-aw-fleet/releases/download
+#
+# This script intentionally avoids editing your shell profile. If the install
+# directory is not on $PATH, the script prints a copy-pasteable export line
+# on stderr and exits successfully.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO="rshade/gh-aw-fleet"
+PROJECT="gh-aw-fleet"
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download"
+
+TMPDIR_INSTALL=""
+cleanup() { [ -n "$TMPDIR_INSTALL" ] && rm -rf "$TMPDIR_INSTALL"; }
+trap cleanup EXIT
+
+log()  { printf '%s\n' "$*" >&2; }
+die()  { log "error: $*"; exit 1; }
+
+detect_platform() {
+    local os arch
+    os=$(uname -s)
+    case "$os" in
+        Linux)   os=linux ;;
+        Darwin)  os=darwin ;;
+        MINGW*|MSYS*|CYGWIN*)
+            log "Windows-flavored shell detected ($os)."
+            log "Use install.ps1 from PowerShell instead:"
+            log "  iwr -UseBasicParsing https://raw.githubusercontent.com/${REPO}/main/install.ps1 | iex"
+            exit 1
+            ;;
+        *) die "unsupported OS: $os" ;;
+    esac
+
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64|amd64)   arch=amd64 ;;
+        aarch64|arm64)  arch=arm64 ;;
+        *) die "unsupported architecture: $arch" ;;
+    esac
+
+    printf '%s_%s\n' "$os" "$arch"
+}
+
+resolve_version() {
+    if [ -n "${VERSION:-}" ]; then
+        printf '%s\n' "$VERSION"
+        return
+    fi
+    local api="https://api.github.com/repos/${REPO}/releases/latest"
+    local body tag token
+    token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+    if [ -n "$token" ]; then
+        body=$(curl -fsSL -H "Authorization: Bearer ${token}" "$api") \
+            || die "failed to fetch latest release from $api"
+    else
+        body=$(curl -fsSL "$api") || die "failed to fetch latest release from $api"
+    fi
+    tag=$(printf '%s\n' "$body" \
+        | grep -E '^[[:space:]]*"tag_name":' \
+        | head -n1 \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    [ -n "$tag" ] || die "could not parse tag_name from $api"
+    printf '%s\n' "$tag"
+}
+
+sha256_check() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c -
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -c -
+    else
+        die "neither sha256sum nor shasum is available"
+    fi
+}
+
+download_and_verify() {
+    local version=$1 platform=$2 tmpdir=$3
+    local version_strip="${version#v}"
+    local archive="${PROJECT}_${version_strip}_${platform}.tar.gz"
+    local checksums="${PROJECT}_${version_strip}_checksums.txt"
+    local base="${RELEASE_BASE_URL:-$DEFAULT_BASE_URL}/${version}"
+
+    log "Downloading ${archive}"
+    curl -fsSL "${base}/${archive}"   -o "${tmpdir}/${archive}" \
+        || die "failed to download ${base}/${archive}"
+    log "Downloading ${checksums}"
+    curl -fsSL "${base}/${checksums}" -o "${tmpdir}/${checksums}" \
+        || die "failed to download ${base}/${checksums}"
+
+    log "Verifying SHA-256"
+    local archive_re="${archive//./\\.}"
+    (
+        cd "$tmpdir"
+        grep -E "[[:space:]]${archive_re}\$" "${checksums}" | sha256_check
+    ) >&2 || die "checksum verification failed for ${archive}"
+
+    printf '%s\n' "${tmpdir}/${archive}"
+}
+
+install_binary() {
+    local archive=$1 install_dir=$2
+    mkdir -p "$install_dir"
+    tar -xzf "$archive" -C "$install_dir" "$PROJECT"
+    chmod +x "${install_dir}/${PROJECT}"
+    log "Installed ${install_dir}/${PROJECT}"
+}
+
+warn_if_not_in_path() {
+    local install_dir=$1
+    case ":$PATH:" in
+        *":$install_dir:"*) return 0 ;;
+    esac
+    log ""
+    log "Note: ${install_dir} is not on your \$PATH."
+    log "To use gh-aw-fleet from any shell, add this line to your shell profile:"
+    log ""
+    log "  export PATH=\"${install_dir}:\$PATH\""
+    log ""
+}
+
+main() {
+    local platform version archive install_dir
+    platform=$(detect_platform)
+    version=$(resolve_version)
+    install_dir="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+    log "Installing ${PROJECT} ${version} (${platform}) into ${install_dir}"
+
+    TMPDIR_INSTALL=$(mktemp -d 2>/dev/null || mktemp -d -t gh-aw-fleet)
+
+    archive=$(download_and_verify "$version" "$platform" "$TMPDIR_INSTALL")
+    install_binary "$archive" "$install_dir"
+    warn_if_not_in_path "$install_dir"
+
+    log ""
+    log "Run 'gh-aw-fleet --help' to get started."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Ship `install.sh` (POSIX) and `install.ps1` (Windows) as release assets via `.goreleaser.yml` `extra_files`, replacing the four-step manual `gh release download` flow with curl/iwr one-liners.
- Each installer resolves the target tag (defaulting to `latest` via the Releases API), downloads the matching OS/arch archive, verifies SHA-256 against the release's `checksums.txt`, and extracts the binary into a per-OS default — `$HOME/.local/bin` on POSIX, `%LOCALAPPDATA%\gh-aw-fleet\bin` on Windows. POSIX never edits shell profiles (prints a copy-pasteable `export PATH=…` line on stderr); Windows updates user-scope PATH unless `-NoPath` is passed.
- Both scripts expose an internal-only `RELEASE_BASE_URL` / `-BaseUrl` injection seam used by CI to stand up a local HTTP server with a corrupted `checksums.txt` and assert the installer rejects it.
- New `install-script` workflow runs `shellcheck` and PSScriptAnalyzer for lint, smoke-installs the latest release on ubuntu/macos/windows in both default-dir and custom-dir modes, and asserts a tampered `checksums.txt` produces a non-zero exit with a checksum-mentioning error message.
- README's Install section gains a new Option 1 (one-liner) with the env-var / PowerShell-parameter knobs and a `raw.githubusercontent.com` fallback URL for the newer-installer-against-older-release case; the prior download / `go install` / source-build paths shift to Options 2–4.

## Test plan

- [x] `shellcheck install.sh` clean (CI `shellcheck` job)
- [x] PSScriptAnalyzer (Warning + Error) clean on `install.ps1` (CI `psscriptanalyzer` job)
- [x] Smoke install runs `gh-aw-fleet --help` on `ubuntu-latest`, `macos-latest`, and `windows-latest` in both default-dir and custom-dir modes
- [x] Tamper test: corrupted `checksums.txt` causes installer exit with a checksum-mentioning error on all three runners
- [x] `make lint` and `make test` pass locally
- [ ] Post-merge: confirm the next GoReleaser run attaches both installers to the release via `extra_files`

## Changes

### New files

- `install.sh` — POSIX bash installer; OS/arch detection, Releases-API tag resolution, SHA-256 verification, archive extract, PATH-not-set guidance on stderr
- `install.ps1` — Windows PowerShell installer; arch detection, tag resolution, SHA-256 verification, `Expand-Archive`, optional user-scope PATH update gated by `-NoPath`
- `.github/workflows/install-script.yml` — `shellcheck` + PSScriptAnalyzer + smoke install + checksum-tamper test across ubuntu/macos/windows

### Modified files

- `.goreleaser.yml` — adds `release.extra_files` for `install.sh` and `install.ps1` so each tag pins the matching installer alongside binary archives
- `README.md` — Install section gains Option 1 (one-liner) with env-var / parameter docs and the `raw.githubusercontent.com` fallback URL; renumbers prior Options 1–3 to 2–4 and updates the PATH-assumption footnote

### Housekeeping

- `ROADMAP.md` — moves #49 from Immediate Focus to Completed (2026-Q2) with the 2026-05-21 / PR #88 reference, updating the v0.3 narrative so #43 is now the lone Immediate Focus item

Closes #43