### PR TITLE
ci(security): add cost-oriented trigger-risk lint over the fleet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ fleet.local.json
 
 # Local PR draft — regenerated per session via /pr-message.
 PR_MESSAGE.md
+.claude/agent-memory/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,57 +38,40 @@ fleet-layer tool existing.
   #102 / #129 (Near-Term), #106 / #107 / #113 / #53 / #59 / #60
   (Future); #57 / #103 / #108 shipped in the v0.2.x line.
 - **Security**: items labeled `security` on GitHub — the supply-chain
-  conflict scanners #101 / #100 (live incident, Immediate Focus), the
-  trigger-risk lint #104, the security epic #36 with children #38–#40,
-  plus #49 (shipped).
+  conflict scanners #101 / #100 (merged to main, ships in next release),
+  the trigger-risk lint #104 (Immediate Focus), the security epic #36
+  with children #38–#40, plus #49 (shipped).
 
 **Status**: release-please cuts **patch** bumps for `0.x` (latest tag
-**v0.2.2**, 2026-06-12; `main` has no unreleased commits). v0.2.0
+**v0.2.2**, 2026-06-12; `main` has unreleased commits — Renovate scanner
+PR #133, Dependabot scanner PR #135, init drift guard PR #130). v0.2.0
 satisfied the rule (#54 / #55 / #56 cost prereqs, #37 Layer 1 security
 scanner); the v0.2.1–v0.2.2 line shipped the cost half repeatedly — the
 consumption rollup (#57), then the `gh aw logs --json` AIC source
 (#103 / PR #116) and the v0.79.2 FinOps baseline (#108) — alongside the
 security half (#49 `--strict` on public repos). The **next** release's
-security half is the live Renovate / Dependabot conflict scanners
-(#101 / #100, incident-driven 2026-06-08); its cost half is the
-trigger-risk lint (#104, promoted to Immediate Focus 2026-06-13 by the
-sync gate to fill the cost slot).
+security half has merged: Renovate and Dependabot conflict scanners
+(#100 / #101, merged 2026-06-16/17); its cost half is the trigger-risk
+lint (#104, Immediate Focus).
 
 **Exception**: a release scoped as a single `fix:` hotfix (no feature
 changes) is exempt — the rule applies to feature-bearing releases.
 
 ## Immediate Focus (next release in progress)
 
-Latest tag is **v0.2.2** (2026-06-12); `main` has no unreleased commits.
-v0.2.2 shipped the FinOps build-out — the `gh aw logs --json` AIC source
-(#103 / PR #116), scope-to-named-repos (#126), the fleet-manifest
-(#114 / PR #124), and the v0.79.2 baseline (#108) — on top of v0.2.0's
-consumption rollup (#57) and `--strict`-on-public security default (#49),
-plus the one-liner installers (#43). Immediate Focus now holds the next
-release's composition pair: the supply-chain conflict scanners
-(#101 / #100, security — promoted 2026-06-08 off a live `finfocus#1246`
-incident) and the cost-oriented trigger-risk lint (#104, cost — promoted
-2026-06-13 by the sync gate to fill the cost slot). The `/roadmap sync`
-gate notes depth 3 > target 1: the deliberate security-incident pair plus
-the required cost item. Demote toward single-WIP once #101 / #100 land.
+Latest tag is **v0.2.2** (2026-06-12); `main` has unreleased commits —
+the Renovate conflict scanner (PR #133, 2026-06-16), the Dependabot
+conflict scanner (PR #135, 2026-06-17), and the init drift guard
+(PR #130, 2026-06-14). v0.2.2 shipped the FinOps build-out — the
+`gh aw logs --json` AIC source (#103 / PR #116), scope-to-named-repos
+(#126), the fleet-manifest (#114 / PR #124), and the v0.79.2 baseline
+(#108) — on top of v0.2.0's consumption rollup (#57) and
+`--strict`-on-public security default (#49), plus the one-liner
+installers (#43). The supply-chain conflict scanners (#101 / #100) have
+merged — filling the security composition slot. Immediate Focus now holds
+only the cost slot: the trigger-risk lint (#104). Depth is 1, matching
+`target_focus_depth: 1`.
 
-- [ ] [#101](https://github.com/rshade/gh-aw-fleet/issues/101) Detect
-  Dependabot configs that conflict with gh-aw-managed pins `[M]` `security`
-  *Parse `.github/dependabot.yml` via `yaml.v3`; if a `github-actions`
-  ecosystem block lacks `ignore` rules for the gh-aw actions, emit a
-  `Finding` quoting the exact `ignore:` YAML. Dependabot can't
-  glob-ignore lock files, so there's no Rule B equivalent — it protects
-  dependency names only. Promoted by `/roadmap sync` on 2026-06-08 —
-  operator override of single-WIP for the live `finfocus#1246` incident;
-  fills v0.4's release-composition security slot.*
-- [ ] [#100](https://github.com/rshade/gh-aw-fleet/issues/100) Detect
-  Renovate configs that conflict with gh-aw-managed pins `[M]` `security`
-  *Probe `renovate.json` / `.renovaterc[.json]` / `renovate.json5` /
-  `.github/renovate.json` (hujson-tolerant) and emit a `Finding` per
-  missing `packageRules` block: disable `gh-aw-actions` bumps (Rule A)
-  and keep Renovate off generated `*.lock.yml` files (Rule B). Promoted
-  by `/roadmap sync` on 2026-06-08 alongside its Dependabot sibling #101
-  for full dependency-bot coverage.*
 - [ ] [#104](https://github.com/rshade/gh-aw-fleet/issues/104)
   Cost-oriented trigger-risk lint over the resolved fleet `[S]`
   `security` `cost` `finops`
@@ -102,12 +85,11 @@ the required cost item. Demote toward single-WIP once #101 / #100 land.
 ## Near-Term Vision (v0.4 — FinOps build-out + operator QoL)
 
 With the FinOps build-out shipped in v0.2.2 (#103 / #108 / #114) and
-Immediate Focus holding the next release's pair (#101 / #100 security
-plus #104 cost), Near-Term holds the remaining FinOps work — forecast
-(#102), the over-budget rollup highlight (#129), and consumption
-scale-hardening (#119) — plus the deploy/consumption follow-ups
-(#112 / #115), a deploy correctness bug (#98), a diagnostics expansion
-(#99), and four docs items (#94 / #95 / #127 / #128).
+the security scanners (#101 / #100) merged to main, Near-Term holds the
+remaining FinOps work — forecast (#102), the over-budget rollup highlight
+(#129), and consumption scale-hardening (#119) — plus deploy follow-ups
+(#112 / #115), a diagnostics expansion (#99), and four docs items
+(#94 / #95 / #127 / #128).
 
 ### FinOps / cost visibility
 
@@ -170,16 +152,6 @@ build on.
 
 ### Operator quality of life
 
-- [ ] [#98](https://github.com/rshade/gh-aw-fleet/issues/98) Fix
-  `ensureInit` probing a stale marker filename — re-inits every run, no
-  drift detection `[M]` `bug`
-  *`ensureInit` probes `.github/agents/agentic-workflows.agent.md`, but
-  real `gh aw init` (v0.77.5) writes `agentic-workflows.md` — the guard
-  never short-circuits, so init re-runs every deploy/sync and every PR
-  body falsely claims "this repo was not yet initialized." CI missed it
-  because the fake-gh stub writes the same wrong filename. Fix: OR
-  multiple real markers so `--no-agent`/`--no-skill` don't fool it, and
-  fail loudly on the next upstream rename.*
 - [ ] [#99](https://github.com/rshade/gh-aw-fleet/issues/99) Add
   `CollectHints` entries for `no aw.yml manifest` / `already exists`
   `gh aw add` errors `[S]`
@@ -420,6 +392,31 @@ were deferred at v1 to keep the initial command surface small.
 
 ### 2026-Q2
 
+- [x] [#101](https://github.com/rshade/gh-aw-fleet/issues/101) Detect
+  Dependabot configs that conflict with gh-aw-managed pins `[M]` `security`
+  *Merged to main (PR #135, closed 2026-06-17); ships in next release.
+  Parses `.github/dependabot.yml` via `yaml.v3`; emits a `LOW` `Finding`
+  per `github-actions` update entry that lacks `ignore` rules for the
+  gh-aw-actions family. Dependabot has no file-glob ignore, so there is
+  one conflict rule (not two); new `security_dependabot` diag code;
+  surfaces on `deploy`/`sync`/`upgrade` via the existing finding
+  pipeline.*
+- [x] [#100](https://github.com/rshade/gh-aw-fleet/issues/100) Detect
+  Renovate configs that conflict with gh-aw-managed pins `[M]` `security`
+  *Merged to main (PR #133, closed 2026-06-16); ships in next release.
+  Probes `renovate.json` / `.renovaterc[.json]` / `renovate.json5` /
+  `.github/renovate.json` (hujson-tolerant); emits `LOW` findings for
+  missing `packageRules`: disable gh-aw-actions bumps (Rule A) and
+  exclude generated `*.lock.yml` files (Rule B). New `security_renovate`
+  diag code; no new deps.*
+- [x] [#98](https://github.com/rshade/gh-aw-fleet/issues/98) Fix
+  `ensureInit` probing a stale marker filename — re-inits every run, no
+  drift detection `[M]` `bug`
+  *Merged to main (PR #130, closed 2026-06-14); ships in next release.
+  Added init drift guard and upgraded init/manifest parity; the
+  manifest-version comparison (foundation from #114) now correctly
+  short-circuits re-init when the deployed gh-aw version matches the
+  fleet pin.*
 - [x] [#114](https://github.com/rshade/gh-aw-fleet/issues/114)
   Fleet-managed marker/manifest per repo: deployed gh-aw version +
   detect/refresh stale init artifacts `[L]`
@@ -620,15 +617,15 @@ Any roadmap item that violates these is rejected, not negotiated.
 
 [meta-spec]: ./CONTEXT.md#roadmap-meta-issue-body-convention
 
-> Tracked as GitHub issues: Immediate Focus — the supply-chain scanners
-> (#101, #100, security) and the trigger-risk lint (#104, cost);
-> Near-Term — the FinOps build-out (#102, #129, #119), the
-> deploy/consumption follow-ups (#112, #115), the deploy bug (#98),
-> diagnostics hint (#99), and docs items (#94, #95, #127, #128); Future
-> Vision — the security epic (#36 with children #38–#40), the FinOps
-> deferred set (#105, #106, #107, #113, #53, #59, #60), and the Status
-> refinements (#61, #62). Shipped in v0.2.2 (2026-06-12): #103, #108,
-> #114 (alongside #57 / #49 / #43 across the v0.2.x line). Excluded as
-> operational noise: #5 (Dependency Dashboard) and #111 / #118 / #123
-> (bot failure reports). The unlinked Near-Term and Future items don't
-> have issues yet — open them as work picks up, then run `/roadmap sync`.
+> Tracked as GitHub issues: Immediate Focus — the trigger-risk lint
+> (#104, cost); Near-Term — the FinOps build-out (#102, #129, #119),
+> deploy follow-ups (#112, #115), diagnostics hint (#99), and docs items
+> (#94, #95, #127, #128); Future Vision — the security epic (#36 with
+> children #38–#40), the FinOps deferred set (#105, #106, #107, #113,
+> #53, #59, #60), and the Status refinements (#61, #62). Merged to main
+> (unreleased): #101 / #100 (conflict scanners) and #98 (init drift
+> guard). Shipped in v0.2.2 (2026-06-12): #103, #108, #114 (alongside
+> #57 / #49 / #43 across the v0.2.x line). Excluded as operational noise:
+> #5 (Dependency Dashboard) and #111 / #118 / #123 / #132 / #134 (bot
+> failure reports). The unlinked Near-Term and Future items don't have
+> issues yet — open them as work picks up, then run `/roadmap sync`.

--- a/internal/fleet/fleetdiag/diag.go
+++ b/internal/fleet/fleetdiag/diag.go
@@ -52,6 +52,10 @@ const (
 	// conflict scanner. One code covers all fleet.dependabot.* rules;
 	// per-rule granularity rides on Diagnostic.Fields["rule_id"].
 	DiagSecurityDependabot = "security_dependabot"
+	// DiagCostTriggerRisk is the family code for the cost-oriented
+	// trigger-risk scanner. One code covers all fleet.cost.* rules;
+	// per-rule granularity rides on Diagnostic.Fields["rule_id"].
+	DiagCostTriggerRisk = "cost_trigger_risk"
 
 	// DiagCompileStrictFailed fires when `gh aw compile --strict` exits non-zero
 	// because one or more workflows violate strict-mode validation. The hint

--- a/internal/fleet/frontmatter.go
+++ b/internal/fleet/frontmatter.go
@@ -6,6 +6,11 @@ import (
 	"github.com/rshade/gh-aw-fleet/internal/fleet/frontmatter"
 )
 
+const (
+	skipIfMatchKey   = "skip-if-match"
+	skipIfNoMatchKey = "skip-if-no-match"
+)
+
 // ErrEmptyFrontmatter is returned by ParseFrontmatter when the input has no
 // YAML content. Callers typically treat this as a non-fatal skip.
 //
@@ -49,6 +54,16 @@ func ExtractWorkflowMeta(fm map[string]any, tw *TemplateWorkflow) {
 	tw.Triggers = extractTriggers(fm["on"])
 	tw.Tools = extractToolKeys(fm["tools"])
 	tw.SafeOutputs = extractToolKeys(fm["safe-outputs"])
+	tw.SkipIfMatch = extractSkipConditions(fm[skipIfMatchKey])
+	tw.SkipIfNoMatch = extractSkipConditions(fm[skipIfNoMatchKey])
+	if on, ok := fm["on"].(map[string]any); ok {
+		if v := extractSkipConditions(on[skipIfMatchKey]); len(v) > 0 {
+			tw.SkipIfMatch = v
+		}
+		if v := extractSkipConditions(on[skipIfNoMatchKey]); len(v) > 0 {
+			tw.SkipIfNoMatch = v
+		}
+	}
 	if perms, ok := fm["permissions"].(map[string]any); ok {
 		tw.Permissions = perms
 	}
@@ -83,6 +98,9 @@ func extractTriggers(v any) []string {
 	case map[string]any:
 		out := make([]string, 0, len(t))
 		for k := range t {
+			if isSkipGuardKey(k) {
+				continue
+			}
 			out = append(out, k)
 		}
 		sort.Strings(out)
@@ -105,4 +123,39 @@ func extractToolKeys(v any) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// extractSkipConditions flattens a skip-if-match or skip-if-no-match value
+// into a sorted list of condition strings. Handles the YAML forms: a bare
+// string, a sequence of strings, and a mapping (keys extracted, mirroring
+// how extractTriggers handles map-form on: blocks).
+func extractSkipConditions(v any) []string {
+	switch t := v.(type) {
+	case string:
+		if t != "" {
+			return []string{t}
+		}
+		return nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		sort.Strings(out)
+		return out
+	case map[string]any:
+		out := make([]string, 0, len(t))
+		for k := range t {
+			out = append(out, k)
+		}
+		sort.Strings(out)
+		return out
+	}
+	return nil
+}
+
+func isSkipGuardKey(k string) bool {
+	return k == skipIfMatchKey || k == skipIfNoMatchKey
 }

--- a/internal/fleet/frontmatter_test.go
+++ b/internal/fleet/frontmatter_test.go
@@ -1,0 +1,44 @@
+package fleet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractWorkflowMeta_NestedSkipGuards(t *testing.T) {
+	fm := map[string]any{
+		"on": map[string]any{
+			"schedule":          "daily",
+			"skip-if-match":     `is:pr is:open in:title "[code-simplifier]"`,
+			"skip-if-no-match":  []any{"*.md", "*.go"},
+			"workflow_dispatch": nil,
+		},
+	}
+
+	var tw TemplateWorkflow
+	ExtractWorkflowMeta(fm, &tw)
+
+	if want := []string{"schedule", "workflow_dispatch"}; !reflect.DeepEqual(tw.Triggers, want) {
+		t.Errorf("Triggers = %v; want %v", tw.Triggers, want)
+	}
+	if want := []string{`is:pr is:open in:title "[code-simplifier]"`}; !reflect.DeepEqual(tw.SkipIfMatch, want) {
+		t.Errorf("SkipIfMatch = %v; want %v", tw.SkipIfMatch, want)
+	}
+	if want := []string{"*.go", "*.md"}; !reflect.DeepEqual(tw.SkipIfNoMatch, want) {
+		t.Errorf("SkipIfNoMatch = %v; want %v", tw.SkipIfNoMatch, want)
+	}
+}
+
+func TestExtractWorkflowMeta_TopLevelSkipGuardFallback(t *testing.T) {
+	fm := map[string]any{
+		"on":            "push",
+		"skip-if-match": []any{"skip-ci"},
+	}
+
+	var tw TemplateWorkflow
+	ExtractWorkflowMeta(fm, &tw)
+
+	if want := []string{"skip-ci"}; !reflect.DeepEqual(tw.SkipIfMatch, want) {
+		t.Errorf("SkipIfMatch = %v; want %v", tw.SkipIfMatch, want)
+	}
+}

--- a/internal/fleet/schema.go
+++ b/internal/fleet/schema.go
@@ -208,9 +208,17 @@ type TemplateWorkflow struct {
 	SafeOutputs []string       `json:"safe_outputs,omitempty"`
 	StopAfter   string         `json:"stop_after,omitempty"`
 	Permissions map[string]any `json:"permissions,omitempty"`
-	Frontmatter map[string]any `json:"frontmatter,omitempty"`
-	Body        string         `json:"body,omitempty"`
-	Lines       int            `json:"lines,omitempty"`
+	// SkipIfMatch holds the pre-activation guard conditions from the
+	// on.skip-if-match frontmatter key. When non-empty, the gh-aw runtime
+	// cancels the workflow cheaply (before any AI call) if a condition matches
+	// — the primary lever for reducing high-frequency trigger cost.
+	SkipIfMatch []string `json:"skip_if_match,omitempty"`
+	// SkipIfNoMatch holds the pre-activation guard conditions from the
+	// on.skip-if-no-match frontmatter key, the inverse of skip-if-match.
+	SkipIfNoMatch []string       `json:"skip_if_no_match,omitempty"`
+	Frontmatter   map[string]any `json:"frontmatter,omitempty"`
+	Body          string         `json:"body,omitempty"`
+	Lines         int            `json:"lines,omitempty"`
 }
 
 // Evaluation is Claude's judgment on a workflow — used by `fleet template

--- a/internal/fleet/security/constants.go
+++ b/internal/fleet/security/constants.go
@@ -26,6 +26,9 @@ const (
 
 const (
 	ruleIDActionlintNotInstalled          = "actionlint:not-installed"
+	ruleIDCostHighFrequencyTrigger        = "fleet.cost.high-frequency-trigger"
+	ruleIDCostReactiveNoSkipGuard         = "fleet.cost.reactive-no-skip-guard"
+	ruleIDCostScheduledNoSkipGuard        = "fleet.cost.scheduled-no-skip-guard"
 	ruleIDDependabotGhAwActionsNotIgnored = "fleet.dependabot.gh-aw-actions-not-ignored"
 	ruleIDDependabotParseError            = "fleet.dependabot.parse-error"
 	ruleIDEngineEnvNonAllowlist           = "fleet.engine.env.non-allowlist"
@@ -42,6 +45,7 @@ const (
 
 const (
 	rulePrefixActionlint = "actionlint:"
+	rulePrefixCost       = "fleet.cost."
 	rulePrefixDependabot = "fleet.dependabot."
 	rulePrefixGitleaks   = "gitleaks:"
 	rulePrefixRenovate   = "fleet.renovate."

--- a/internal/fleet/security/cost.go
+++ b/internal/fleet/security/cost.go
@@ -1,0 +1,226 @@
+package security
+
+import (
+	"context"
+	"os"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/frontmatter"
+)
+
+// costScanner evaluates each workflow's YAML frontmatter for high-frequency
+// triggers (push, check_run, check_suite), medium-frequency reactive
+// triggers (pull_request, issues, issue_comment), and recurring schedule
+// triggers that lack a skip-if-match or skip-if-no-match pre-activation
+// guard. Pre-activation guards let the gh-aw runtime cancel a workflow
+// cheaply — before incurring Copilot-credit or Actions-minute cost — when a
+// condition is not met (e.g. no relevant files changed). Without a guard,
+// every matching event unconditionally burns credits. All rules are
+// advisory-only (never blocking). The costScanner silently skips files with
+// unparseable frontmatter; the structural scanner already emits a parse-error
+// INFO finding for those.
+type costScanner struct {
+	rules []rule
+}
+
+// newCostScanner constructs the cost trigger-risk scanner. Rule evaluation
+// functions are closures over no mutable state, so a single costScanner
+// instance is safe for concurrent use.
+func newCostScanner() *costScanner {
+	return &costScanner{rules: costRules()}
+}
+
+// Scan walks <cloneDir>/.github/workflows/*.md, parses each workflow's YAML
+// frontmatter, and runs every cost rule against it. Returns nil when the
+// workflows directory does not exist.
+func (s *costScanner) Scan(_ context.Context, cloneDir string) []Finding {
+	var out []Finding
+	for _, w := range walkWorkflows(cloneDir, ".md") {
+		out = append(out, s.scanFile(w)...)
+	}
+	return out
+}
+
+func (s *costScanner) scanFile(w walkEntry) []Finding {
+	content, err := os.ReadFile(w.Full)
+	if err != nil {
+		return nil
+	}
+	fmText, _ := frontmatter.Split(string(content))
+	fm, parseErr := frontmatter.Parse(fmText)
+	if parseErr != nil {
+		// Silently skip files with malformed frontmatter — the structural
+		// scanner already emits a parse-error INFO finding for them.
+		return nil
+	}
+	var out []Finding
+	for _, r := range s.rules {
+		for _, h := range r.Eval(fm) {
+			out = append(out, hitToFinding(r, h, w.Rel))
+		}
+	}
+	return out
+}
+
+// highFrequencyTriggerSet is the set of trigger names that drive the
+// highest Copilot-credit burn per the gh-aw cost-management docs. These
+// fire on every commit (push) or every CI status update (check_run,
+// check_suite), potentially dozens of times per PR on active repos.
+//
+//nolint:gochecknoglobals // immutable lookup set
+var highFrequencyTriggerSet = map[string]bool{
+	"push":        true,
+	"check_run":   true,
+	"check_suite": true,
+}
+
+// reactiveTriggerSet covers the medium-cost event-driven triggers that fire
+// more frequently than workflow_dispatch but less than the high tier. Each PR
+// typically generates multiple pull_request events; issues and issue_comment
+// fire on every comment.
+//
+//nolint:gochecknoglobals // immutable lookup set
+var reactiveTriggerSet = map[string]bool{
+	"pull_request":        true,
+	"pull_request_target": true,
+	"issues":              true,
+	"issue_comment":       true,
+}
+
+// scheduledTriggerSet covers recurring timer-driven workflows. Schedules are
+// lower-frequency than push/check events, but still burn credits on idle repos
+// unless bounded by a pre-activation guard.
+//
+//nolint:gochecknoglobals // immutable lookup set
+var scheduledTriggerSet = map[string]bool{
+	"schedule": true,
+}
+
+// costRules returns the cost-risk lint rules. Each rule is independent:
+// a workflow with push, pull_request, and schedule triggers and no skip guard
+// fires every applicable rule simultaneously.
+func costRules() []rule {
+	return []rule{
+		highFrequencyTriggerRule(),
+		reactiveNoSkipGuardRule(),
+		scheduledNoSkipGuardRule(),
+	}
+}
+
+// noSkipGuardRule builds a cost rule that fires when the workflow declares any
+// trigger in set but lacks a skip-if-match or skip-if-no-match guard. All
+// cost rules share this Eval shape; only the trigger set, severity, and
+// human-readable strings differ.
+func noSkipGuardRule(id string, sev Severity, msg, remedy string, set map[string]bool) rule {
+	return rule{
+		ID: id, Severity: sev, Message: msg, Remedy: remedy,
+		Eval: func(fm map[string]any) []ruleHit {
+			if !hasTriggerInSet(fm["on"], set) {
+				return nil
+			}
+			if hasSkipGuard(fm) {
+				return nil
+			}
+			return []ruleHit{{Line: 0}}
+		},
+	}
+}
+
+// highFrequencyTriggerRule fires MEDIUM when the workflow declares a push,
+// check_run, or check_suite trigger without a skip-if-match or
+// skip-if-no-match pre-activation guard. These are the dominant cost drivers
+// named in the gh-aw cost-management reference: they fire on every commit or
+// CI event without a guard to short-circuit the credit burn.
+func highFrequencyTriggerRule() rule {
+	return noSkipGuardRule(
+		ruleIDCostHighFrequencyTrigger,
+		SeverityMedium,
+		"workflow uses a high-frequency trigger (push / check_run / check_suite) without a skip-if-match or skip-if-no-match guard",
+		"Add skip-if-match or skip-if-no-match to the workflow frontmatter. The pre-activation job exits early when the guard matches, saving Copilot credits and Actions minutes before any AI call is made.",
+		highFrequencyTriggerSet,
+	)
+}
+
+// reactiveNoSkipGuardRule fires LOW when the workflow declares a medium-cost
+// reactive trigger (pull_request, pull_request_target, issues, or
+// issue_comment) without a skip-if-match or skip-if-no-match guard. Adding a
+// guard lets the pre-activation job cancel cheaply when no relevant activity
+// has occurred (e.g. the PR touches only docs).
+func reactiveNoSkipGuardRule() rule {
+	return noSkipGuardRule(
+		ruleIDCostReactiveNoSkipGuard,
+		SeverityLow,
+		"reactive workflow (pull_request / pull_request_target / issues / issue_comment) lacks a skip-if-match or skip-if-no-match guard",
+		"Add skip-if-match or skip-if-no-match to the workflow frontmatter. The pre-activation job exits early when the guard matches, saving Copilot credits and Actions minutes before any AI call is made.",
+		reactiveTriggerSet,
+	)
+}
+
+// scheduledNoSkipGuardRule fires LOW when the workflow declares a schedule
+// trigger without a skip-if-match or skip-if-no-match guard. Scheduled
+// workflows can burn credits on quiet repos because the timer fires regardless
+// of whether there is useful work to perform.
+func scheduledNoSkipGuardRule() rule {
+	return noSkipGuardRule(
+		ruleIDCostScheduledNoSkipGuard,
+		SeverityLow,
+		"scheduled workflow lacks a skip-if-match or skip-if-no-match guard",
+		"Add skip-if-match or skip-if-no-match under the workflow's on: block so scheduled runs can exit before any AI call when there is no useful work to perform.",
+		scheduledTriggerSet,
+	)
+}
+
+// hasTriggerInSet reports whether the `on:` value contains any trigger name
+// present in set. Handles the three YAML forms GitHub Actions accepts: a bare
+// string, a YAML sequence of strings, and a mapping whose keys are trigger
+// names.
+func hasTriggerInSet(v any, set map[string]bool) bool {
+	switch t := v.(type) {
+	case string:
+		return set[t]
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && set[s] {
+				return true
+			}
+		}
+	case map[string]any:
+		for k := range t {
+			if set[k] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasSkipGuard reports whether the frontmatter contains a substantive
+// skip-if-match or skip-if-no-match guard either under the on: block (the
+// gh-aw syntax) or at the top level (legacy/test fixture fallback). A key that
+// is present but nil, an empty string, or an empty sequence does not constitute
+// an active guard (the gh-aw runtime would treat it as a no-op).
+func hasSkipGuard(fm map[string]any) bool {
+	return hasSubstantiveSkipGuard(fm, "skip-if-match") || hasSubstantiveSkipGuard(fm, "skip-if-no-match")
+}
+
+func hasSubstantiveSkipGuard(fm map[string]any, key string) bool {
+	if on, ok := fm["on"].(map[string]any); ok && isSubstantiveSkipKey(on[key]) {
+		return true
+	}
+	return isSubstantiveSkipKey(fm[key])
+}
+
+// isSubstantiveSkipKey returns true when v is a non-nil, non-empty guard
+// value. Unknown types (e.g. a future structured form) are treated as present.
+func isSubstantiveSkipKey(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return false
+	case string:
+		return t != ""
+	case []any:
+		return len(t) > 0
+	case map[string]any:
+		return len(t) > 0
+	}
+	return true
+}

--- a/internal/fleet/security/cost.go
+++ b/internal/fleet/security/cost.go
@@ -9,7 +9,7 @@ import (
 
 // costScanner evaluates each workflow's YAML frontmatter for high-frequency
 // triggers (push, check_run, check_suite), medium-frequency reactive
-// triggers (pull_request, issues, issue_comment), and recurring schedule
+// triggers (pull_request, pull_request_target, issues, issue_comment), and recurring schedule
 // triggers that lack a skip-if-match or skip-if-no-match pre-activation
 // guard. Pre-activation guards let the gh-aw runtime cancel a workflow
 // cheaply — before incurring Copilot-credit or Actions-minute cost — when a

--- a/internal/fleet/security/cost_test.go
+++ b/internal/fleet/security/cost_test.go
@@ -1,0 +1,201 @@
+package security
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/fleetdiag"
+)
+
+// ---------------- Rule 1: high-frequency trigger ----------------
+
+func TestCostScanner_PushNoSkipGuard_Medium(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-push-no-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostHighFrequencyTrigger, false)
+	if f == nil {
+		t.Fatalf("expected %s finding; got %v", ruleIDCostHighFrequencyTrigger, out)
+	}
+	if f.Severity != SeverityMedium {
+		t.Errorf("Severity = %v; want MEDIUM", f.Severity)
+	}
+	if f.File != ".github/workflows/workflow-with-push-no-skip-guard.md" {
+		t.Errorf("File = %q; want repo-relative path", f.File)
+	}
+	if f.Remedy == "" {
+		t.Error("Remedy is empty; should have skip-guard guidance")
+	}
+}
+
+func TestCostScanner_CheckRunNoSkipGuard_Medium(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-check-run-no-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostHighFrequencyTrigger, false)
+	if f == nil {
+		t.Fatalf("expected %s finding for check_run trigger; got %v", ruleIDCostHighFrequencyTrigger, out)
+	}
+	if f.Severity != SeverityMedium {
+		t.Errorf("Severity = %v; want MEDIUM", f.Severity)
+	}
+}
+
+func TestCostScanner_PushWithSkipMatchGuard_Clean(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-push-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostHighFrequencyTrigger, false)
+	if f != nil {
+		t.Errorf("push with skip-if-match should produce no high-frequency finding; got %+v", f)
+	}
+}
+
+// ---------------- Rule 2: reactive without skip guard ----------------
+
+func TestCostScanner_PRNoSkipGuard_Low(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-pr-no-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostReactiveNoSkipGuard, false)
+	if f == nil {
+		t.Fatalf("expected %s finding; got %v", ruleIDCostReactiveNoSkipGuard, out)
+	}
+	if f.Severity != SeverityLow {
+		t.Errorf("Severity = %v; want LOW", f.Severity)
+	}
+	if f.File != ".github/workflows/workflow-with-pr-no-skip-guard.md" {
+		t.Errorf("File = %q; want repo-relative path", f.File)
+	}
+	if f.Remedy == "" {
+		t.Error("Remedy is empty; should have skip-guard guidance")
+	}
+}
+
+func TestCostScanner_PRWithSkipNoMatchGuard_Clean(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-pr-skip-no-match.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostReactiveNoSkipGuard, false)
+	if f != nil {
+		t.Errorf("pull_request with skip-if-no-match should produce no reactive finding; got %+v", f)
+	}
+}
+
+func TestCostScanner_PRTargetNoSkipGuard_Low(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-prt-no-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostReactiveNoSkipGuard, false)
+	if f == nil {
+		t.Fatalf("expected %s finding for pull_request_target trigger; got %v", ruleIDCostReactiveNoSkipGuard, out)
+	}
+	if f.Severity != SeverityLow {
+		t.Errorf("Severity = %v; want LOW", f.Severity)
+	}
+}
+
+// ---------------- User-dispatched triggers are clean ----------------
+
+func TestCostScanner_WorkflowDispatch_Clean(t *testing.T) {
+	// clean-agentics-workflow.md uses on: workflow_dispatch — should fire no cost findings.
+	dir := stageFixture(t, "clean-agentics-workflow.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	if len(out) != 0 {
+		t.Errorf("workflow_dispatch trigger should produce zero cost findings; got %d: %+v", len(out), out)
+	}
+}
+
+// ---------------- Rule 3: scheduled without skip guard ----------------
+
+func TestCostScanner_ScheduleNoSkipGuard_Low(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-write-on-schedule.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostScheduledNoSkipGuard, false)
+	if f == nil {
+		t.Fatalf("expected %s finding for schedule trigger; got %v", ruleIDCostScheduledNoSkipGuard, out)
+	}
+	if f.Severity != SeverityLow {
+		t.Errorf("Severity = %v; want LOW", f.Severity)
+	}
+	if f.File != ".github/workflows/workflow-with-write-on-schedule.md" {
+		t.Errorf("File = %q; want repo-relative path", f.File)
+	}
+	if f.Remedy == "" {
+		t.Error("Remedy is empty; should have skip-guard guidance")
+	}
+}
+
+func TestCostScanner_ScheduleWithSkipGuard_Clean(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-schedule-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	f := findRule(out, ruleIDCostScheduledNoSkipGuard, false)
+	if f != nil {
+		t.Errorf("schedule with skip-if-match should produce no scheduled finding; got %+v", f)
+	}
+}
+
+// ---------------- Diagnostic code ----------------
+
+func TestCostScanner_DiagCodeIsCostFamily(t *testing.T) {
+	dir := stageFixture(t, "workflow-with-push-no-skip-guard.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	if len(out) == 0 {
+		t.Fatal("expected findings against push-no-skip-guard fixture")
+	}
+	for _, f := range out {
+		if code := f.ToDiagnostic().Code; code != fleetdiag.DiagCostTriggerRisk {
+			t.Errorf("ToDiagnostic().Code = %q; want %q", code, fleetdiag.DiagCostTriggerRisk)
+		}
+	}
+}
+
+// ---------------- Read-only contract ----------------
+
+func TestCostScanner_ReadOnly(t *testing.T) {
+	// Staging push-no-skip-guard guarantees there is at least one .md file
+	// to scan. The scanner must not modify any file (Scanner contract).
+	dir := stageFixture(t, "workflow-with-push-no-skip-guard.md")
+	before := dirSnapshot(t, dir)
+	_ = newCostScanner().Scan(context.Background(), dir)
+	after := dirSnapshot(t, dir)
+	if before != after {
+		t.Errorf("cost scanner mutated files in the clone dir")
+	}
+}
+
+// dirSnapshot returns a fingerprint of the directory by joining each file's
+// relative path and byte length. This catches both creation/deletion of files
+// and in-place overwrites (a scanner writing to an existing file changes its
+// length unless the output is byte-identical, which is a practical guarantee).
+func dirSnapshot(t *testing.T, dir string) string {
+	t.Helper()
+	entries := walkWorkflows(dir, ".md")
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		data, err := os.ReadFile(e.Full)
+		if err != nil {
+			t.Fatalf("dirSnapshot: read %s: %v", e.Full, err)
+		}
+		parts = append(parts, e.Rel+":"+strconv.Itoa(len(data)))
+	}
+	return strings.Join(parts, ",")
+}
+
+// ---------------- Empty / missing directory ----------------
+
+func TestCostScanner_EmptyDir_Silent(t *testing.T) {
+	out := newCostScanner().Scan(context.Background(), t.TempDir())
+	if len(out) != 0 {
+		t.Errorf("empty dir should produce zero findings; got %d: %+v", len(out), out)
+	}
+}
+
+// ---------------- Malformed frontmatter is skipped silently ----------------
+
+func TestCostScanner_MalformedFrontmatter_Silent(t *testing.T) {
+	// The structural scanner emits the parse-error INFO finding; the cost
+	// scanner must silently skip the file (no double-reporting).
+	dir := stageFixture(t, "workflow-with-malformed-frontmatter.md")
+	out := newCostScanner().Scan(context.Background(), dir)
+	if len(out) != 0 {
+		t.Errorf("malformed frontmatter should produce zero cost findings; got %d: %+v", len(out), out)
+	}
+}

--- a/internal/fleet/security/finding.go
+++ b/internal/fleet/security/finding.go
@@ -186,16 +186,18 @@ func diagCodeForRuleID(ruleID string) string {
 		return fleetdiag.DiagSecurityRenovate
 	case strings.HasPrefix(ruleID, rulePrefixDependabot):
 		return fleetdiag.DiagSecurityDependabot
+	case strings.HasPrefix(ruleID, rulePrefixCost):
+		return fleetdiag.DiagCostTriggerRisk
 	default:
 		return fleetdiag.DiagHint
 	}
 }
 
 // defaultScanners constructs the v1 scanner list in the canonical order:
-// gitleaks → structural → actionlint → renovate → dependabot. Each scanner's
-// constructor cost (gitleaks regex compilation, actionlint exec.LookPath)
-// is paid once per Run invocation. Run sorts the combined findings, so the
-// registration order does not affect output ordering.
+// gitleaks → structural → actionlint → renovate → dependabot → cost. Each
+// scanner's constructor cost (gitleaks regex compilation, actionlint
+// exec.LookPath) is paid once per Run invocation. Run sorts the combined
+// findings, so the registration order does not affect output ordering.
 func defaultScanners() []Scanner {
 	return []Scanner{
 		newGitleaksScanner(),
@@ -203,5 +205,6 @@ func defaultScanners() []Scanner {
 		newActionlintScanner(),
 		newRenovateScanner(),
 		newDependabotScanner(),
+		newCostScanner(),
 	}
 }

--- a/internal/fleet/security/security_integration_test.go
+++ b/internal/fleet/security/security_integration_test.go
@@ -44,10 +44,14 @@ func stageFixturesIntoClone(t *testing.T) string {
 	return tmp
 }
 
-// TestRunEndToEnd asserts SC-001 coverage and FR-015 ("v1 MUST NOT emit
-// LOW"). Run is invoked against the entire fixture set and the union of
-// findings is checked for: at least one finding per expected rule, and
-// zero LOW findings overall.
+// TestRunEndToEnd asserts SC-001 coverage. Run is invoked against the entire
+// fixture set and the union of findings is checked for at least one finding
+// per expected rule.
+//
+// FR-015 ("structural rules MUST NOT emit LOW") is enforced per-scanner in
+// TestStructuralScanner_AggregateNoLowSeverity. The Renovate, Dependabot,
+// and cost scanners emit LOW by design; the integration test does not
+// re-assert that invariant here.
 func TestRunEndToEnd(t *testing.T) {
 	dir := stageFixturesIntoClone(t)
 	got := Run(context.Background(), dir)
@@ -55,10 +59,24 @@ func TestRunEndToEnd(t *testing.T) {
 		t.Fatal("expected at least some findings end-to-end; got 0")
 	}
 
-	// FR-015 invariant: v1 must not emit LOW.
+	// FR-015 scoped to structural rules only — the cost/renovate/dependabot
+	// scanners emit LOW intentionally. Use an allowlist of advisory-scanner
+	// prefixes: any LOW finding whose rule ID does NOT start with one of these
+	// is unexpected and fails the test.
+	allowedLowPrefixes := []string{rulePrefixCost, rulePrefixRenovate, rulePrefixDependabot}
 	for _, f := range got {
-		if f.Severity == SeverityLow {
-			t.Errorf("FR-015 violated: %+v has SeverityLow", f)
+		if f.Severity != SeverityLow {
+			continue
+		}
+		allowed := false
+		for _, p := range allowedLowPrefixes {
+			if strings.HasPrefix(f.RuleID, p) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			t.Errorf("FR-015 violated: structural rule %q emitted LOW", f.RuleID)
 		}
 	}
 
@@ -70,6 +88,9 @@ func TestRunEndToEnd(t *testing.T) {
 		"fleet.repo-memory.main-branch",
 		"fleet.mcp.non-standard-server",
 		"fleet.frontmatter.parse-error",
+		ruleIDCostHighFrequencyTrigger,
+		ruleIDCostReactiveNoSkipGuard,
+		ruleIDCostScheduledNoSkipGuard,
 	}
 	for _, id := range expectedRuleIDs {
 		if findRule(got, id, false) == nil {
@@ -248,31 +269,23 @@ func extractStderrTuple(line string) string {
 func extractBodyTuple(line string) string {
 	// Strip the "- **" prefix.
 	line = strings.TrimPrefix(line, "- **")
-	endSev := strings.Index(line, "**")
-	if endSev < 0 {
+	sev, rest, ok := strings.Cut(line, "**")
+	if !ok {
 		return line
 	}
-	sev := line[:endSev]
-	rest := line[endSev+2:]
 	// rest starts with " `rule_id` — `file:line` — ..."
 	rest = strings.TrimLeft(rest, " ")
 	rest = strings.TrimPrefix(rest, "`")
-	endRule := strings.Index(rest, "`")
-	if endRule < 0 {
+	rule, rest, ok := strings.Cut(rest, "`")
+	if !ok {
 		return line
 	}
-	rule := rest[:endRule]
-	rest = rest[endRule+1:]
-	idx := strings.Index(rest, "`")
-	if idx < 0 {
+	// Advance past the separator to the next backtick-delimited token.
+	_, rest, ok = strings.Cut(rest, "`")
+	if !ok {
 		return sev + "|" + rule + "|"
 	}
-	rest = rest[idx+1:]
-	endLoc := strings.Index(rest, "`")
-	if endLoc < 0 {
-		return sev + "|" + rule + "|"
-	}
-	loc := rest[:endLoc]
+	loc, _, _ := strings.Cut(rest, "`")
 	if loc == "" {
 		loc = "-"
 	}

--- a/internal/fleet/security/security_test.go
+++ b/internal/fleet/security/security_test.go
@@ -377,10 +377,10 @@ func assertRepoRelativeActionlintFile(t *testing.T, cloneDir, got string) {
 }
 
 func TestRunRegistersAllScanners(t *testing.T) {
-	// Smoke test: ensure default Run wires gitleaks + structural + actionlint + renovate + dependabot.
+	// Smoke test: ensure default Run wires gitleaks + structural + actionlint + renovate + dependabot + cost.
 	scanners := defaultScanners()
-	if len(scanners) != 5 {
-		t.Fatalf("defaultScanners() len = %d; want 5", len(scanners))
+	if len(scanners) != 6 {
+		t.Fatalf("defaultScanners() len = %d; want 6", len(scanners))
 	}
 	if _, ok := scanners[0].(*gitleaksScanner); !ok {
 		t.Errorf("scanner[0] type = %T; want *gitleaksScanner", scanners[0])
@@ -396,6 +396,9 @@ func TestRunRegistersAllScanners(t *testing.T) {
 	}
 	if _, ok := scanners[4].(*dependabotScanner); !ok {
 		t.Errorf("scanner[4] type = %T; want *dependabotScanner", scanners[4])
+	}
+	if _, ok := scanners[5].(*costScanner); !ok {
+		t.Errorf("scanner[5] type = %T; want *costScanner", scanners[5])
 	}
 }
 

--- a/internal/fleet/security/structural.go
+++ b/internal/fleet/security/structural.go
@@ -177,25 +177,19 @@ func hasWriteOrAdminPermission(v any) bool {
 	return false
 }
 
+// scheduleOrWorkflowRunSet is the set of triggers inspected by writeOnScheduleRule.
+//
+//nolint:gochecknoglobals // immutable lookup set
+var scheduleOrWorkflowRunSet = map[string]bool{
+	"schedule":     true,
+	"workflow_run": true,
+}
+
 // hasScheduleOrWorkflowRunTrigger inspects the `on:` block for the two
 // triggers that turn this rule on. Accepts the string, list, and map forms
 // GitHub Actions allows.
 func hasScheduleOrWorkflowRunTrigger(v any) bool {
-	switch t := v.(type) {
-	case string:
-		return t == "schedule" || t == "workflow_run"
-	case []any:
-		for _, e := range t {
-			if s, ok := e.(string); ok && (s == "schedule" || s == "workflow_run") {
-				return true
-			}
-		}
-	case map[string]any:
-		_, sched := t["schedule"]
-		_, wfRun := t["workflow_run"]
-		return sched || wfRun
-	}
-	return false
+	return hasTriggerInSet(v, scheduleOrWorkflowRunSet)
 }
 
 // draftFalseRule fires MEDIUM when safe-outputs.create-pull-request.draft

--- a/internal/fleet/security/testdata/security/workflow-with-check-run-no-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-check-run-no-skip-guard.md
@@ -1,0 +1,13 @@
+---
+on:
+  check_run:
+    types: [completed]
+engine: claude
+description: "React to CI check completions."
+permissions:
+  contents: read
+---
+
+# Check run handler
+
+Examine the completed check run and file a report.

--- a/internal/fleet/security/testdata/security/workflow-with-pr-no-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-pr-no-skip-guard.md
@@ -1,0 +1,14 @@
+---
+on:
+  pull_request:
+    types: [opened, synchronize]
+engine: claude
+description: "Review pull request changes."
+permissions:
+  contents: read
+  pull-requests: read
+---
+
+# PR reviewer
+
+Examine the pull request diff and summarise potential issues.

--- a/internal/fleet/security/testdata/security/workflow-with-pr-skip-no-match.md
+++ b/internal/fleet/security/testdata/security/workflow-with-pr-skip-no-match.md
@@ -1,0 +1,18 @@
+---
+on:
+  pull_request:
+    types: [opened, synchronize]
+  skip-if-no-match:
+    - "*.go"
+    - "*.ts"
+engine: claude
+description: "Review pull request changes."
+permissions:
+  contents: read
+  pull-requests: read
+---
+
+# PR reviewer with guard
+
+Examine the pull request diff and summarise potential issues.
+Only runs when Go or TypeScript files changed.

--- a/internal/fleet/security/testdata/security/workflow-with-prt-no-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-prt-no-skip-guard.md
@@ -1,0 +1,14 @@
+---
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+engine: claude
+description: "Review pull request changes from forks."
+permissions:
+  contents: read
+  pull-requests: read
+---
+
+# Fork PR reviewer
+
+Examine the pull request diff from a fork and summarise potential issues.

--- a/internal/fleet/security/testdata/security/workflow-with-push-no-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-push-no-skip-guard.md
@@ -1,0 +1,13 @@
+---
+on:
+  push:
+    branches: [main]
+engine: claude
+description: "Analyse new commits and update docs."
+permissions:
+  contents: read
+---
+
+# Push analyser
+
+Examine each new commit to main and update the documentation index.

--- a/internal/fleet/security/testdata/security/workflow-with-push-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-push-skip-guard.md
@@ -1,0 +1,16 @@
+---
+on:
+  push:
+    branches: [main]
+  skip-if-match:
+    - "skip-ci"
+engine: claude
+description: "Analyse new commits and update docs."
+permissions:
+  contents: read
+---
+
+# Push analyser with guard
+
+Examine each new commit to main and update the documentation index.
+Only runs when the commit message does not contain skip-ci.

--- a/internal/fleet/security/testdata/security/workflow-with-schedule-skip-guard.md
+++ b/internal/fleet/security/testdata/security/workflow-with-schedule-skip-guard.md
@@ -1,0 +1,14 @@
+---
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  skip-if-match:
+    - "is:pr is:open in:title \"[daily-scan]\""
+permissions:
+  contents: read
+engine: claude
+---
+
+# Scheduled workflow with guard
+
+Body content.


### PR DESCRIPTION
## Summary

- Introduces a `costScanner` that advises operators when a workflow's trigger shape will drive high Copilot-credit burn without a pre-activation guard
- Three advisory-only rules, all surfaced through the existing security-finding pipeline (deploy / sync / upgrade stderr + JSON envelope + PR body):
  - `fleet.cost.high-frequency-trigger` (MEDIUM) — fires when `push`, `check_run`, or `check_suite` is used without a `skip-if-match` / `skip-if-no-match` frontmatter key
  - `fleet.cost.reactive-no-skip-guard` (LOW) — fires when `pull_request`, `pull_request_target`, `issues`, or `issue_comment` is used without a skip guard
  - `fleet.cost.scheduled-no-skip-guard` (LOW) — fires when `schedule` is used without a skip guard (timer-driven workflows burn credits on quiet repos)
- Adds `skip-if-match` / `skip-if-no-match` extraction to `ExtractWorkflowMeta` and two new fields (`SkipIfMatch`, `SkipIfNoMatch`) to `TemplateWorkflow` so the template catalog surfaces guard presence without re-fetching
- New `DiagCostTriggerRisk` (`cost_trigger_risk`) diag code for downstream agents to gate on cost findings independently of security findings
- Updates the end-to-end integration test to scope the FR-015 "structural rules must not emit LOW" invariant correctly — Renovate, Dependabot, and cost scanners emit LOW by design

## Test plan

- [x] 12 unit tests in `cost_test.go` — all three rules, guard-present clean paths, low-cost trigger exemptions, diag code contract, read-only invariant, empty dir, malformed frontmatter
- [x] `TestRunRegistersAllScanners` updated (5 → 6 scanners)
- [x] `TestRunEndToEnd` updated with cost rule assertions
- [x] `make ci` passes with 0 issues (fmt, vet, lint, test)

## Changes

### New files

- `internal/fleet/security/cost.go` — `costScanner` implementing the `Scanner` interface; `hasTriggerInSet` and `hasSkipGuard` helpers; three `rule`-table entries reusing `structural.go` types
- `internal/fleet/security/cost_test.go` — 12 unit tests
- `testdata/security/workflow-with-push-no-skip-guard.md`
- `testdata/security/workflow-with-push-skip-guard.md`
- `testdata/security/workflow-with-check-run-no-skip-guard.md`
- `testdata/security/workflow-with-pr-no-skip-guard.md`
- `testdata/security/workflow-with-pr-skip-no-match.md`

### Modified files

- `internal/fleet/fleetdiag/diag.go` — added `DiagCostTriggerRisk`
- `internal/fleet/security/constants.go` — added two rule ID constants and `rulePrefixCost`
- `internal/fleet/security/finding.go` — wired cost prefix in `diagCodeForRuleID`; registered `newCostScanner()` as scanner[5]
- `internal/fleet/schema.go` — `SkipIfMatch` and `SkipIfNoMatch` fields on `TemplateWorkflow`
- `internal/fleet/frontmatter.go` — `extractSkipConditions` helper; populate new fields in `ExtractWorkflowMeta`
- `internal/fleet/security/security_test.go` — scanner count 5 → 6
- `internal/fleet/security/security_integration_test.go` — scoped FR-015 assertion; added cost rule IDs to expected set; replaced `strings.Index` with `strings.Cut` in parse helpers

Closes #104