### PR TITLE
feat(consumption): scope rollup to named repos via positional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ repos get which workflows is also the natural place to attribute consumption:
 by repo, by profile, or by cost center. The `consumption` subcommand does
 exactly that — `gh-aw-fleet consumption` (default `--source logs`) reads
 AI-credit (AIC) usage from `gh aw logs --json` per agentic workflow and rolls it
-up `--by repo|profile|cost-center|workflow`, with USD derived as AIC × $0.01. It
+up `--by repo|profile|cost-center|workflow`, with USD derived as AIC × $0.01.
+Pass one or more repos by name (`gh-aw-fleet consumption rshade/finfocus --by
+workflow`) to scope the rollup and drill into a single repo's per-workflow
+spend; omit them for the whole fleet. It
 needs no deployed reporting workflow ([#57](https://github.com/rshade/gh-aw-fleet/issues/57),
 [#103](https://github.com/rshade/gh-aw-fleet/issues/103)); see
 [ROADMAP.md](ROADMAP.md) for the broader billing-readiness arc.

--- a/cmd/consumption.go
+++ b/cmd/consumption.go
@@ -29,9 +29,13 @@ func newConsumptionCmd(flagDir *string) *cobra.Command {
 	var flags consumptionFlags
 
 	cmd := &cobra.Command{
-		Use:   commandConsumption,
+		Use:   commandConsumption + " [repo...]",
 		Short: "Aggregate api-consumption-report output across the fleet",
 		Long: `Aggregate api-consumption-report output across the fleet.
+
+Pass one or more repos (owner/name) to scope the rollup to just those repos;
+with no args it covers the whole fleet. Combine with --by workflow to drill
+into a single repo's per-workflow spend.
 
 Discovery: queries each repo's audits-category discussions and filters by
 the api-consumption-report-daily tracker marker. Data: fetches the
@@ -49,8 +53,8 @@ Data source:
   --source logs        AI credits from gh aw logs --json per workflow (default;
                        needs no deployed api-consumption-report workflow)
   --source artifacts   legacy: api-consumption-report discussions + run artifacts`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runConsumption(cmd, flagDir, &flags)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConsumption(cmd, flagDir, &flags, args)
 		},
 	}
 	cmd.Flags().BoolVar(&flags.latest, "latest", true, "Most-recent valid report per repo (default)")
@@ -65,7 +69,7 @@ Data source:
 // runConsumption loads fleet config, builds the FetchMode from flags,
 // invokes the aggregator, and writes either tabwriter text or the JSON
 // envelope based on --output.
-func runConsumption(cmd *cobra.Command, flagDir *string, flags *consumptionFlags) error {
+func runConsumption(cmd *cobra.Command, flagDir *string, flags *consumptionFlags, repos []string) error {
 	jsonMode := outputMode(cmd) == outputJSON
 
 	by, err := fleet.ParseGroupBy(flags.by)
@@ -100,6 +104,14 @@ func runConsumption(cmd *cobra.Command, flagDir *string, flags *consumptionFlags
 		return err
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "  (loaded %s)\n", cfg.LoadedFrom)
+
+	cfg, err = fleet.ScopeToRepos(cfg, repos)
+	if err != nil {
+		if jsonMode {
+			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
+		}
+		return err
+	}
 
 	res, warnings, err := fleet.AggregateConsumption(cmd.Context(), cfg, mode, by, source)
 	if err != nil {

--- a/internal/fleet/consumption.go
+++ b/internal/fleet/consumption.go
@@ -713,6 +713,39 @@ func inProgressIncludedDiag(ref reportRef) *Diagnostic {
 // Aggregation — AggregateConsumption
 // ---------------------------------------------------------------------------
 
+// ScopeToRepos returns a shallow copy of cfg whose Repos map is restricted to
+// the named repos, preserving Profiles, Defaults, and LoadedFrom so profile
+// and cost-center grouping still resolve against the full fleet definition. An
+// empty names slice returns cfg unchanged (the whole-fleet default). When a
+// single requested repo is absent it returns ErrRepoNotTracked (which names the
+// config file to edit), matching deploy/sync/upgrade; when several are absent it
+// lists every offender.
+func ScopeToRepos(cfg *Config, names []string) (*Config, error) {
+	if len(names) == 0 {
+		return cfg, nil
+	}
+	scoped := make(map[string]RepoSpec, len(names))
+	var missing []string
+	for _, n := range names {
+		spec, ok := cfg.Repos[n]
+		if !ok {
+			missing = append(missing, n)
+			continue
+		}
+		scoped[n] = spec
+	}
+	switch len(missing) {
+	case 0:
+	case 1:
+		return nil, ErrRepoNotTracked(missing[0], cfg.LoadedFrom)
+	default:
+		return nil, fmt.Errorf("repos not tracked in fleet config: %s", strings.Join(missing, ", "))
+	}
+	out := *cfg
+	out.Repos = scoped
+	return &out, nil
+}
+
 // AggregateConsumption walks every repo in cfg in sorted order, discovers
 // each repo's consumption reports, applies the temporal/status filter,
 // fetches the matching run artifacts, and assembles a ConsumptionResult

--- a/internal/fleet/consumption_test.go
+++ b/internal/fleet/consumption_test.go
@@ -1309,3 +1309,77 @@ func TestCompareVersionTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestScopeToRepos(t *testing.T) {
+	base := &Config{
+		LoadedFrom: "fleet.local.json",
+		Profiles: map[string]Profile{
+			"default": {Sources: map[string]SourcePin{}, Workflows: []ProfileWorkflow{}},
+		},
+		Repos: map[string]RepoSpec{
+			"a/one":   {Profiles: []string{"default"}},
+			"b/two":   {Profiles: []string{"default"}},
+			"c/three": {Profiles: []string{"default"}},
+		},
+	}
+
+	t.Run("empty names returns config unchanged", func(t *testing.T) {
+		got, err := ScopeToRepos(base, nil)
+		if err != nil {
+			t.Fatalf("err = %v; want nil", err)
+		}
+		if got != base {
+			t.Errorf("empty names should return the same config pointer")
+		}
+	})
+
+	t.Run("valid subset filters repos and preserves the rest", func(t *testing.T) {
+		got, err := ScopeToRepos(base, []string{"a/one", "c/three"})
+		if err != nil {
+			t.Fatalf("err = %v; want nil", err)
+		}
+		if len(got.Repos) != 2 {
+			t.Fatalf("len(Repos) = %d; want 2", len(got.Repos))
+		}
+		for _, want := range []string{"a/one", "c/three"} {
+			if _, ok := got.Repos[want]; !ok {
+				t.Errorf("scoped config missing %q", want)
+			}
+		}
+		if _, ok := got.Repos["b/two"]; ok {
+			t.Errorf("b/two should have been excluded from the scoped config")
+		}
+		if got.LoadedFrom != base.LoadedFrom {
+			t.Errorf("LoadedFrom = %q; want %q (preserved)", got.LoadedFrom, base.LoadedFrom)
+		}
+		if _, ok := got.Profiles["default"]; !ok {
+			t.Errorf("Profiles not preserved in scoped config")
+		}
+		if len(base.Repos) != 3 {
+			t.Errorf("original config mutated: len(base.Repos) = %d; want 3", len(base.Repos))
+		}
+	})
+
+	t.Run("single unknown repo errors via ErrRepoNotTracked naming the config file", func(t *testing.T) {
+		_, err := ScopeToRepos(base, []string{"x/missing"})
+		if err == nil {
+			t.Fatal("err = nil; want error for unknown repo")
+		}
+		got := err.Error()
+		if !strings.Contains(got, "x/missing") || !strings.Contains(got, base.LoadedFrom) {
+			t.Errorf("err = %q; want it to name %q and %q", got, "x/missing", base.LoadedFrom)
+		}
+	})
+
+	t.Run("unknown repo errors and names every offender", func(t *testing.T) {
+		_, err := ScopeToRepos(base, []string{"a/one", "x/missing", "y/gone"})
+		if err == nil {
+			t.Fatal("err = nil; want error for unknown repos")
+		}
+		for _, want := range []string{"x/missing", "y/gone"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("err = %q; want it to name %q", err, want)
+			}
+		}
+	})
+}

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -933,12 +933,13 @@ var ghAwVersionRE = regexp.MustCompile(`v\d+\.\d+\.\d+`)
 
 // ghAwVersion runs `gh aw --version` and returns the parsed semver token
 // (e.g. "v0.72.1") or an empty string when parsing fails. The wrapped error
-// is non-nil only on exec failure.
+// is non-nil only on exec failure. Uses CombinedOutput because `gh aw
+// --version` prints the version line to stderr, not stdout.
 //
 //nolint:gochecknoglobals // test-injection seam mirroring ghAPIExists/ghAPIJSON
 var ghAwVersion = func(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", "aw", "--version")
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err
 	}

--- a/skills/fleet-budget-review/SKILL.md
+++ b/skills/fleet-budget-review/SKILL.md
@@ -68,8 +68,10 @@ Any value outside the four-axis set is a hard error — cobra rejects with `--by
 ### Step 3 — invoke
 
 ```bash
-gh-aw-fleet consumption [--latest|--trailing Nd|--since YYYY-MM-DD] --by <axis>
+gh-aw-fleet consumption [repo...] [--latest|--trailing Nd|--since YYYY-MM-DD] --by <axis>
 ```
+
+**Scope to specific repos:** pass one or more `owner/name` args to limit the rollup to just those repos; omit them for the whole fleet. This is the way to drill into *one* repo's per-workflow spend — `gh-aw-fleet consumption rshade/finfocus --by workflow` answers "which workflows are burning credits in finfocus?", whereas a bare `--by workflow` sums each workflow across every repo running it. Unknown repo names are a hard error that lists the offenders (validated before any network call).
 
 Add `--output json` if you want to pipe through jq. The envelope is the standard fleet shape (`schema_version: 1`, `command: "consumption"`, `result.groups[]`, `result.top_burners[]`, `warnings[]`).
 


### PR DESCRIPTION
## Summary

- `gh-aw-fleet consumption` now accepts one or more `owner/name` positional args that scope the rollup to just those repos; with no args it still covers the whole fleet.
- This is the way to drill into a single repo's per-workflow spend: `gh-aw-fleet consumption rshade/finfocus --by workflow` answers "which workflows burn credits in finfocus?", where a bare `--by workflow` would sum each workflow across every repo running it.
- Scoping keeps the full Profiles/Defaults/LoadedFrom context, so profile and cost-center grouping still resolve against the whole fleet definition — only the per-repo fetch set shrinks.
- Unknown repo names are a hard error raised before any network call. A single bad name reuses `ErrRepoNotTracked` (which names the config file to edit, matching deploy/sync/upgrade); several list every offender at once.
- Drive-by fix: `ghAwVersion` now reads `CombinedOutput`, because `gh aw --version` prints the version line to stderr, not stdout — the previous `Output()` call captured an empty string and silently skipped version-drift detection.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `~/go/bin/golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes (full suite)
- [x] `make fmt-check` reports no formatting changes
- [x] `TestScopeToRepos` covers empty / valid-subset / single-missing / multi-missing cases

## Changes

### Modified files

- `cmd/consumption.go` - accept `[repo...]` positional args, thread them into `runConsumption`, and call `ScopeToRepos` after config load; expanded `Use`/`Long` help text.
- `internal/fleet/consumption.go` - new `ScopeToRepos` helper returning a shallow Config copy whose `Repos` map is restricted to the named set, validating names before any I/O.
- `internal/fleet/consumption_test.go` - `TestScopeToRepos` table covering the empty, subset, single-missing, and multi-missing paths.
- `internal/fleet/deploy.go` - `ghAwVersion` switched from `Output()` to `CombinedOutput()` so the stderr-printed version line parses.
- `README.md` - document repo-scoping on the `consumption` subcommand.
- `skills/fleet-budget-review/SKILL.md` - document repo-scoping in the invoke step, including the unknown-repo hard-error behavior.