### PR TITLE
feat(pkg/fleet): export fleet.json config contract as public package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,18 @@
 /gh-aw-fleet.exe
 /bin/
 /dist/
+build/
 node_modules/
 docs/.astro/
+vendor/
+*.log
 *.test
 *.out
+.env*
+.DS_Store
+Thumbs.db
+*.tmp
+*.swp
 .vscode/
 .idea/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@
 
 **Language**: Go 1.26.4 for the local development gate; `go.mod` currently declares module compatibility at `go 1.25.8`.
 
+## Architecture big-picture
+
+`pkg/fleet` is the module's first public surface and the single canonical home of the `fleet.json` wire contract. `internal/fleet` aliases those config types while keeping load, merge, resolve, and deploy logic internal.
+
 Per-slice dependency and storage deltas:
 
 - (006-layer1-security-scanner) Storage: N/A — pure read calls against files already in the work-dir clone. No on-disk scanner state, no cache, no baseline file. Findings are transient on result structs (`DeployResult`/`SyncResult`/`UpgradeResult`).
@@ -25,5 +29,5 @@ Per-slice dependency and storage deltas:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/014-starlight-docs-site/plan.md](./specs/014-starlight-docs-site/plan.md)
+[specs/015-pkg-fleet-config-export/plan.md](./specs/015-pkg-fleet-config-export/plan.md)
 <!-- SPECKIT END -->

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,7 +48,7 @@ func newListCmd(flagDir *string) *cobra.Command {
 			sort.Strings(repos)
 			for _, r := range repos {
 				spec := cfg.Repos[r]
-				resolved, resolveErr := cfg.ResolveRepoWorkflows(r)
+				resolved, resolveErr := fleet.ResolveRepoWorkflows(cfg, r)
 				if resolveErr != nil {
 					return resolveErr
 				}

--- a/internal/fleet/add.go
+++ b/internal/fleet/add.go
@@ -132,7 +132,7 @@ func Add(cfg *Config, opts AddOptions) (*AddResult, error) {
 		cfg.Repos = make(map[string]RepoSpec)
 	}
 	cfg.Repos[opts.Repo] = candidate
-	resolved, err := cfg.ResolveRepoWorkflows(opts.Repo)
+	resolved, err := ResolveRepoWorkflows(cfg, opts.Repo)
 	delete(cfg.Repos, opts.Repo)
 	if err != nil {
 		return nil, fmt.Errorf("resolve workflows for %q: %w", opts.Repo, err)

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -215,7 +215,7 @@ func setupRequiredSection(res *DeployResult) string {
 // Dry-run (Apply=false) stops after pre-flight and returns the plan.
 // --apply extends through branch/commit/push/PR.
 func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*DeployResult, error) {
-	resolved, err := cfg.ResolveRepoWorkflows(repo)
+	resolved, err := ResolveRepoWorkflows(cfg, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1057,7 @@ const CompileStrictMinVersion = "v0.79.2"
 // the resolve+log keeps the FR-006/FR-007 log shape identical across call
 // sites.
 func logCompileStrictResolution(ctx context.Context, cfg *Config, repo string) (bool, string) {
-	effective, source, reason := cfg.EffectiveCompileStrict(ctx, repo)
+	effective, source, reason := EffectiveCompileStrict(ctx, cfg, repo)
 	zlog.Info().
 		Str("event", "compile_strict_resolved").
 		Str(fieldRepo, repo).

--- a/internal/fleet/list_result.go
+++ b/internal/fleet/list_result.go
@@ -50,7 +50,7 @@ func BuildListResult(cfg *Config) (*ListResult, error) {
 	rows := make([]ListRow, 0, len(repoNames))
 	for _, repo := range repoNames {
 		spec := cfg.Repos[repo]
-		resolved, err := cfg.ResolveRepoWorkflows(repo)
+		resolved, err := ResolveRepoWorkflows(cfg, repo)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/fleet/load.go
+++ b/internal/fleet/load.go
@@ -368,7 +368,7 @@ func readHujsonOrScaffold(path string) ([]byte, error) {
 // ResolveRepoWorkflows flattens a RepoSpec into the concrete list of
 // (workflow, source, ref) tuples that should be deployed to that repo.
 // Applies profile membership, exclusions, and extras in that order.
-func (c *Config) ResolveRepoWorkflows(repo string) ([]ResolvedWorkflow, error) {
+func ResolveRepoWorkflows(c *Config, repo string) ([]ResolvedWorkflow, error) {
 	spec, ok := c.Repos[repo]
 	if !ok {
 		return nil, fmt.Errorf("repo %q not in fleet.json", repo)

--- a/internal/fleet/manifest.go
+++ b/internal/fleet/manifest.go
@@ -89,7 +89,7 @@ type VersionDrift struct {
 // Source is "github/gh-aw". Returns an empty string when the repo has no
 // github/gh-aw-sourced workflows or when ResolveRepoWorkflows fails.
 func resolvedGhAwPin(cfg *Config, repo string) string {
-	workflows, err := cfg.ResolveRepoWorkflows(repo)
+	workflows, err := ResolveRepoWorkflows(cfg, repo)
 	if err != nil {
 		return ""
 	}

--- a/internal/fleet/schema.go
+++ b/internal/fleet/schema.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 	"unicode/utf8"
+
+	pkgfleet "github.com/rshade/gh-aw-fleet/pkg/fleet"
 )
 
 // effectiveCompileStrictReasonMax bounds the length of the truncated raw
@@ -34,36 +36,29 @@ const VisibilityPublic = "public"
 // version written into Config.Version. Bumped only on breaking changes to the
 // on-disk structure; additive changes (new optional fields) do not bump.
 // Distinct from cmd.SchemaVersion, which versions the JSON output envelope.
-const SchemaVersion = 1
+const SchemaVersion = pkgfleet.SchemaVersion
 
 // Config is the declarative desired state for the fleet.
-// Loaded from fleet.local.json (if present) or fleet.json. Edits to this file are the source of truth;
-// `fleet sync` and `fleet upgrade` reconcile repos toward it.
-type Config struct {
-	Version  int                 `json:"version"`
-	Defaults Defaults            `json:"defaults,omitzero"`
-	Profiles map[string]Profile  `json:"profiles,omitempty"`
-	Repos    map[string]RepoSpec `json:"repos"`
-	// LoadedFrom names the on-disk source of this Config in human form,
-	// e.g. "fleet.json", "fleet.local.hujson", or "fleet.json + fleet.local.json"
-	// when both base and local files were merged. Set by LoadConfig only;
-	// callers must not modify.
-	LoadedFrom string `json:"-"`
-}
+type Config = pkgfleet.Config
 
 // Defaults are applied to every repo unless overridden in RepoSpec.
-type Defaults struct {
-	Engine string `json:"engine,omitempty"`
-}
+type Defaults = pkgfleet.Defaults
 
-// EffectiveEngine returns the engine for a repo, preferring per-repo override
-// over fleet-level default.
-func (c *Config) EffectiveEngine(repo string) string {
-	if spec, ok := c.Repos[repo]; ok && spec.Engine != "" {
-		return spec.Engine
-	}
-	return c.Defaults.Engine
-}
+// Profile is a named bundle of workflows pulled from one or more upstream
+// source repositories.
+type Profile = pkgfleet.Profile
+
+// SourcePin records the ref for a source repo within a profile.
+type SourcePin = pkgfleet.SourcePin
+
+// ProfileWorkflow names a workflow and which source repo provides it.
+type ProfileWorkflow = pkgfleet.ProfileWorkflow
+
+// RepoSpec is the desired state for a single target repo.
+type RepoSpec = pkgfleet.RepoSpec
+
+// ExtraWorkflow is a per-repo workflow not sourced from any profile.
+type ExtraWorkflow = pkgfleet.ExtraWorkflow
 
 // EffectiveCompileStrict resolves whether `gh aw compile --strict` should run
 // for repo. Returns (effective, source, reason) where source is one of
@@ -71,13 +66,11 @@ func (c *Config) EffectiveEngine(repo string) string {
 // CompileStrictSourceAutoPublic (visibility lookup returned "public"),
 // CompileStrictSourceAutoPrivate (visibility lookup returned any other value),
 // or CompileStrictSourceAutoFallback (visibility lookup errored — fail-secure
-// to strict ON, reason carries the truncated raw error). The method never
+// to strict ON, reason carries the truncated raw error). The function never
 // returns an error: lookup failures fold into the auto-fallback source so the
 // caller can proceed deterministically. Explicit override skips the
 // visibility lookup entirely (FR-008).
-func (c *Config) EffectiveCompileStrict(
-	ctx context.Context, repo string,
-) (bool, string, string) {
+func EffectiveCompileStrict(ctx context.Context, c *Config, repo string) (bool, string, string) {
 	if spec, ok := c.Repos[repo]; ok && spec.CompileStrict != nil {
 		return *spec.CompileStrict, CompileStrictSourceExplicit, ""
 	}
@@ -110,71 +103,6 @@ func truncateReason(s string, limit int) string {
 		out = out[:len(out)-1]
 	}
 	return out
-}
-
-// Profile is a named bundle of workflows pulled from one or more upstream
-// source repositories. A profile advances atomically: bumping Sources[x].Ref
-// re-pins every workflow in the profile sourced from x. The optional Tier
-// field carries an advisory cost-tier label consumed by `gh-aw-fleet list`
-// and the planned consumption subcommand.
-type Profile struct {
-	Description string `json:"description,omitempty"`
-	// Tier is an advisory cost-tier label (recommended vocabulary:
-	// "minimal" | "standard" | "premium") used by the planned consumption
-	// subcommand as a group-by key. Free-form — the tool does not enforce
-	// the recommended vocabulary, and an empty string is equivalent to the
-	// field being absent on disk.
-	Tier      string               `json:"tier,omitempty"`
-	Sources   map[string]SourcePin `json:"sources"`
-	Workflows []ProfileWorkflow    `json:"workflows"`
-}
-
-// SourcePin records the ref (tag/branch/sha) for a given source repo within
-// a profile. Keyed by "owner/repo" in the enclosing map.
-type SourcePin struct {
-	Ref string `json:"ref"`
-}
-
-// ProfileWorkflow names a workflow and which source repo provides it.
-// The actual ref comes from Profile.Sources[Source].Ref at deploy time.
-type ProfileWorkflow struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
-	Path   string `json:"path,omitempty"`
-}
-
-// RepoSpec is the desired state for a single target repo. The optional
-// CostCenter field carries a free-form budget-attribution label surfaced by
-// `gh-aw-fleet list` and consumed as a group-by key by the planned
-// consumption subcommand.
-type RepoSpec struct {
-	Profiles []string `json:"profiles"`
-	// CostCenter is a free-form per-repo budget-attribution label. The tool
-	// does not validate that the named cost center actually exists in the
-	// org's billing UI, and applies no special handling based on which
-	// fleet file (fleet.json vs fleet.local.json) the value appears in.
-	CostCenter string `json:"cost_center,omitempty"`
-	Engine     string `json:"engine,omitempty"`
-	// CompileStrict toggles `gh aw compile --strict` for this repo's deploy
-	// and upgrade pipelines. Tri-state: nil (the default) auto-detects from
-	// repo visibility (public → ON, non-public → OFF, lookup failure →
-	// fail-secure ON); a non-nil value short-circuits the auto-detect and
-	// the visibility lookup is skipped. The field is additive — absence
-	// round-trips byte-identically via HuJson AST mutation and incurs no
-	// `fleet.SchemaVersion` bump.
-	CompileStrict       *bool             `json:"compile_strict,omitempty"`
-	ExtraWorkflows      []ExtraWorkflow   `json:"extra,omitempty"`
-	ExcludeFromProfiles []string          `json:"exclude,omitempty"`
-	Overrides           map[string]string `json:"overrides,omitempty"`
-}
-
-// ExtraWorkflow is a per-repo workflow not from any profile. Source "local"
-// means it lives in the target repo and is not re-deployed from elsewhere.
-type ExtraWorkflow struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
-	Ref    string `json:"ref,omitempty"`
-	Path   string `json:"path,omitempty"`
 }
 
 // Templates is the upstream catalog cache (templates.json). Populated by

--- a/internal/fleet/schema_test.go
+++ b/internal/fleet/schema_test.go
@@ -76,7 +76,7 @@ func TestEffectiveCompileStrict(t *testing.T) {
 			cfg := &Config{Repos: map[string]RepoSpec{
 				repo: {CompileStrict: tc.spec},
 			}}
-			gotEff, gotSrc, gotReason := cfg.EffectiveCompileStrict(context.Background(), repo)
+			gotEff, gotSrc, gotReason := EffectiveCompileStrict(context.Background(), cfg, repo)
 
 			if gotEff != tc.wantEffective {
 				t.Errorf("effective = %v; want %v", gotEff, tc.wantEffective)
@@ -211,7 +211,7 @@ func TestEffectiveCompileStrict_ReasonTruncated(t *testing.T) {
 	}
 
 	cfg := &Config{Repos: map[string]RepoSpec{"rshade/test": {}}}
-	_, _, gotReason := cfg.EffectiveCompileStrict(context.Background(), "rshade/test")
+	_, _, gotReason := EffectiveCompileStrict(context.Background(), cfg, "rshade/test")
 	if len(gotReason) > effectiveCompileStrictReasonMax {
 		t.Errorf("len(reason) = %d; want <= %d", len(gotReason), effectiveCompileStrictReasonMax)
 	}

--- a/internal/fleet/status.go
+++ b/internal/fleet/status.go
@@ -91,7 +91,7 @@ type WorkflowDrift struct {
 type statusJob struct {
 	repo     string
 	declared []ResolvedWorkflow
-	// resolveErr surfaces a cfg.ResolveRepoWorkflows failure (broken profile
+	// resolveErr surfaces a ResolveRepoWorkflows failure (broken profile
 	// reference, etc.). When non-nil, the worker short-circuits to an errored
 	// RepoStatus rather than fetching anything.
 	resolveErr error
@@ -260,7 +260,7 @@ func selectRepos(cfg *Config, opts StatusOpts) ([]string, error) {
 func buildStatusJobs(cfg *Config, repos []string) []statusJob {
 	jobs := make([]statusJob, 0, len(repos))
 	for _, repo := range repos {
-		declared, err := cfg.ResolveRepoWorkflows(repo)
+		declared, err := ResolveRepoWorkflows(cfg, repo)
 		jobs = append(jobs, statusJob{
 			repo:            repo,
 			declared:        declared,

--- a/internal/fleet/sync.go
+++ b/internal/fleet/sync.go
@@ -40,7 +40,7 @@ type SyncResult struct {
 // Sync reconciles one repo's .github/workflows/ to match its declared profile(s).
 // Detects missing, drift, and expected workflows, then optionally deploys or prunes.
 func Sync(ctx context.Context, cfg *Config, repo string, opts SyncOpts) (*SyncResult, error) {
-	resolved, err := cfg.ResolveRepoWorkflows(repo)
+	resolved, err := ResolveRepoWorkflows(cfg, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fleet/config.go
+++ b/pkg/fleet/config.go
@@ -1,0 +1,98 @@
+// Package fleet defines the public, importable fleet.json wire contract:
+// the config-data shapes, the on-disk schema version, and their JSON
+// serialization. Load/merge/validate/analysis logic lives in the engine's
+// internal package, not here.
+package fleet
+
+// SchemaVersion is the on-disk fleet-config (fleet.json / fleet.local.json)
+// format version written into Config.Version. Distinct from the CLI output
+// envelope version.
+const SchemaVersion = 1
+
+// Config is the declarative desired state for the fleet.
+type Config struct {
+	// Version is the on-disk fleet-config schema version.
+	Version int `json:"version"`
+	// Defaults contains fleet-wide settings applied unless a repo overrides them.
+	Defaults Defaults `json:"defaults,omitzero"`
+	// Profiles maps profile names to workflow bundles.
+	Profiles map[string]Profile `json:"profiles,omitempty"`
+	// Repos maps owner/repo names to desired repo state.
+	Repos map[string]RepoSpec `json:"repos"`
+	// LoadedFrom names the on-disk source that produced this Config.
+	LoadedFrom string `json:"-"`
+}
+
+// EffectiveEngine returns the engine for repo, preferring the per-repo override
+// over the fleet-level default.
+func (c *Config) EffectiveEngine(repo string) string {
+	if spec, ok := c.Repos[repo]; ok && spec.Engine != "" {
+		return spec.Engine
+	}
+	return c.Defaults.Engine
+}
+
+// Defaults are applied to every repo unless overridden in RepoSpec.
+type Defaults struct {
+	// Engine is the fleet-wide default agentic workflow engine.
+	Engine string `json:"engine,omitempty"`
+}
+
+// Profile is a named bundle of workflows pulled from one or more upstream
+// source repositories.
+type Profile struct {
+	// Description summarizes the profile's intended workflow bundle.
+	Description string `json:"description,omitempty"`
+	// Tier is an advisory cost-tier label for fleet reporting.
+	Tier string `json:"tier,omitempty"`
+	// Sources maps source repositories to the refs used by this profile.
+	Sources map[string]SourcePin `json:"sources"`
+	// Workflows lists the workflows included in this profile.
+	Workflows []ProfileWorkflow `json:"workflows"`
+}
+
+// SourcePin records the ref for a source repo within a profile.
+type SourcePin struct {
+	// Ref is the tag, branch, or commit SHA pinned for a source repo.
+	Ref string `json:"ref"`
+}
+
+// ProfileWorkflow names a workflow and which source repo provides it.
+type ProfileWorkflow struct {
+	// Name is the workflow slug.
+	Name string `json:"name"`
+	// Source is the owner/repo key into the profile's Sources map.
+	Source string `json:"source"`
+	// Path is an optional source-relative workflow path override.
+	Path string `json:"path,omitempty"`
+}
+
+// RepoSpec is the desired state for a single target repo.
+type RepoSpec struct {
+	// Profiles lists the profile names applied to the repo.
+	Profiles []string `json:"profiles"`
+	// CostCenter is a free-form per-repo budget-attribution label.
+	CostCenter string `json:"cost_center,omitempty"`
+	// Engine is the repo-specific engine override.
+	Engine string `json:"engine,omitempty"`
+	// CompileStrict toggles gh-aw strict compilation for this repo.
+	CompileStrict *bool `json:"compile_strict,omitempty"`
+	// ExtraWorkflows lists per-repo workflows outside applied profiles.
+	ExtraWorkflows []ExtraWorkflow `json:"extra,omitempty"`
+	// ExcludeFromProfiles lists profile workflow names excluded for this repo.
+	ExcludeFromProfiles []string `json:"exclude,omitempty"`
+	// Overrides maps profile workflow names to local override paths.
+	Overrides map[string]string `json:"overrides,omitempty"`
+}
+
+// ExtraWorkflow is a per-repo workflow not sourced from any profile.
+type ExtraWorkflow struct {
+	// Name is the workflow slug.
+	Name string `json:"name"`
+	// Source identifies where the workflow comes from.
+	Source string `json:"source"`
+	// Ref is an optional source ref override.
+	Ref string `json:"ref,omitempty"`
+	// Path is an optional workflow path override.
+	Path string `json:"path,omitempty"`
+}

--- a/pkg/fleet/config_test.go
+++ b/pkg/fleet/config_test.go
@@ -1,0 +1,80 @@
+package fleet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/pkg/fleet"
+)
+
+func TestExternalConsumer(t *testing.T) {
+	if fleet.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d; want 1", fleet.SchemaVersion)
+	}
+
+	compileStrict := true
+	cfg := &fleet.Config{
+		Version: fleet.SchemaVersion,
+		Defaults: fleet.Defaults{
+			Engine: "copilot",
+		},
+		Profiles: map[string]fleet.Profile{
+			"default": {
+				Description: "Baseline workflows",
+				Tier:        "standard",
+				Sources: map[string]fleet.SourcePin{
+					"githubnext/agentics": {Ref: "main"},
+				},
+				Workflows: []fleet.ProfileWorkflow{
+					{
+						Name:   "ci-doctor",
+						Source: "githubnext/agentics",
+						Path:   "workflows/ci-doctor.md",
+					},
+				},
+			},
+		},
+		Repos: map[string]fleet.RepoSpec{
+			"acme/widgets": {
+				Profiles:      []string{"default"},
+				CostCenter:    "platform",
+				Engine:        "claude",
+				CompileStrict: &compileStrict,
+				ExtraWorkflows: []fleet.ExtraWorkflow{
+					{
+						Name:   "local-check",
+						Source: "local",
+						Path:   ".github/workflows/local-check.md",
+					},
+				},
+				ExcludeFromProfiles: []string{"mergefest"},
+				Overrides: map[string]string{
+					"ci-doctor": ".github/workflows/ci-doctor.md",
+				},
+			},
+		},
+	}
+
+	if got := cfg.EffectiveEngine("acme/widgets"); got != "claude" {
+		t.Errorf("EffectiveEngine override = %q; want %q", got, "claude")
+	}
+	if got := cfg.EffectiveEngine("acme/api"); got != "copilot" {
+		t.Errorf("EffectiveEngine default = %q; want %q", got, "copilot")
+	}
+}
+
+func ExampleConfig_EffectiveEngine() {
+	cfg := &fleet.Config{
+		Defaults: fleet.Defaults{Engine: "copilot"},
+		Repos: map[string]fleet.RepoSpec{
+			"acme/widgets": {Engine: "claude"},
+		},
+	}
+
+	fmt.Println(cfg.EffectiveEngine("acme/widgets"))
+	fmt.Println(cfg.EffectiveEngine("acme/api"))
+
+	// Output:
+	// claude
+	// copilot
+}

--- a/pkg/fleet/roundtrip_test.go
+++ b/pkg/fleet/roundtrip_test.go
@@ -1,0 +1,113 @@
+package fleet_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/pkg/fleet"
+)
+
+//nolint:gochecknoglobals // test flag registered at package scope so the standard test harness parses it
+var updateGolden = flag.Bool("update", false, "update golden testdata")
+
+func TestGoldenRoundTrip(t *testing.T) {
+	root := filepath.Join("..", "..")
+	inputPath := filepath.Join(root, "fleet.example.json")
+	goldenPath := filepath.Join("testdata", "config.canonical.json")
+
+	input, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("read fleet example: %v", err)
+	}
+
+	var cfg fleet.Config
+	if err := json.Unmarshal(input, &cfg); err != nil {
+		t.Fatalf("unmarshal fleet example: %v", err)
+	}
+	cfg.LoadedFrom = "fleet.example.json"
+
+	got, err := marshalCanonical(cfg)
+	if err != nil {
+		t.Fatalf("marshal canonical config: %v", err)
+	}
+	if bytes.Contains(got, []byte("LoadedFrom")) || bytes.Contains(got, []byte("loaded_from")) {
+		t.Fatalf("serialized config includes LoadedFrom: %s", got)
+	}
+
+	if updateGoldenEnabled() {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatalf("create testdata dir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("canonical config mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+func TestConfigJSONTags(t *testing.T) {
+	mustMarshal := func(t *testing.T, v any) []byte {
+		t.Helper()
+		out, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return out
+	}
+
+	cfg := fleet.Config{
+		Version:    fleet.SchemaVersion,
+		Profiles:   map[string]fleet.Profile{},
+		LoadedFrom: "fleet.local.json",
+	}
+	out := mustMarshal(t, cfg)
+
+	if bytes.Contains(out, []byte("defaults")) {
+		t.Errorf("zero Defaults field was serialized: %s", out)
+	}
+	if bytes.Contains(out, []byte("profiles")) {
+		t.Errorf("empty Profiles map was serialized: %s", out)
+	}
+	if !bytes.Contains(out, []byte(`"repos":null`)) {
+		t.Errorf("nil Repos field was omitted; got %s", out)
+	}
+	if bytes.Contains(out, []byte("LoadedFrom")) || bytes.Contains(out, []byte("loaded_from")) {
+		t.Errorf("LoadedFrom field was serialized: %s", out)
+	}
+
+	repo := fleet.RepoSpec{
+		Profiles:            []string{"default"},
+		ExtraWorkflows:      []fleet.ExtraWorkflow{},
+		ExcludeFromProfiles: []string{},
+	}
+	repoOut := mustMarshal(t, repo)
+	if bytes.Contains(repoOut, []byte("extra")) {
+		t.Errorf("empty ExtraWorkflows slice was serialized: %s", repoOut)
+	}
+	if bytes.Contains(repoOut, []byte("exclude")) {
+		t.Errorf("empty ExcludeFromProfiles slice was serialized: %s", repoOut)
+	}
+}
+
+func updateGoldenEnabled() bool {
+	return *updateGolden
+}
+
+func marshalCanonical(cfg fleet.Config) ([]byte, error) {
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}

--- a/pkg/fleet/testdata/config.canonical.json
+++ b/pkg/fleet/testdata/config.canonical.json
@@ -1,0 +1,74 @@
+{
+  "version": 1,
+  "profiles": {
+    "default": {
+      "description": "Baseline profile. Workflows pulled from agentics (the curated library) wherever an equivalent exists; gh-aw only for dogfooded items with no agentics counterpart (audit-workflows, docs-noob-tester, mergefest). Mirrors profiles/default.json — keep them in sync.",
+      "sources": {
+        "github/gh-aw": {
+          "ref": "v0.79.2"
+        },
+        "githubnext/agentics": {
+          "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a"
+        }
+      },
+      "workflows": [
+        {
+          "name": "audit-workflows",
+          "source": "github/gh-aw"
+        },
+        {
+          "name": "docs-noob-tester",
+          "source": "github/gh-aw"
+        },
+        {
+          "name": "mergefest",
+          "source": "github/gh-aw"
+        },
+        {
+          "name": "ci-doctor",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "code-simplifier",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "daily-doc-updater",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "daily-malicious-code-scan",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "pr-fix",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "weekly-issue-summary",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "issue-arborist",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "sub-issue-closer",
+          "source": "githubnext/agentics"
+        },
+        {
+          "name": "dependabot-pr-bundler",
+          "source": "githubnext/agentics"
+        }
+      ]
+    }
+  },
+  "repos": {
+    "acme/widgets": {
+      "profiles": [
+        "default"
+      ],
+      "engine": "copilot"
+    }
+  }
+}

--- a/specs/015-pkg-fleet-config-export/checklists/requirements.md
+++ b/specs/015-pkg-fleet-config-export/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Specification Quality Checklist: Export Fleet Config Contract into Public `pkg/fleet`
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This feature is an API-contract / library-export task, so the package import
+  path (`pkg/fleet`) and the exported identifier names ARE the user-facing
+  contract — naming them is specifying the deliverable, not leaking
+  implementation. The "no implementation details" items are interpreted in that
+  light: the spec names *what is exported* (the contract surface) but defers
+  *how* the refactor is mechanically performed (alias vs embedding, file
+  layout) to the plan, recording only the chosen default in Assumptions.
+- Zero [NEEDS CLARIFICATION] markers: the source issue (#148) is highly
+  prescriptive, and every open choice has a reasonable default grounded in the
+  issue text or existing repo conventions. Defaults are recorded in the
+  Assumptions section.
+- Items marked incomplete require spec updates before `/speckit-clarify` or
+  `/speckit-plan`. All items currently pass.

--- a/specs/015-pkg-fleet-config-export/contracts/pkg-fleet.md
+++ b/specs/015-pkg-fleet-config-export/contracts/pkg-fleet.md
@@ -1,0 +1,108 @@
+# Contract: Public Go Package `github.com/rshade/gh-aw-fleet/pkg/fleet`
+
+For a CLI/library project the "interface contract" is the **exported Go API
+surface** of the new package. This is the stable promise the control-plane module
+(#142/#143) imports against. Every identifier below MUST exist, be exported, and
+carry a godoc comment (FR-010, SC-005).
+
+## Import path
+
+```go
+import "github.com/rshade/gh-aw-fleet/pkg/fleet"
+```
+
+Package clause: `package fleet`. Distinguished from `internal/fleet` (also
+`package fleet`) by import path only.
+
+## Exported surface (declarative signature contract)
+
+```go
+// Package fleet defines the public, importable fleet.json wire contract:
+// the config-data shapes, the on-disk schema version, and their JSON
+// serialization. Load/merge/validate/analysis logic lives in the engine's
+// internal package, not here.
+package fleet
+
+// SchemaVersion is the on-disk fleet-config (fleet.json / fleet.local.json)
+// format version written into Config.Version. Distinct from the CLI output
+// envelope version. Value: 1.
+const SchemaVersion = 1
+
+type Config struct {
+    Version    int                 `json:"version"`
+    Defaults   Defaults            `json:"defaults,omitzero"`
+    Profiles   map[string]Profile  `json:"profiles,omitempty"`
+    Repos      map[string]RepoSpec `json:"repos"`
+    LoadedFrom string              `json:"-"`
+}
+
+// EffectiveEngine returns the engine for repo, preferring the per-repo
+// override over the fleet-level default.
+func (c *Config) EffectiveEngine(repo string) string
+
+type Defaults struct {
+    Engine string `json:"engine,omitempty"`
+}
+
+type Profile struct {
+    Description string               `json:"description,omitempty"`
+    Tier       string               `json:"tier,omitempty"`
+    Sources    map[string]SourcePin `json:"sources"`
+    Workflows  []ProfileWorkflow    `json:"workflows"`
+}
+
+type SourcePin struct {
+    Ref string `json:"ref"`
+}
+
+type ProfileWorkflow struct {
+    Name   string `json:"name"`
+    Source string `json:"source"`
+    Path   string `json:"path,omitempty"`
+}
+
+type RepoSpec struct {
+    Profiles            []string          `json:"profiles"`
+    CostCenter          string            `json:"cost_center,omitempty"`
+    Engine              string            `json:"engine,omitempty"`
+    CompileStrict       *bool             `json:"compile_strict,omitempty"`
+    ExtraWorkflows      []ExtraWorkflow   `json:"extra,omitempty"`
+    ExcludeFromProfiles []string          `json:"exclude,omitempty"`
+    Overrides           map[string]string `json:"overrides,omitempty"`
+}
+
+type ExtraWorkflow struct {
+    Name   string `json:"name"`
+    Source string `json:"source"`
+    Ref    string `json:"ref,omitempty"`
+    Path   string `json:"path,omitempty"`
+}
+```
+
+## Contract guarantees (asserted by tests)
+
+| ID | Guarantee | Verified by |
+|----|-----------|-------------|
+| C-1 | All seven types + `SchemaVersion` are importable from outside `internal/` and compile. | `package fleet_test` black-box test (SC-001) |
+| C-2 | `SchemaVersion == 1`. | black-box assertion (FR-003) |
+| C-3 | `(&Config{...}).EffectiveEngine(repo)` returns per-repo override else default. | black-box behavior test (FR-004) |
+| C-4 | Marshal/unmarshal is byte-identical to the canonical baseline for `fleet.example.json` data. | golden round-trip vs. `testdata/config.canonical.json` (SC-002, FR-005/FR-006) |
+| C-5 | `LoadedFrom` (`json:"-"`) never appears in serialized output. | golden round-trip + explicit absence assertion (FR-005, spec US2 #3) |
+| C-6 | `omitzero` (Defaults) / `omitempty` (Profiles, RepoSpec slices) / no-omit (Repos→`null`) all preserved. | golden round-trip covering each case (spec Edge Cases) |
+| C-7 | Every exported identifier has a godoc comment. | `make lint` (revive/staticcheck), SC-005 |
+
+## NON-contract (explicitly NOT exported by this package)
+
+These remain `internal/fleet` and MUST NOT be importable via `pkg/fleet`
+(FR-008/FR-015/FR-016, one-way-dependency FR-013):
+
+- `EffectiveCompileStrict` (now a standalone func in `internal/fleet`),
+  `ghRepoVisibility`, `truncateReason`, `CompileStrictSource*`, `VisibilityPublic`.
+- `Templates`, `TemplateSource`, `TemplateWorkflow`, `Evaluation`.
+- `LoadConfig`, `mergeConfigs`, `ResolveRepoWorkflows`, `ResolvedWorkflow`.
+
+## Compatibility / stability
+
+- The on-disk format does not change; `SchemaVersion` stays `1` (FR-011).
+- No new `go.mod` require entry; the package is stdlib-only (FR-014, SC-006).
+- The engine module takes on no dependency on the control plane (FR-013).

--- a/specs/015-pkg-fleet-config-export/data-model.md
+++ b/specs/015-pkg-fleet-config-export/data-model.md
@@ -1,0 +1,125 @@
+# Phase 1 Data Model: Public `pkg/fleet` Config Contract
+
+This slice **moves** an existing, stable data model; it does not design a new one.
+The entities below are the seven config-contract types relocated verbatim from
+`internal/fleet/schema.go` into `pkg/fleet/config.go`, plus the `SchemaVersion`
+constant. Field names, types, and JSON tags are preserved **byte-for-byte** —
+the tables double as the FR-005 fidelity checklist.
+
+## Entity relationship (composition)
+
+```text
+Config
+├── Version        int
+├── Defaults       Defaults
+├── Profiles       map[string]Profile
+│                     └── Profile
+│                          ├── Sources    map[string]SourcePin
+│                          └── Workflows  []ProfileWorkflow
+├── Repos          map[string]RepoSpec
+│                     └── RepoSpec
+│                          └── ExtraWorkflows  []ExtraWorkflow
+└── LoadedFrom     string   (json:"-", loader-only)
+```
+
+The set is **closed**: no field references a type outside these seven (verified
+against the source). That is what lets them relocate without dragging
+`Templates`, `ResolvedWorkflow`, or any network helper across the module boundary.
+
+---
+
+## Config — root of the wire contract
+
+| Field | Type | JSON tag | Omit behavior (MUST preserve) |
+|-------|------|----------|-------------------------------|
+| `Version` | `int` | `version` | always present |
+| `Defaults` | `Defaults` | `defaults,omitzero` | omitted when zero-value (Go 1.24+ `omitzero`) |
+| `Profiles` | `map[string]Profile` | `profiles,omitempty` | omitted when nil/empty |
+| `Repos` | `map[string]RepoSpec` | `repos` | **no omit** — encodes as `null` when nil |
+| `LoadedFrom` | `string` | `-` | **never serialized**; set by `LoadConfig` only |
+
+- **Method** (moves with the type, stays a method): `EffectiveEngine(repo string) string`
+  — returns the per-repo `Engine` override if set, else `Defaults.Engine`. Pure;
+  no internal/network dependency (FR-004).
+- **Validation**: `LoadConfig` rejects `Version != SchemaVersion` — but that check
+  lives in `internal/fleet/load.go` and **stays there** (FR-016). The contract type
+  itself enforces nothing.
+- **Edge cases locked by tags**: `Defaults` uses `omitzero` (NOT `omitempty`);
+  `Profiles` uses `omitempty`; `Repos` has *no* omit tag (the three behaviors are
+  deliberately different and must each survive — spec Edge Cases).
+
+## Defaults — fleet-wide defaults
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Engine` | `string` | `engine,omitempty` | omitted when `""` |
+
+## Profile — atomically-advancing workflow bundle
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Description` | `string` | `description,omitempty` | omitted when `""` |
+| `Tier` | `string` | `tier,omitempty` | advisory cost label; omitted when `""` |
+| `Sources` | `map[string]SourcePin` | `sources` | always present |
+| `Workflows` | `[]ProfileWorkflow` | `workflows` | always present |
+
+## SourcePin — pinned ref for a source repo within a profile
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Ref` | `string` | `ref` | always present |
+
+## ProfileWorkflow — a workflow entry in a profile
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Name` | `string` | `name` | always present |
+| `Source` | `string` | `source` | always present |
+| `Path` | `string` | `path,omitempty` | omitted when `""` |
+
+## RepoSpec — per-repo desired state
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Profiles` | `[]string` | `profiles` | always present |
+| `CostCenter` | `string` | `cost_center,omitempty` | advisory; omitted when `""` |
+| `Engine` | `string` | `engine,omitempty` | omitted when `""` |
+| `CompileStrict` | `*bool` | `compile_strict,omitempty` | tri-state; omitted when nil |
+| `ExtraWorkflows` | `[]ExtraWorkflow` | `extra,omitempty` | **omitted when empty** (drops `"extra": []`) |
+| `ExcludeFromProfiles` | `[]string` | `exclude,omitempty` | **omitted when empty** (drops `"exclude": []`) |
+| `Overrides` | `map[string]string` | `overrides,omitempty` | omitted when nil/empty |
+
+> The two `omitempty` slices are why `fleet.example.json` cannot be the byte-for-byte
+> golden target (research.md Decision 4): the example's `"extra": []` / `"exclude": []`
+> vanish on re-marshal. `CompileStrict` is read by the *relocated* standalone
+> `EffectiveCompileStrict` function in `internal/fleet`, not by anything in `pkg/fleet`.
+
+## ExtraWorkflow — per-repo workflow not from any profile
+
+| Field | Type | JSON tag | Omit behavior |
+|-------|------|----------|---------------|
+| `Name` | `string` | `name` | always present |
+| `Source` | `string` | `source` | always present |
+| `Ref` | `string` | `ref,omitempty` | omitted when `""` |
+| `Path` | `string` | `path,omitempty` | omitted when `""` |
+
+## SchemaVersion — constant
+
+| Identifier | Type | Value | Notes |
+|------------|------|-------|-------|
+| `SchemaVersion` | untyped int const | `1` | on-disk fleet-config format version; **distinct** from `cmd.SchemaVersion` (JSON envelope). MUST NOT change (FR-011, SC-006). Re-exported in `internal/fleet` via `const SchemaVersion = pkgfleet.SchemaVersion`. |
+
+---
+
+## What does NOT move (stays in `internal/fleet`)
+
+These are listed so a reviewer can confirm the boundary is correct:
+
+- **Impure / deploy-path**: `EffectiveCompileStrict` (method → func),
+  `ghRepoVisibility` (network), `truncateReason`, `effectiveCompileStrictReasonMax`,
+  `CompileStrictSource{Explicit,AutoPublic,AutoPrivate,AutoFallback}`,
+  `VisibilityPublic` (FR-008).
+- **Catalog cache**: `Templates`, `TemplateSource`, `TemplateWorkflow`, `Evaluation`
+  (FR-015).
+- **Load / resolve**: `LoadConfig`, `mergeConfigs`, HuJson read path,
+  `ResolveRepoWorkflows` (method → func), `ResolvedWorkflow` type (FR-016).

--- a/specs/015-pkg-fleet-config-export/plan.md
+++ b/specs/015-pkg-fleet-config-export/plan.md
@@ -1,0 +1,154 @@
+# Implementation Plan: Export Fleet Config Contract into Public `pkg/fleet`
+
+**Branch**: `015-pkg-fleet-config-export` | **Date**: 2026-06-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/015-pkg-fleet-config-export/spec.md` (GitHub issue #148)
+
+## Summary
+
+Publish the `fleet.json` *wire contract* — the seven config-contract types
+(`Config`, `Defaults`, `Profile`, `SourcePin`, `ProfileWorkflow`, `RepoSpec`,
+`ExtraWorkflow`), the `SchemaVersion` constant (`1`), the pure `EffectiveEngine`
+method, and their exact JSON struct tags — in a new public package
+`github.com/rshade/gh-aw-fleet/pkg/fleet`, so the separate `agentic-fleet.ai`
+control-plane module can import one canonical type instead of re-declaring the
+schema by hand (the silent-drift failure mode behind #142). All load / merge /
+validate / analysis logic stays behind in `internal/fleet`; `internal/fleet`
+re-exposes the moved types via **type aliases** so existing CLI behavior and the
+on-disk format are byte-for-byte unchanged.
+
+**Technical approach** (decided in [research.md](./research.md)): a pure
+relocation within the existing module. Move the contract types, `SchemaVersion`,
+and `EffectiveEngine` into `pkg/fleet`; in `internal/fleet` add
+`type X = pkgfleet.X` aliases and a `const SchemaVersion = pkgfleet.SchemaVersion`
+re-export. The
+type-alias approach has one consequence the spec under-counted: **methods cannot
+be attached to an aliased type**, so *both* impure methods on `Config` —
+`EffectiveCompileStrict` (already named in the spec) **and** `ResolveRepoWorkflows`
+(not named, ~7 production call sites) — must convert from methods to standalone
+functions in `internal/fleet`. Catalog types (`Templates`, …) and load/merge stay
+put per FR-015/FR-016. Byte-fidelity is locked by a golden round-trip test against
+a newly-committed *canonical* baseline (the hand-aligned `fleet.example.json`
+cannot be the byte target — see research.md Decision 4).
+
+## Technical Context
+
+**Language/Version**: Go 1.26.4 local development gate; `go.mod` declares module
+compatibility at `go 1.25.8` (the `omitzero` tag in use requires Go 1.24+, which
+both satisfy — no encoding behavior change from the toolchain).
+**Primary Dependencies**: stdlib only for the new package (`encoding/json` via
+struct tags; no imports needed in the contract file itself beyond what the types
+require — none). Existing module deps (`cobra`, `zerolog`, `yaml.v3`, `hujson`,
+`gitleaks/v8`) are untouched. **No new third-party dependency** (FR-014; Constitution
+§Third-Party Dependencies).
+**Storage**: N/A — pure code relocation; no on-disk format change, no new state,
+no schema-version bump (FR-011). `fleet.json` / `fleet.local.json` bytes unchanged.
+**Testing**: `go test ./...` (existing suite, run via `make test`); a new
+black-box test in `package fleet_test` under `pkg/fleet/` for SC-001 (external
+consumer compiles & uses all seven types + `SchemaVersion`) and SC-002 (golden
+round-trip vs. canonical baseline). Full gate: `make ci` (fmt-check, vet, lint, test).
+**Target Platform**: Linux / macOS developer toolchain; the package is consumed by
+another Go module (the control plane) at build time.
+**Project Type**: Single Go module — CLI + library. The feature adds the module's
+first public (`pkg/`) surface; everything else stays under `internal/`.
+**Performance Goals**: N/A — no runtime path changes; compile-time-only contract.
+**Constraints**: One-way dependency — the engine MUST NOT depend on the control
+plane (FR-013). JSON encoding MUST stay byte-identical (FR-005). 100% godoc on
+new exported identifiers (FR-010, SC-005).
+**Scale/Scope**: ~230 lines split out of `internal/fleet/schema.go`; ~9 call-site
+edits for the two method→function conversions; 1 new package file + 2 new test
+files (`config_test.go`, `roundtrip_test.go`) + 1 new golden testdata file. No
+behavior-test expectations change (SC-004).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against Constitution v1.1.0:
+
+- **I. Thin-Orchestrator Code Quality** — ✅ PASS. No upstream-tool logic is
+  re-implemented; this is a pure intra-module relocation. `go build`/`go vet` stay
+  clean. Splitting the impure logic (`EffectiveCompileStrict`) out of the contract
+  file and naming the relocated functions expressively (no comments needed for the
+  *what*) aligns with the WHY-only comment rule. `schema.go` shrinks; no file
+  crosses the 300-line guidance as a result.
+- **II. Testing Standards (Build-Green + Real-World Dry-Run)** — ✅ PASS. No
+  mutating-command behavior changes, so the dry-run substrate is untouched; the
+  existing dry-run/integration tests are the regression guard. New unit-style tests
+  (golden round-trip + external-consumer compile) are additive and justified — they
+  verify a wire contract, exactly the kind of pure, stateless transformation the
+  project's unit-test guidance endorses.
+- **III. UX Consistency (Three-Turn Mutation Pattern)** — ✅ PASS / N/A. No command
+  surface, output, exit code, commit message, or PR title changes (FR-012). The
+  three-turn pattern and `CollectHints` paths are untouched.
+- **IV. Performance (Parallelism, Cache, 5-Min Ceiling)** — ✅ PASS / N/A. No new
+  I/O, no network calls in the contract package (the network helper `ghRepoVisibility`
+  stays in `internal/fleet`, FR-008/FR-013). No caching surface affected.
+- **Third-Party Dependencies** — ✅ PASS. No new `require` entry (FR-014, SC-006).
+  `go.mod` is unchanged except possibly nothing at all.
+- **Declarative Reconcile Invariants** — ✅ PASS. `fleet.json` remains source of
+  truth; no signing/git-path changes; `fleet.local.json` handling unchanged.
+
+**Result**: No violations. Complexity Tracking table is empty (nothing to justify).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-pkg-fleet-config-export/
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 — decisions (alias vs embed, method conversions, golden baseline)
+├── data-model.md        # Phase 1 — the seven contract entities + field/tag fidelity table
+├── quickstart.md        # Phase 1 — how to verify SC-001..SC-006 locally
+├── contracts/
+│   └── pkg-fleet.md      # Phase 1 — the public Go API surface (exported identifiers + godoc contract)
+└── tasks.md             # Phase 2 — created by /speckit-tasks, NOT here
+```
+
+### Source Code (repository root)
+
+```text
+pkg/                                  # NEW — module's first public surface
+└── fleet/
+    ├── config.go                     # NEW — Config, Defaults, Profile, SourcePin,
+    │                                 #       ProfileWorkflow, RepoSpec, ExtraWorkflow,
+    │                                 #       SchemaVersion, (c *Config) EffectiveEngine,
+    │                                 #       package doc. stdlib-only, no internal imports.
+    ├── config_test.go                # NEW — package fleet_test (black-box): SC-001 compile
+    │                                 #       + SchemaVersion==1 + EffectiveEngine behavior
+    ├── roundtrip_test.go             # NEW — package fleet_test: SC-002 golden round-trip vs canonical baseline
+    └── testdata/
+        └── config.canonical.json     # NEW — committed canonical baseline (json.MarshalIndent form of the example)
+
+internal/fleet/
+├── schema.go                         # CHANGED — contract types removed; now holds:
+│                                     #   type aliases (Config, Defaults, Profile, SourcePin,
+│                                     #     ProfileWorkflow, RepoSpec, ExtraWorkflow = pkgfleet.X),
+│                                     #   const SchemaVersion = pkgfleet.SchemaVersion (re-export),
+│                                     #   CompileStrictSource* + VisibilityPublic + effectiveCompileStrictReasonMax,
+│                                     #   truncateReason, EffectiveCompileStrict (now a standalone func),
+│                                     #   Templates/TemplateSource/TemplateWorkflow/Evaluation (catalog — stay, FR-015)
+├── load.go                           # CHANGED — ResolveRepoWorkflows: method → standalone func
+├── deploy.go                         # CHANGED — 1 call site: cfg.EffectiveCompileStrict(ctx,repo) → EffectiveCompileStrict(ctx,cfg,repo); ghRepoVisibility stays here
+├── add.go, sync.go, manifest.go,     # CHANGED — ResolveRepoWorkflows call sites (cfg.R(repo) → R(cfg,repo))
+│   status.go, list_result.go
+└── *_test.go                         # CHANGED — mechanical: schema_test.go references the relocated EffectiveCompileStrict func (sync_test.go mentions ResolveRepoWorkflows only in a comment — no change)
+
+cmd/
+├── list.go                           # CHANGED — fleet.ResolveRepoWorkflows(cfg,r) + fleet.EffectiveEngine unchanged (method stays)
+```
+
+**Structure Decision**: Single Go module. The feature introduces the conventional
+`pkg/<name>` directory for the module's first publicly-importable package, keeping
+the rest of the codebase under `internal/`. The public package is `package fleet`
+at import path `…/pkg/fleet`; the internal package keeps `package fleet` at
+`…/internal/fleet` and aliases the moved types — legal because the two are
+distinguished by import path (spec Edge Case "Same package name, two import paths").
+
+## Complexity Tracking
+
+> No Constitution violations — table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)*  | —          | —                                    |

--- a/specs/015-pkg-fleet-config-export/quickstart.md
+++ b/specs/015-pkg-fleet-config-export/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart: Verifying the `pkg/fleet` Contract Export
+
+How to confirm each success criterion locally once the change is implemented. All
+commands run from the repo root. No `--apply`, no network mutation — this slice is
+pure code relocation.
+
+## 1. Build & full gate (SC-003, SC-004)
+
+```bash
+go build ./...        # compiles, including the new pkg/fleet package
+go vet ./...
+make ci               # fmt-check + vet + lint + full test suite (the CI gate)
+```
+
+`make ci` must be green with **no new lint suppressions** (SC-003) and **no
+modified behavior-test expectations** — only references to relocated symbols
+should change in existing tests (SC-004).
+
+> Per project convention (operator preference): if `make lint` misbehaves, run the
+> linter directly with `~/go/bin/golangci-lint run ./...`. Lint can exceed 5
+> minutes — use an extended timeout, do not skip it.
+
+## 2. External consumer can import the contract (SC-001, C-1/C-2/C-3)
+
+The black-box test in `pkg/fleet/config_test.go` (`package fleet_test`) is the
+in-module proof — it can only touch exported identifiers, exactly like an outside
+module:
+
+```bash
+go test ./pkg/fleet/ -run 'TestExternalConsumer|Example' -v
+```
+
+Expect: declares `fleet.Config`, `fleet.RepoSpec`, `fleet.Profile`,
+`fleet.SourcePin`, `fleet.ProfileWorkflow`, `fleet.ExtraWorkflow`,
+`fleet.Defaults`; asserts `fleet.SchemaVersion == 1`; asserts
+`EffectiveEngine` returns the per-repo override then the default.
+
+Optional belt-and-suspenders (a literal *separate module* importing the engine) is
+not required by this slice — the external test package gives the same compile-time
+guarantee within CI.
+
+## 3. Wire bytes stay byte-identical (SC-002, C-4/C-5/C-6)
+
+```bash
+go test ./pkg/fleet/ -run TestGoldenRoundTrip -v
+```
+
+The test: read `fleet.example.json` → `json.Unmarshal` into `pkg/fleet.Config` →
+`json.MarshalIndent(cfg, "", "  ")` + trailing newline → assert **byte-equal** to
+`pkg/fleet/testdata/config.canonical.json`.
+
+To regenerate the golden after an *intentional* example-data change (rare — not in
+this slice):
+
+```bash
+# conceptual — implement as a small -update flag or one-off:
+#   marshal(unmarshal(fleet.example.json)) > pkg/fleet/testdata/config.canonical.json
+```
+
+It also asserts `LoadedFrom` never appears in the output (C-5) and that the
+`omitzero`/`omitempty`/no-omit cases each behave as documented (C-6).
+
+> Reminder: the golden is **not** `fleet.example.json` verbatim — the example is
+> hand-aligned and carries `omitempty` empty arrays that drop on re-marshal
+> (research.md Decision 4).
+
+## 4. No on-disk or behavior change (SC-004, SC-006, FR-011/FR-012)
+
+```bash
+# Before and after the change, on main vs the branch:
+go run . list 2>&1 | tee /tmp/list.after.txt
+# diff against a capture from main — output + exit code must match.
+
+git diff main -- go.mod          # expect: empty (no new require) — SC-006
+grep -rn "SchemaVersion = " internal/fleet cmd   # values unchanged (still 1)
+```
+
+`fleet.json` / `fleet.local.json` on disk are never rewritten by this change.
+
+## 5. Godoc completeness (SC-005, C-7)
+
+```bash
+make lint     # revive + staticcheck flag any exported symbol missing a godoc comment
+go doc ./pkg/fleet            # eyeball: every type/const/method documented
+go doc ./pkg/fleet Config
+```
+
+## Acceptance checklist (maps to spec Success Criteria)
+
+- [ ] SC-001 — external `package fleet_test` references all 7 types + `SchemaVersion`, compiles.
+- [ ] SC-002 — golden round-trip byte-identical to `config.canonical.json`.
+- [ ] SC-003 — `make ci` green, no new lint suppressions.
+- [ ] SC-004 — `go run . list` (and suite) output/exit unchanged vs `main`; only relocated-symbol references edited.
+- [ ] SC-005 — 100% godoc on new exported identifiers (clean revive/staticcheck).
+- [ ] SC-006 — no `SchemaVersion` value change; `go.mod` gains no `require`.

--- a/specs/015-pkg-fleet-config-export/research.md
+++ b/specs/015-pkg-fleet-config-export/research.md
@@ -1,0 +1,206 @@
+# Phase 0 Research: Export Fleet Config Contract into Public `pkg/fleet`
+
+All "NEEDS CLARIFICATION" items from Technical Context are resolved here. The
+feature is a constrained refactor, so the research is less "evaluate libraries"
+and more "verify the chosen Go mechanics against the actual code." Each decision
+below was checked against the current `internal/fleet` source, not just the spec.
+
+---
+
+## Decision 1 — Refactor mechanism: type aliases (not embedding)
+
+**Decision**: In `internal/fleet`, re-expose every moved contract type with a Go
+**type alias** (`type Config = pkgfleet.Config`), and re-export the constant with
+`const SchemaVersion = pkgfleet.SchemaVersion`. The seven contract types and
+`SchemaVersion` physically live in `pkg/fleet`.
+
+**Rationale**: A type alias makes `internal/fleet.Config` and `pkg/fleet.Config`
+the *same* type — there is exactly one underlying definition, so the control plane
+(importing `pkg/fleet`) and the engine (using the alias) can never drift, and JSON
+encoding is provably identical because it is literally the same struct + tags.
+This is the issue's recommended approach and what the spec selected (FR-007,
+Assumptions "Preferred refactor approach").
+
+**Alternatives considered**:
+
+- **Anonymous embedding** (`type Config struct { pkgfleet.Config }`) — the issue's
+  stated *fallback*. Rejected: it creates a *distinct* internal type, reintroducing
+  a second (thin) definition and undermining "one canonical type." Field promotion
+  preserves most JSON behavior but is a subtle, easy-to-break surface; and anywhere
+  a literal `pkg/fleet.Config` is required (future `RemoteSource` parse target,
+  control-plane interop) the embedder is the wrong type. Embedding's only advantage —
+  methods can stay attached — is outweighed by Decision 2 making the method
+  conversions cheap and mechanical anyway.
+- **Re-declare structs in both packages** — the status quo the feature exists to
+  kill. Rejected by definition (silent drift is the bug).
+
+---
+
+## Decision 2 — Methods on the aliased type must become standalone functions
+
+**Decision**: Convert **both** impure methods currently hanging off `*Config` into
+standalone functions in `internal/fleet`:
+
+- `(c *Config) EffectiveCompileStrict(ctx, repo)` → `func EffectiveCompileStrict(c *Config, ctx context.Context, repo string)` (FR-008/FR-009, already in spec)
+- `(c *Config) ResolveRepoWorkflows(repo)` → `func ResolveRepoWorkflows(c *Config, repo string)` (**NOT in the spec — discovered during code verification**)
+
+The one *pure* method, `(c *Config) EffectiveEngine(repo)`, moves **with** the
+type into `pkg/fleet` and stays a method (FR-004).
+
+**Rationale**: Go forbids declaring methods on a non-local (aliased) type — once
+`Config` aliases `pkg/fleet.Config`, any `func (c *Config) …` in `internal/fleet`
+fails to compile ("cannot define new methods on non-local type"). The spec's Edge
+Case "Methods cannot follow an aliased type" states the rule but FR-009 only
+enumerated the single `EffectiveCompileStrict` call site. Verification against the
+code found a second method, `ResolveRepoWorkflows` in `internal/fleet/load.go:371`,
+with **7 production call sites** the spec did not budget for:
+
+| Call site | Current | After |
+|-----------|---------|-------|
+| `cmd/list.go:51` | `cfg.ResolveRepoWorkflows(r)` | `fleet.ResolveRepoWorkflows(cfg, r)` |
+| `internal/fleet/add.go:135` | `cfg.ResolveRepoWorkflows(opts.Repo)` | `ResolveRepoWorkflows(cfg, opts.Repo)` |
+| `internal/fleet/deploy.go:218` | `cfg.ResolveRepoWorkflows(repo)` | `ResolveRepoWorkflows(cfg, repo)` |
+| `internal/fleet/list_result.go:53` | `cfg.ResolveRepoWorkflows(repo)` | `ResolveRepoWorkflows(cfg, repo)` |
+| `internal/fleet/manifest.go:92` | `cfg.ResolveRepoWorkflows(repo)` | `ResolveRepoWorkflows(cfg, repo)` |
+| `internal/fleet/sync.go:43` | `cfg.ResolveRepoWorkflows(repo)` | `ResolveRepoWorkflows(cfg, repo)` |
+| `internal/fleet/status.go:263` | `cfg.ResolveRepoWorkflows(repo)` | `ResolveRepoWorkflows(cfg, repo)` |
+| `internal/fleet/sync_test.go` | (comment only, line 271 — not a call) | no change needed |
+
+Plus the single `EffectiveCompileStrict` site at `internal/fleet/deploy.go:1060`
+and its test in `internal/fleet/schema_test.go`. `ResolveRepoWorkflows` cannot
+instead move to `pkg/fleet` (the spec defers load/resolve logic — FR-016 — and it
+returns the internal `ResolvedWorkflow` type, which stays internal), so the
+standalone-function-in-`internal/fleet` form is the only option consistent with
+the slice's scope.
+
+**Signature ordering note**: Go style puts `context.Context` first. The relocated
+`EffectiveCompileStrict` should read `func EffectiveCompileStrict(ctx context.Context, c *Config, repo string)`
+(context first, then the former receiver) — confirm during implementation; the
+exact parameter order is the implementer's mechanical choice as long as the single
+call site matches.
+
+**Alternatives considered**: Keep methods via embedding (Decision 1 rejects
+embedding wholesale). Move `ResolveRepoWorkflows` + `ResolvedWorkflow` to
+`pkg/fleet` (rejected: out of scope for this slice per FR-016; pulls load logic
+forward into #141's territory).
+
+---
+
+## Decision 3 — Package layout and what stays behind
+
+**Decision**: New file `pkg/fleet/config.go` holds the seven contract types,
+`SchemaVersion`, the `EffectiveEngine` method, and the package doc comment, with
+**stdlib-only** content (no imports needed). Everything else stays in
+`internal/fleet`:
+
+- **Impure / deploy-path** (FR-008): `EffectiveCompileStrict` (now a func),
+  `ghRepoVisibility` (network — `deploy.go:943`), `truncateReason`,
+  `effectiveCompileStrictReasonMax`, `CompileStrictSource*` constants,
+  `VisibilityPublic`.
+- **Catalog cache** (FR-015): `Templates`, `TemplateSource`, `TemplateWorkflow`,
+  `Evaluation` — these are the upstream-catalog cache, not the wire contract.
+- **Load / merge / resolve** (FR-016): `LoadConfig`, `mergeConfigs`, the HuJson
+  read path, `ResolveRepoWorkflows` (now a func).
+
+**Rationale**: The contract package must stay free of network dependencies and
+internal-only types so an external module can import it cleanly with no transitive
+surprises (FR-013 one-way dependency). Keeping the catalog and load logic internal
+honors the "contract only" scope discipline (spec Assumptions / Scope discipline).
+
+**Verification**: The seven contract types form a closed set — `Config` → `Defaults`,
+`Profile`, `RepoSpec`; `Profile` → `SourcePin`, `ProfileWorkflow`; `RepoSpec` →
+`ExtraWorkflow`. No field references `Templates`, `ResolvedWorkflow`, or any
+internal type, so they relocate without dragging internal symbols across the
+boundary. (Confirmed by reading every field type in `internal/fleet/schema.go`.)
+
+---
+
+## Decision 4 — Golden round-trip baseline is a NEW canonical file, not `fleet.example.json`
+
+**Decision**: Commit a new `pkg/fleet/testdata/config.canonical.json` produced by
+`json.MarshalIndent(cfg, "", "  ")` (the repo's canonical `writeJSON` format —
+2-space indent, trailing newline) of the data unmarshaled from `fleet.example.json`.
+The golden round-trip test reads `fleet.example.json` (the human-facing example,
+single source of input data), unmarshals into `pkg/fleet.Config`, re-marshals, and
+asserts byte-equality against `config.canonical.json`.
+
+**Rationale**: `fleet.example.json` **cannot** be the byte-for-byte target, for two
+independent reasons found by inspecting the file:
+
+1. **Hand alignment**: the example column-aligns workflow entries
+   (`"audit-workflows",          "source": …`). `json.MarshalIndent` produces
+   single-space-after-colon output and never reproduces that padding.
+2. **`omitempty` drops fields**: the example's `acme/widgets` repo carries
+   `"extra": []` and `"exclude": []`, but `RepoSpec.ExtraWorkflows` and
+   `.ExcludeFromProfiles` are tagged `omitempty`. An empty slice (len 0) is omitted
+   on marshal, so a re-marshal *deletes* both keys.
+
+Therefore "re-marshal == `fleet.example.json`" is structurally impossible. The
+spec's intent (SC-002: "byte-identical to the committed baseline"; FR-006:
+"re-marshals to the canonical baseline") is satisfied by committing the canonical
+form as the baseline — `fleet.example.json` supplies the *input data*, the new
+golden supplies the *expected wire bytes*. This also makes the test a genuine
+regression guard for any future tag change.
+
+**Alternatives considered**:
+
+- **Compare re-marshal to `fleet.example.json` directly** — rejected: impossible
+  (above); the test would never pass.
+- **`reflect.DeepEqual` on structs instead of bytes** — rejected: proves semantic
+  round-trip but not *byte*-fidelity, which is the actual correctness guarantee for
+  the remote-pull wire path (Story 2).
+- **No committed golden; assert marshal idempotence** (`m(u(m(u(x)))) == m(u(x))`) —
+  rejected: proves stability, not that the right fields are present/absent. A
+  committed golden pins the exact expected bytes.
+
+---
+
+## Decision 5 — Demonstrating the "external consumer" (SC-001) without a second module
+
+**Decision**: Place the new tests in `package fleet_test` (a black-box external
+test package) inside `pkg/fleet/`. The test imports
+`github.com/rshade/gh-aw-fleet/pkg/fleet`, declares values of all seven types,
+reads `fleet.SchemaVersion` (asserts `== 1`), and calls `cfg.EffectiveEngine(repo)`.
+
+**Rationale**: A `_test` external package can reference **only exported**
+identifiers — the compiler enforces exactly the constraint a real outside consumer
+faces, so a passing black-box test *is* the SC-001 proof that the public surface is
+complete and importable. The spec's Independent Test for Story 1 explicitly allows
+"the package's own external example test" as an acceptable form, so no nested
+throwaway module (separate `go.mod` + `replace`) is required for this slice. An
+`Example` function additionally renders in godoc and doubles as living
+documentation of the import path.
+
+**Alternatives considered**: A separate nested module under `pkg/fleet/internal_e2e/`
+with its own `go.mod` — rejected as heavier than the slice needs; the external test
+package gives the same compile-time guarantee within the existing module and CI run.
+
+---
+
+## Decision 6 — `SchemaVersion` re-export keeps internal churn mechanical
+
+**Decision**: `internal/fleet` keeps the identifier `SchemaVersion` via
+`const SchemaVersion = pkgfleet.SchemaVersion`. No call site that references the
+bare `SchemaVersion` (verified: `add.go:413`, `load.go:164/222`, `fetch.go:40`,
+plus ~20 test sites, and `Templates{Version: SchemaVersion}`) needs to change.
+
+**Rationale**: FR-007 requires existing internal code to compile "with only
+mechanical changes." A re-export const preserves the bare name everywhere it is
+used, so the move touches *zero* `SchemaVersion` call sites. The value (`1`) is
+unchanged (FR-011, SC-006). `cmd.SchemaVersion` (the JSON-envelope version in
+`cmd/output.go`) is a separate, unrelated constant and is not touched — the
+two-`SchemaVersion` invariant in CLAUDE.md still holds.
+
+---
+
+## Resolved unknowns summary
+
+| Unknown (from Technical Context) | Resolution |
+|----------------------------------|------------|
+| Alias vs. embedding | Type aliases (Decision 1) |
+| Which methods move vs. become functions | `EffectiveEngine`→moves; `EffectiveCompileStrict` + `ResolveRepoWorkflows`→funcs (Decision 2) |
+| What stays in `internal/fleet` | impure/catalog/load logic (Decision 3) |
+| Golden baseline definition | new committed canonical file (Decision 4) |
+| How to prove external importability | `package fleet_test` black-box test (Decision 5) |
+| Keeping internal `SchemaVersion` references compiling | re-export const (Decision 6) |
+| New dependencies | none (stdlib only; FR-014/SC-006) |

--- a/specs/015-pkg-fleet-config-export/spec.md
+++ b/specs/015-pkg-fleet-config-export/spec.md
@@ -1,0 +1,288 @@
+# Feature Specification: Export Fleet Config Contract into Public `pkg/fleet`
+
+**Feature Branch**: `015-pkg-fleet-config-export`
+**Created**: 2026-06-20
+**Status**: Draft
+**Input**: GitHub issue #148 — "Export fleet config contract into public pkg/fleet (types + SchemaVersion + JSON) — minimal first slice of #141"
+
+## Overview
+
+The `agentic-fleet.ai` control plane (a separate, private Go module) must serve
+the exact `fleet.json` wire contract that this engine's CLI will later pull
+(`RemoteSource`, issue #142). For that to be correct, the control plane and this
+engine must share **one canonical definition** of the fleet-config shape.
+
+Today that shape lives in `internal/fleet/schema.go`. Go forbids importing an
+`internal/` package across a module boundary, so the control plane cannot reuse
+the type — its only alternative is to re-declare the schema by hand, producing
+**two hand-maintained definitions of one contract that drift silently** and
+break the remote pull. This feature removes that risk by publishing the config
+*contract* (data shapes + version + JSON serialization) in a public
+`pkg/fleet` package, while leaving all load / merge / validate / analysis logic
+behind for later slices (issues #141 and #144).
+
+This is the **minimal first slice of epic #146** via parent #141: export only the
+contract, change no on-disk format, and keep the CLI's observable behavior
+identical.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - External module consumes one canonical contract type (Priority: P1)
+
+A maintainer of the separate control-plane module needs to serve `fleet.json`
+from a Go type that is guaranteed to match what the engine produces and parses.
+They add a dependency on this engine module and import the public package, then
+use `Config` and `SchemaVersion` directly — with no copy-pasted struct
+definitions and no second source of truth to keep in sync.
+
+**Why this priority**: This is the entire reason the issue exists. Without an
+importable canonical type, the control plane must re-declare the schema by hand,
+which is precisely the silent-drift failure mode the feature is meant to
+prevent. Delivering only this story already eliminates the drift risk and
+unblocks #142/#143.
+
+**Independent Test**: From a throwaway Go program *outside* this module's
+`internal/` tree (e.g., a separate test module or the package's own external
+example test), `import "github.com/rshade/gh-aw-fleet/pkg/fleet"`, declare a
+`fleet.Config`, and read `fleet.SchemaVersion`. The program compiles and the
+constant equals `1`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an external Go module that depends on this engine module, **When**
+   it imports `github.com/rshade/gh-aw-fleet/pkg/fleet` and references
+   `fleet.Config`, `fleet.RepoSpec`, `fleet.Profile`, `fleet.SourcePin`,
+   `fleet.ProfileWorkflow`, `fleet.ExtraWorkflow`, `fleet.Defaults`, and
+   `fleet.SchemaVersion`, **Then** the module compiles with no errors.
+2. **Given** the imported package, **When** the consumer reads
+   `fleet.SchemaVersion`, **Then** the value is `1`.
+3. **Given** a populated `fleet.Config` value, **When** the consumer calls
+   `cfg.EffectiveEngine(repo)`, **Then** it returns the per-repo engine override
+   if present, otherwise the fleet-level default — identical to today's
+   behavior.
+
+---
+
+### User Story 2 - Wire bytes stay byte-identical to today's `fleet.json` (Priority: P2)
+
+The control plane will serve, and the engine's future `RemoteSource` will parse,
+the same bytes. A consumer marshals a `fleet.Config` and gets output that is
+byte-for-byte identical to what the engine produces today for the same data, so
+nothing downstream of the wire contract has to change.
+
+**Why this priority**: Byte-fidelity is the correctness guarantee that protects
+the remote-pull path (#142). Moving the structs is only safe if the JSON
+encoding is provably unchanged. This story is the explicit verification layer on
+top of Story 1.
+
+**Independent Test**: A golden round-trip test reads the committed
+`fleet.example.json`, unmarshals it into `pkg/fleet.Config`, re-marshals it, and
+asserts the result matches the committed baseline byte-for-byte (modulo the
+project's canonical formatting). The test lives so it exercises the public
+package's tags only.
+
+**Acceptance Scenarios**:
+
+1. **Given** the committed `fleet.example.json`, **When** it is unmarshaled into
+   `pkg/fleet.Config` and re-marshaled, **Then** the output is byte-identical to
+   the canonical baseline.
+2. **Given** a `Config` with an absent `Defaults` block and an empty `Profiles`
+   map, **When** it is marshaled, **Then** the `omitzero`/`omitempty` behavior of
+   each field is preserved exactly as it is today (no field appears or
+   disappears relative to the current encoding).
+3. **Given** a `Config` whose `LoadedFrom` field is set, **When** it is
+   marshaled, **Then** `LoadedFrom` is excluded from the JSON (its `json:"-"`
+   tag is preserved).
+
+---
+
+### User Story 3 - The CLI and internal callers behave identically (Priority: P3)
+
+An operator who already uses `gh-aw-fleet` (`list`, `deploy`, `sync`, `upgrade`,
+`status`, `consumption`, …) sees no change in any command's output, exit
+behavior, or on-disk file format after the refactor. Internal code that
+previously referenced the config types and methods continues to work with
+minimal, mechanical edits.
+
+**Why this priority**: This is the safety constraint on the refactor. Publishing
+the contract is only acceptable if it is regression-free; a broken CLI or a
+changed on-disk format would be a net negative regardless of the new export.
+
+**Independent Test**: Run the full existing test suite and a representative set
+of read-only CLI invocations (e.g., `go run . list`) before and after the
+change; output and exit codes match, and `make ci` is green.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing internal codebase and tests, **When** the structs move
+   to `pkg/fleet` and `internal/fleet` re-exposes them via type aliases, **Then**
+   `internal/fleet` compiles and the full test suite passes.
+2. **Given** the deploy path's previous `cfg.EffectiveCompileStrict(ctx, repo)`
+   call, **When** the impure logic is relocated to a standalone function in
+   `internal/fleet`, **Then** the single call site is updated and the
+   compile-strict resolution (explicit / auto-public / auto-private /
+   auto-fallback) behaves exactly as before.
+3. **Given** the change set, **When** the loader reads any existing
+   `fleet.json` / `fleet.local.json`, **Then** no on-disk format change occurs
+   and neither `fleet.SchemaVersion` nor `cmd.SchemaVersion` is bumped.
+
+---
+
+### Edge Cases
+
+- **Same package name, two import paths**: `pkg/fleet` and `internal/fleet` both
+  declare `package fleet`. This is legal Go (distinct import paths); the internal
+  package's aliases reference the public one. The build must remain unambiguous.
+- **Methods cannot follow an aliased type**: any method that previously hung off
+  the internal `Config`/`RepoSpec` must either move *with* the type into
+  `pkg/fleet` (if pure) or be re-expressed as a standalone function in
+  `internal/fleet` (if impure). The one pure method, `EffectiveEngine`, moves
+  *with* the type; the two impure methods, `EffectiveCompileStrict` **and**
+  `ResolveRepoWorkflows`, become standalone functions in `internal/fleet`. No
+  method may be silently dropped in the move.
+- **Network dependency must not leak into the contract package**:
+  `EffectiveCompileStrict` calls `ghRepoVisibility` (network) — it and its
+  helpers (`truncateReason`, the `CompileStrictSource*` constants,
+  `VisibilityPublic`) must stay in `internal/fleet`, not the contract package.
+- **`omitzero` vs `omitempty` fidelity**: `Defaults` uses `omitzero`, `Profiles`
+  uses `omitempty`, and `Repos` has *no* omit tag (so it encodes as `null` when
+  nil). All three behaviors must survive the move byte-for-byte.
+- **Excluded-from-JSON field**: `Config.LoadedFrom` (`json:"-"`, set only by the
+  loader) must continue to be omitted from serialized output.
+- **Catalog types stay put**: `Templates`, `TemplateSource`, `TemplateWorkflow`,
+  and `Evaluation` are the upstream-catalog cache, not the fleet config
+  contract, and must remain in `internal/fleet`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A public Go package MUST exist at import path
+  `github.com/rshade/gh-aw-fleet/pkg/fleet` and be importable from a Go module
+  outside this repository.
+- **FR-002**: The public package MUST export the config-contract types `Config`,
+  `Defaults`, `Profile`, `SourcePin`, `ProfileWorkflow`, `RepoSpec`, and
+  `ExtraWorkflow` with the same field names, types, and JSON struct tags they
+  have today.
+- **FR-003**: The public package MUST export the `SchemaVersion` constant with
+  the current value `1`.
+- **FR-004**: The public package MUST export the pure helper `EffectiveEngine`
+  (as a method on `Config`) with behavior identical to today's.
+- **FR-005**: JSON marshaling and unmarshaling of the public types MUST be
+  byte-identical to the current `internal/fleet` encoding for equivalent data;
+  every struct tag (including `omitzero`, `omitempty`, and `json:"-"`) MUST be
+  preserved verbatim.
+- **FR-006**: A golden round-trip test MUST verify that `fleet.example.json`
+  unmarshals into `pkg/fleet.Config` and re-marshals to the canonical baseline
+  byte-for-byte.
+- **FR-007**: The `internal/fleet` package MUST continue to expose the same type
+  names (via type aliases to the `pkg/fleet` types) so existing internal code
+  and tests compile with only mechanical changes.
+- **FR-008**: Impure, deploy-path logic MUST remain in `internal/fleet`:
+  `EffectiveCompileStrict` (and its dependencies `ghRepoVisibility`,
+  `truncateReason`, the `CompileStrictSource*` constants, and `VisibilityPublic`)
+  MUST NOT move into the contract package; where it was a method on `Config`, it
+  MUST be relocated as a standalone function taking `*fleet.Config`.
+- **FR-009**: All call sites of any relocated method MUST be updated to the new
+  function form. Two methods are relocated to standalone functions:
+  `EffectiveCompileStrict` (one call site — the deploy path) and
+  `ResolveRepoWorkflows` (seven production call sites — `cmd/list.go`,
+  `internal/fleet/add.go`, `deploy.go`, `list_result.go`, `manifest.go`,
+  `sync.go`, and `status.go`). The `ResolveRepoWorkflows` conversion was
+  discovered during planning (research.md Decision 2) and was not enumerated in
+  the original draft of this requirement.
+- **FR-010**: Every newly-exported identifier in `pkg/fleet` (package, types,
+  exported fields, constant, method) MUST carry a godoc comment per the repo's
+  self-documentation convention.
+- **FR-011**: The on-disk fleet config format MUST NOT change; neither
+  `fleet.SchemaVersion` nor `cmd.SchemaVersion` may be bumped.
+- **FR-012**: The CLI MUST behave identically before and after the change — no
+  observable change to any command's output, exit codes, or written files.
+- **FR-013**: The engine module MUST NOT take on any dependency on the control
+  plane or other external module (the one-way dependency rule: engine never
+  depends on the control plane).
+- **FR-014**: No new third-party dependency may be introduced (Constitution
+  Principle I); the move is a pure relocation within the existing module.
+- **FR-015**: The catalog types `Templates`, `TemplateSource`,
+  `TemplateWorkflow`, and `Evaluation` MUST remain in `internal/fleet` (they are
+  out of scope for this slice).
+- **FR-016**: The load/merge/validate logic (`LoadConfig`, `mergeConfigs`, the
+  HuJson read path, `ResolveRepoWorkflows`) MUST remain in `internal/fleet`
+  (deferred to #141).
+
+### Key Entities *(the config contract being exported)*
+
+- **Config**: The declarative desired state for the fleet — `Version`,
+  `Defaults`, `Profiles`, `Repos`, and the loader-only `LoadedFrom`. The root of
+  the wire contract.
+- **Defaults**: Fleet-wide defaults applied to every repo unless overridden
+  (currently `Engine`).
+- **Profile**: A named, atomically-advancing bundle of workflows with an
+  advisory cost `Tier`, a `Sources` pin map, and a `Workflows` list.
+- **SourcePin**: The pinned `Ref` (tag/branch/sha) for a source repo within a
+  profile.
+- **ProfileWorkflow**: A workflow entry naming its `Source` repo and optional
+  `Path`.
+- **RepoSpec**: Per-repo desired state — `Profiles`, advisory `CostCenter`,
+  optional `Engine`, tri-state `CompileStrict`, `ExtraWorkflows`,
+  `ExcludeFromProfiles`, and `Overrides`.
+- **ExtraWorkflow**: A per-repo workflow not sourced from any profile.
+- **SchemaVersion**: The on-disk fleet-config format version (`1`), distinct
+  from the CLI output-envelope version.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A consumer outside this module's `internal/` tree can import
+  `pkg/fleet`, reference all seven contract types plus `SchemaVersion`, and
+  compile with zero errors (demonstrated by an external/black-box test).
+- **SC-002**: The golden round-trip test passes — re-marshaled
+  `fleet.example.json` is byte-identical to the committed baseline.
+- **SC-003**: `make ci` (fmt-check, vet, lint, full test suite) is green with no
+  new failures and no new lint suppressions.
+- **SC-004**: Across the existing test suite and a representative set of
+  read-only CLI commands, observable output and exit codes are unchanged
+  relative to `main` (no behavior-test expectations are modified — only
+  references to relocated symbols).
+- **SC-005**: 100% of newly-exported identifiers in `pkg/fleet` carry godoc
+  comments (revive/staticcheck report zero exported-symbol violations).
+- **SC-006**: No `SchemaVersion` constant value changes and `go.mod` gains no new
+  `require` entries.
+
+## Assumptions
+
+- **Package naming**: The public package is `package fleet` at `pkg/fleet`,
+  matching the existing internal package name; the two are distinguished by
+  import path. The internal package's type aliases reference the public types so
+  there is exactly one underlying definition.
+- **Preferred refactor approach**: Type aliases in `internal/fleet` plus
+  standalone functions for relocated impure logic (the issue's recommended
+  approach), rather than anonymous embedding (the issue's stated fallback). The
+  alias path keeps internal and external sharing one type.
+- **Constant placement for impure logic**: The `CompileStrictSource*` constants
+  and `VisibilityPublic` stay in `internal/fleet` alongside the relocated
+  `EffectiveCompileStrict`, since they are deploy-path concerns rather than part
+  of the serialized contract. (Open to revisiting during planning if a cleaner
+  split emerges, but not required by this slice.)
+- **Golden baseline**: `fleet.example.json` is the byte-fidelity baseline for the
+  round-trip test.
+- **Toolchain**: The local development gate runs Go 1.26.4 / golangci-lint
+  v2.12.2; the module's declared compatibility (`go 1.25.8`) is unaffected. The
+  `omitzero` tag in use requires Go 1.24+, which both satisfy — no encoding
+  behavior change from the toolchain.
+- **Scope discipline**: This slice exports the *contract only*. Load/merge,
+  remote `ConfigSource`/`RemoteSource` (#142), the wire-contract spec/doc (#143),
+  consumption/FinOps and security analysis exports (#144), and the catalog types
+  are explicitly deferred.
+
+## Dependencies & References
+
+- **Parent**: #141 (full `pkg/fleet` model + load/merge). **Epic**: #146.
+- **Downstream consumers of this type + `SchemaVersion`**: #142 (`RemoteSource`),
+  #143 (wire-contract spec/doc).
+- **Consumer rationale** ("engine owns the `fleet.json` body, Goa owns the
+  endpoint"): `agentic-fleet/control-plane/docs/architecture.md` (external,
+  private repo).
+- **Invariant**: One-way dependency — the engine must never depend on the
+  control plane.

--- a/specs/015-pkg-fleet-config-export/tasks.md
+++ b/specs/015-pkg-fleet-config-export/tasks.md
@@ -1,0 +1,208 @@
+---
+
+description: "Task list for: Export Fleet Config Contract into Public pkg/fleet"
+---
+
+# Tasks: Export Fleet Config Contract into Public `pkg/fleet`
+
+**Input**: Design documents from `/specs/015-pkg-fleet-config-export/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/pkg-fleet.md, quickstart.md
+
+**Tests**: INCLUDED — the spec explicitly requires them (FR-006 golden round-trip;
+SC-001 external black-box compile test). These are the slice's primary
+verification surface, not optional extras.
+
+**Organization**: Grouped by user story (US1 P1 → US2 P2 → US3 P3). This is a
+refactor, so the stories are sequentially dependent (US2 and US3 build on the
+public types delivered in US1), but each leaves `go build ./...` green and is
+independently testable. Strategy: **build the new public package first (US1),
+prove byte-fidelity (US2), then cut the internal package over to it (US3)** — the
+internal duplicate exists only transiently inside this one PR and is deleted in
+US3 (T007), at which point "one canonical definition" is fully realized.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Polish carry no story label)
+- Exact file paths included in every task
+
+## Path Conventions
+
+Single Go module rooted at repository root. New public surface under `pkg/fleet/`;
+existing code under `internal/fleet/` and `cmd/`. Paths below are repo-relative.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the new public package path.
+
+- [X] T001 Create the `pkg/fleet/` package directory (and `pkg/fleet/testdata/`) and add `pkg/fleet/config.go` containing only the `package fleet` clause and the package-level godoc comment from `specs/015-pkg-fleet-config-export/contracts/pkg-fleet.md` — establishes import path `github.com/rshade/gh-aw-fleet/pkg/fleet` (FR-001).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Cross-story prerequisites.
+
+**No foundational tasks.** This refactor has no blocking infrastructure beyond
+Setup; the shared dependency for US2 and US3 is the public type set delivered by
+US1 (Phase 3). US2/US3 therefore begin once US1's types compile.
+
+**Checkpoint**: Setup done — User Story 1 can begin.
+
+---
+
+## Phase 3: User Story 1 - External module consumes one canonical contract type (Priority: P1) 🎯 MVP
+
+**Goal**: A public `pkg/fleet` package exports the seven config-contract types,
+the `SchemaVersion` constant (`1`), and the pure `EffectiveEngine` method — all
+importable and usable from outside this module's `internal/` tree.
+
+**Independent Test**: From `package fleet_test` (black-box, exported-only access),
+import `github.com/rshade/gh-aw-fleet/pkg/fleet`, declare all seven types, read
+`fleet.SchemaVersion`, and call `EffectiveEngine`; it compiles and `SchemaVersion == 1`.
+
+### Tests for User Story 1 ⚠️ (write first; it fails until T002–T003 land)
+
+- [X] T002 [US1] Write the black-box compile/use test `TestExternalConsumer` (plus an `Example` that renders in godoc) in `pkg/fleet/config_test.go` (`package fleet_test`): import the public package; declare values of `fleet.Config`, `fleet.Defaults`, `fleet.Profile`, `fleet.SourcePin`, `fleet.ProfileWorkflow`, `fleet.RepoSpec`, `fleet.ExtraWorkflow`; assert `fleet.SchemaVersion == 1`; assert `(&fleet.Config{...}).EffectiveEngine(repo)` returns the per-repo override then the fleet default (SC-001; US1 acceptance 1–3). The function names match the quickstart command `go test ./pkg/fleet/ -run 'TestExternalConsumer|Example'`.
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] In `pkg/fleet/config.go` define the seven contract types — `Config`, `Defaults`, `Profile`, `SourcePin`, `ProfileWorkflow`, `RepoSpec`, `ExtraWorkflow` — copying field names, types, and JSON struct tags **verbatim** from `internal/fleet/schema.go` (preserve `omitzero`, `omitempty`, and `json:"-"` exactly), plus `const SchemaVersion = 1`; add a godoc comment to every exported identifier and field (FR-002, FR-003, FR-005, FR-010; data-model.md fidelity tables).
+- [X] T004 [US1] In `pkg/fleet/config.go` add the pure method `func (c *Config) EffectiveEngine(repo string) string` (per-repo `Engine` override else `Defaults.Engine`), copied from the internal method, with godoc (FR-004). Depends on T003 (same file).
+- [X] T005 [US1] Run `go test ./pkg/fleet/` and `go vet ./pkg/fleet/`; confirm T002 now passes and the package is stdlib-only (no internal imports, no new `go.mod` require) (FR-013, FR-014, SC-001). Depends on T002–T004.
+
+**Checkpoint**: `pkg/fleet` is importable and exercised by an external test; `internal/fleet` is untouched and still builds. MVP for the control plane (#142) is unblocked.
+
+---
+
+## Phase 4: User Story 2 - Wire bytes stay byte-identical to today's `fleet.json` (Priority: P2) 🔒
+
+**Goal**: Prove that marshaling a `pkg/fleet.Config` reproduces the canonical wire
+bytes for `fleet.example.json` data, so the remote-pull path is encoding-safe.
+
+**Independent Test**: The golden round-trip test reads `fleet.example.json`,
+unmarshals into `pkg/fleet.Config`, re-marshals, and matches the committed
+canonical baseline byte-for-byte.
+
+### Tests for User Story 2 ⚠️
+
+- [X] T006 [US2] Write the golden round-trip test in `pkg/fleet/roundtrip_test.go` (`package fleet_test`) with a `-update` flag: read `../../fleet.example.json`, `json.Unmarshal` into `fleet.Config`, `json.MarshalIndent(cfg, "", "  ")` + trailing newline, and assert **byte-equality** against `pkg/fleet/testdata/config.canonical.json`; additionally assert `LoadedFrom` is absent from the output and that the `omitzero` (Defaults) / `omitempty` (Profiles, `extra`, `exclude`) / no-omit (`repos`→`null` when nil) cases each behave as documented (FR-005, FR-006, SC-002; US2 acceptance 1–3; contracts C-4/C-5/C-6). Depends on T003.
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Materialize the baseline: run `go test ./pkg/fleet/ -run TestGoldenRoundTrip -update` to generate `pkg/fleet/testdata/config.canonical.json` from `fleet.example.json`, then re-run **without** `-update` to confirm it passes; commit the golden file. Note the baseline is NOT `fleet.example.json` verbatim — the example's hand alignment and `omitempty` empty `extra`/`exclude` arrays do not survive re-marshal (research.md Decision 4). Depends on T006.
+
+**Checkpoint**: Byte-fidelity is locked by a committed golden; US1 + US2 both pass with `internal/fleet` still unchanged.
+
+---
+
+## Phase 5: User Story 3 - The CLI and internal callers behave identically (Priority: P3)
+
+**Goal**: Cut `internal/fleet` over to the public types via type aliases, relocate
+the two impure `Config` methods to standalone functions, update every call site,
+and prove zero observable change — completing the "one canonical definition" goal
+by deleting the internal duplicate.
+
+**Independent Test**: `make ci` is green and `go run . list` (plus the full suite)
+produces identical output and exit codes to `main`; only relocated-symbol
+references changed.
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] In `internal/fleet/schema.go` delete the seven contract type definitions and replace them with type aliases to the public package — `type Config = pkgfleet.Config`, `Defaults`, `Profile`, `SourcePin`, `ProfileWorkflow`, `RepoSpec`, `ExtraWorkflow` — add `const SchemaVersion = pkgfleet.SchemaVersion` (re-export), add the `pkgfleet "github.com/rshade/gh-aw-fleet/pkg/fleet"` import, and **keep** `Templates`/`TemplateSource`/`TemplateWorkflow`/`Evaluation` defined here (FR-007, FR-011, FR-015; research.md Decisions 1 & 6). Depends on T003.
+- [X] T009 [P] [US3] In `internal/fleet/schema.go` convert `EffectiveCompileStrict` from a method on `*Config` to a standalone function (e.g. `func EffectiveCompileStrict(ctx context.Context, c *Config, repo string) (bool, string, string)`); keep `ghRepoVisibility`, `truncateReason`, `effectiveCompileStrictReasonMax`, the `CompileStrictSource*` constants, and `VisibilityPublic` in `internal/fleet` (FR-008). Depends on T008.
+- [X] T010 [P] [US3] In `internal/fleet/load.go` convert `ResolveRepoWorkflows` from a method on `*Config` to a standalone function `func ResolveRepoWorkflows(c *Config, repo string) ([]ResolvedWorkflow, error)`; `ResolvedWorkflow` stays in `internal/fleet` (research.md Decision 2; FR-016). Depends on T008.
+- [X] T011 [US3] Update the single `EffectiveCompileStrict` call site at `internal/fleet/deploy.go:1060` from `cfg.EffectiveCompileStrict(ctx, repo)` to the function form (FR-009). Depends on T009.
+- [X] T012 [US3] Update all seven `ResolveRepoWorkflows` call sites from `cfg.ResolveRepoWorkflows(repo)` to `ResolveRepoWorkflows(cfg, repo)` (or `fleet.ResolveRepoWorkflows(cfg, r)` from `cmd`): `internal/fleet/add.go:135`, `internal/fleet/deploy.go:218`, `internal/fleet/list_result.go:53`, `internal/fleet/manifest.go:92`, `internal/fleet/sync.go:43`, `internal/fleet/status.go:263`, and `cmd/list.go:51` (FR-009; research.md Decision 2). Sequenced after T011 to avoid a same-file edit conflict in `deploy.go`. Depends on T010.
+- [X] T013 [P] [US3] Update the one internal test that calls a relocated symbol — `internal/fleet/schema_test.go` (`EffectiveCompileStrict` function form, two call sites at lines 79 and 214) — mechanical reference changes only; do **not** alter any behavioral expectation (SC-004). No test invokes `ResolveRepoWorkflows` as a method (`sync_test.go` only mentions it in a comment at line 271), so that conversion needs no test edit. Depends on T009, T010.
+- [X] T014 [US3] Run `make ci` (fmt-check, vet, lint, full suite) and capture `go run . list` output/exit; confirm green with no new lint suppressions, output/exit identical to `main`, `go.mod` gains no `require` entry, and both `SchemaVersion` values still equal `1` (SC-003, SC-004, SC-006; FR-011, FR-012). Depends on T011, T012, T013.
+
+**Checkpoint**: Internal duplicate deleted — exactly one definition of the contract; CLI and on-disk format unchanged; full gate green.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T015 [P] Add a short note to `CLAUDE.md` (Architecture section) recording the new architectural invariant: `pkg/fleet` is the module's first public surface and the single canonical home of the `fleet.json` wire contract; `internal/fleet` aliases it (Constitution §Development Workflow — new architectural invariant). The SPECKIT plan pointer was already updated during `/speckit-plan`.
+- [x] T016 [P] Reconcile the spec with the implementation: update `specs/015-pkg-fleet-config-export/spec.md` FR-009 (and the "Methods cannot follow an aliased type" Edge Case) to enumerate `ResolveRepoWorkflows` alongside `EffectiveCompileStrict` as a method that must be relocated, since the original draft under-counted the conversions (research.md Decision 2). ✅ Completed during `/speckit-analyze` remediation — spec.md FR-009 and the Edge Case now enumerate both impure methods.
+- [X] T017 Run the `quickstart.md` acceptance checklist end-to-end (SC-001…SC-006) and confirm every box passes. Depends on T014.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001)**: no dependencies — start immediately.
+- **Foundational**: none.
+- **US1 (T002–T005)**: depends on Setup. Delivers the public package (MVP).
+- **US2 (T006–T007)**: depends on US1's types (T003).
+- **US3 (T008–T014)**: depends on US1's types (T003); T008 deletes the internal
+  duplicate and aliases to the public package.
+- **Polish (T015–T017)**: T015/T016 anytime after their targets exist; T017 after T014.
+
+### Story Dependencies (refactor — sequential, unlike a typical greenfield feature)
+
+- US1 (P1) → independent of US2/US3; build the new package.
+- US2 (P2) → needs US1 types; pure additive test + golden.
+- US3 (P3) → needs US1 types; rewires `internal/fleet` to consume them.
+
+### Within US3
+
+- T008 (aliases) before T009/T010 (method→function conversions).
+- T009 before T011; T010 before T012; T011 before T012 (shared `deploy.go`).
+- T009/T010 before T013 (tests reference the new function forms).
+- All before T014 (verification).
+
+### Parallel Opportunities
+
+- T009 ‖ T010 (different files: `schema.go` vs `load.go`, both after T008).
+- T013 ‖ T011/T012 (test files vs non-test files; after T009/T010).
+- T015 ‖ T016 (docs vs spec, independent files).
+- US1 and US2 are mostly serial (shared `config.go` / dependent on its types); the
+  real parallelism lives inside US3's conversion step.
+
+---
+
+## Parallel Example: User Story 3 conversions
+
+```bash
+# After T008 (aliases in place), the two method→function conversions touch
+# different files and can proceed in parallel:
+Task: "T009 convert EffectiveCompileStrict to a func in internal/fleet/schema.go"
+Task: "T010 convert ResolveRepoWorkflows to a func in internal/fleet/load.go"
+
+# After both, test updates run alongside the production call-site updates:
+Task: "T013 update internal/fleet/schema_test.go + sync_test.go references"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. T001 Setup → 2. T002–T005 US1. **STOP & VALIDATE**: external `package fleet_test`
+   compiles and uses all seven types; `SchemaVersion == 1`. The control plane can
+   now import `pkg/fleet` — the entire reason the issue exists is satisfied.
+
+### Incremental Delivery
+
+1. Setup + US1 → public package importable (MVP, unblocks #142).
+2. US2 → byte-fidelity locked by golden round-trip.
+3. US3 → internal cut over to aliases, duplicate deleted, full gate green, CLI
+   unchanged. Ship.
+
+### Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- Tests are included because the spec mandates them (FR-006, SC-001) — not the
+  usual optional case.
+- Keep `go build ./...` green at each checkpoint; the internal duplicate is
+  transient (US1→US3) and removed by T008.
+- Do not bump `fleet.SchemaVersion` or `cmd.SchemaVersion`; do not add a `go.mod`
+  require entry; do not modify any behavioral test expectation.
+- Golden baseline is the canonical re-marshal, not `fleet.example.json` verbatim
+  (research.md Decision 4).


### PR DESCRIPTION
## Summary

- Publishes the `fleet.json` wire contract — config-data shapes, the on-disk `SchemaVersion`, and their JSON serialization — at the public import path `github.com/rshade/gh-aw-fleet/pkg/fleet`. The separate `agentic-fleet.ai` control-plane module can now depend on one canonical type instead of re-declaring a second definition that drifts silently and breaks the future remote pull (#142).
- `internal/fleet` re-exposes the seven contract types as Go type aliases (`Config`, `Defaults`, `Profile`, `SourcePin`, `ProfileWorkflow`, `RepoSpec`, `ExtraWorkflow`), so internal code and tests compile with only mechanical edits and there is exactly one underlying struct definition.
- A purity split keeps the network out of the contract package: the pure `EffectiveEngine` moves with `Config` into `pkg/fleet`, while the impure `EffectiveCompileStrict` (calls `ghRepoVisibility`) and `ResolveRepoWorkflows` become standalone functions in `internal/fleet`.
- Minimal first slice of rshade/gh-aw-fleet#141 / epic rshade/gh-aw-fleet#146: contract export only. No on-disk format change, no `fleet.SchemaVersion` / `cmd.SchemaVersion` bump, no new third-party dependency, and identical CLI behavior.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./pkg/fleet/...` passes — black-box (`package fleet_test`) external-consumer test plus golden round-trip test
- [x] `go test ./internal/fleet/` passes — relocated call sites and `EffectiveCompileStrict` tests updated
- [x] Golden round-trip: `fleet.example.json` unmarshals into `pkg/fleet.Config` and re-marshals byte-identical to `pkg/fleet/testdata/config.canonical.json`
- [ ] `make ci` (fmt-check, vet, lint, full suite) — run before merge

## Changes

### New files

- `pkg/fleet/config.go` - public config contract: the seven types, `SchemaVersion`, and the pure `EffectiveEngine` method
- `pkg/fleet/config_test.go` - external black-box test proving `pkg/fleet` is importable and `SchemaVersion == 1`
- `pkg/fleet/roundtrip_test.go` - golden byte-fidelity round-trip test (`-update` regenerates the baseline)
- `pkg/fleet/testdata/config.canonical.json` - canonical JSON baseline

### Modified files

- `internal/fleet/schema.go` - replaces the seven struct definitions with aliases to `pkg/fleet`; `SchemaVersion` aliases the public constant; `EffectiveCompileStrict` becomes a standalone function
- `internal/fleet/load.go` - `ResolveRepoWorkflows` converted from a `*Config` method to a standalone function
- `cmd/list.go`, `internal/fleet/add.go`, `deploy.go`, `list_result.go`, `manifest.go`, `status.go`, `sync.go` - updated the eight relocated-function call sites
- `internal/fleet/schema_test.go` - updated `EffectiveCompileStrict` call sites to the new function form
- `CLAUDE.md` - documents the new `pkg/fleet` public surface

### Housekeeping

- `.gitignore` - adds `build/`, `vendor/`, `*.log`, `.env*`, and editor/OS cruft (`.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`)

Closes rshade/gh-aw-fleet#148