### PR TITLE
feat(consumption): read-only over-budget highlighting (--budget)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,5 +31,5 @@ Per-slice dependency and storage deltas:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/016-ax-go-foundation/plan.md](./specs/016-ax-go-foundation/plan.md)
+[specs/017-consumption-budget/plan.md](./specs/017-consumption-budget/plan.md)
 <!-- SPECKIT END -->

--- a/cmd/consumption.go
+++ b/cmd/consumption.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"text/tabwriter"
 	"time"
 
@@ -46,9 +47,9 @@ Pass one or more repos (owner/name) to scope the rollup to just those repos;
 with no args it covers the whole fleet. Combine with --by workflow to drill
 into a single repo's per-workflow spend.
 
-Discovery: queries each repo's audits-category discussions and filters by
-the api-consumption-report-daily tracker marker. Data: fetches the
-referenced workflow run's aw_info.json and run_summary.json artifacts.
+Discovery and data depend on --source (see below). The default --source logs
+enumerates each repo's agentic workflows via the Actions API and sums AI
+credits from gh aw logs --json per workflow.
 
 Temporal modes (mutually exclusive):
   --latest                        most-recent valid report per repo (default)
@@ -59,9 +60,13 @@ Grouping axis:
   --by repo|profile|cost-center|workflow   (default: repo)
 
 Data source:
-  --source logs        AI credits from gh aw logs --json per workflow (default;
-                       needs no deployed api-consumption-report workflow)
-  --source artifacts   legacy: api-consumption-report discussions + run artifacts
+  --source logs        (default) enumerate agentic workflows via the Actions
+                       API; AI credits from gh aw logs --json per workflow.
+                       Needs no deployed api-consumption-report workflow.
+  --source artifacts   legacy: discover via audits-category discussions
+                       filtered by the api-consumption-report-daily tracker
+                       marker; data from the run's aw_info.json and
+                       run_summary.json artifacts.
 
 Budget highlighting:
   --budget AIC         mark rows whose AIC strictly exceeds this ceiling`,
@@ -143,6 +148,12 @@ func buildBudget(cmd *cobra.Command, flags *consumptionFlags) (*float64, error) 
 	if !cmd.Flags().Changed("budget") {
 		//nolint:nilnil // a nil ceiling is the valid "no --budget supplied" signal
 		return nil, nil
+	}
+	if math.IsNaN(flags.budget) || math.IsInf(flags.budget, 0) {
+		return nil, fmt.Errorf(
+			"--budget value %g invalid: expected a finite AIC ceiling",
+			flags.budget,
+		)
 	}
 	if flags.budget < 0 {
 		return nil, fmt.Errorf(

--- a/cmd/consumption.go
+++ b/cmd/consumption.go
@@ -20,7 +20,16 @@ type consumptionFlags struct {
 	since    string
 	by       string
 	source   string
+	budget   float64
 }
+
+// aggregateConsumption is a package-level seam (matching the ghLogsAPI /
+// ghWorkflowsAPI convention in internal/fleet) so cmd tests can stub the
+// rollup without live gh calls. Tests save/restore it; cmd tests do not run
+// in parallel, so a package var is safe.
+//
+//nolint:gochecknoglobals // test-injection seam for fleet.AggregateConsumption
+var aggregateConsumption = fleet.AggregateConsumption
 
 // newConsumptionCmd builds the cobra command for `gh-aw-fleet consumption`.
 // It aggregates per-repo api-consumption-report output across the fleet via
@@ -52,7 +61,10 @@ Grouping axis:
 Data source:
   --source logs        AI credits from gh aw logs --json per workflow (default;
                        needs no deployed api-consumption-report workflow)
-  --source artifacts   legacy: api-consumption-report discussions + run artifacts`,
+  --source artifacts   legacy: api-consumption-report discussions + run artifacts
+
+Budget highlighting:
+  --budget AIC         mark rows whose AIC strictly exceeds this ceiling`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConsumption(cmd, flagDir, &flags, args)
 		},
@@ -62,6 +74,7 @@ Data source:
 	cmd.Flags().StringVar(&flags.since, "since", "", "Since date in YYYY-MM-DD")
 	cmd.Flags().StringVar(&flags.by, "by", "repo", "Group-by axis: repo|profile|cost-center|workflow")
 	cmd.Flags().StringVar(&flags.source, "source", "logs", "Data source: logs|artifacts")
+	cmd.Flags().Float64Var(&flags.budget, "budget", 0, "Highlight rows whose AIC strictly exceeds this ceiling")
 	cmd.MarkFlagsMutuallyExclusive("latest", "trailing", "since")
 	return cmd
 }
@@ -74,52 +87,40 @@ func runConsumption(cmd *cobra.Command, flagDir *string, flags *consumptionFlags
 
 	by, err := fleet.ParseGroupBy(flags.by)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
 	}
 
 	source, err := fleet.ParseSource(flags.source)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
 	}
 
 	mode, err := buildFetchMode(flags)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
+	}
+
+	budget, err := buildBudget(cmd, flags)
+	if err != nil {
+		return consumptionFailure(cmd, jsonMode, err)
 	}
 
 	cfg, err := fleet.LoadConfig(*flagDir)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "  (loaded %s)\n", cfg.LoadedFrom)
 
 	cfg, err = fleet.ScopeToRepos(cfg, repos)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
 	}
 
-	res, warnings, err := fleet.AggregateConsumption(cmd.Context(), cfg, mode, by, source)
+	res, warnings, err := aggregateConsumption(cmd.Context(), cfg, mode, by, source)
 	if err != nil {
-		if jsonMode {
-			return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
-		}
-		return err
+		return consumptionFailure(cmd, jsonMode, err)
 	}
+	fleet.ApplyBudget(res, budget)
 
 	if jsonMode {
 		return writeEnvelope(cmd, commandConsumption, "", false, res, warnings, nil)
@@ -127,6 +128,30 @@ func runConsumption(cmd *cobra.Command, flagDir *string, flags *consumptionFlags
 
 	emitConsumptionWarnings(warnings)
 	return renderConsumptionText(cmd, by, res)
+}
+
+func consumptionFailure(cmd *cobra.Command, jsonMode bool, err error) error {
+	if jsonMode {
+		return preResultFailureEnvelope(cmd, commandConsumption, "", false, err)
+	}
+	return err
+}
+
+// buildBudget translates the optional --budget flag into a pointer so zero can
+// remain a valid ceiling while an absent flag stays nil.
+func buildBudget(cmd *cobra.Command, flags *consumptionFlags) (*float64, error) {
+	if !cmd.Flags().Changed("budget") {
+		//nolint:nilnil // a nil ceiling is the valid "no --budget supplied" signal
+		return nil, nil
+	}
+	if flags.budget < 0 {
+		return nil, fmt.Errorf(
+			"--budget value %g invalid: expected a non-negative AIC ceiling",
+			flags.budget,
+		)
+	}
+	v := flags.budget
+	return &v, nil
 }
 
 // buildFetchMode translates the mutually-exclusive temporal flags into a
@@ -162,11 +187,26 @@ func emitConsumptionWarnings(warnings []fleet.Diagnostic) {
 // renderConsumptionText renders the primary grouped table and the
 // top-burners footer to cmd.OutOrStdout().
 func renderConsumptionText(cmd *cobra.Command, by fleet.GroupByKind, res *fleet.ConsumptionResult) error {
+	budgeted := res.Budget != nil
+	// overColumn appends the trailing OVER column only when a budget is set,
+	// so no-budget output stays byte-identical (no trailing tab).
+	overColumn := func(over *bool) string {
+		if !budgeted {
+			return ""
+		}
+		return "\t" + overBudgetMarker(over)
+	}
+	overHeader := ""
+	if budgeted {
+		overHeader = "\tOVER"
+	}
+
 	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, tabPadding, ' ', 0)
-	fmt.Fprintf(tw, "%s\tAPI_CALLS\tSAFE_WRITES\tAIC\tCOST\tREPORTS\n", byColumnHeader(by))
+	fmt.Fprintf(tw, "%s\tAPI_CALLS\tSAFE_WRITES\tAIC\tCOST\tREPORTS%s\n", byColumnHeader(by), overHeader)
 	for _, g := range res.Groups {
-		fmt.Fprintf(tw, "%s\t%d\t%d\t%s\t%s\t%d\n",
-			g.Key, g.GitHubAPICalls, g.SafeOutputCalls, formatAIC(g.AIC), formatCost(g.Cost), g.ReportCount)
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%s\t%s\t%d%s\n",
+			g.Key, g.GitHubAPICalls, g.SafeOutputCalls, formatAIC(g.AIC),
+			formatCost(g.Cost), g.ReportCount, overColumn(g.OverBudget))
 	}
 	if err := tw.Flush(); err != nil {
 		return err
@@ -177,12 +217,20 @@ func renderConsumptionText(cmd *cobra.Command, by fleet.GroupByKind, res *fleet.
 	fmt.Fprintln(cmd.OutOrStdout())
 	fmt.Fprintln(cmd.OutOrStdout(), "TOP 10 BURNERS:")
 	bt := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, tabPadding, ' ', 0)
-	fmt.Fprintln(bt, "WORKFLOW\tRUNS\tAPI_CALLS\tAVG_DURATION\tAIC\tCOST")
+	fmt.Fprintf(bt, "WORKFLOW\tRUNS\tAPI_CALLS\tAVG_DURATION\tAIC\tCOST%s\n", overHeader)
 	for _, w := range res.TopBurners {
-		fmt.Fprintf(bt, "%s\t%d\t%d\t%.1fs\t%s\t%s\n",
-			w.Workflow, w.Runs, w.APICalls, w.AvgDurationS, formatAIC(w.AIC), formatCost(w.Cost))
+		fmt.Fprintf(bt, "%s\t%d\t%d\t%.1fs\t%s\t%s%s\n",
+			w.Workflow, w.Runs, w.APICalls, w.AvgDurationS,
+			formatAIC(w.AIC), formatCost(w.Cost), overColumn(w.OverBudget))
 	}
 	return bt.Flush()
+}
+
+func overBudgetMarker(over *bool) string {
+	if over != nil && *over {
+		return "!"
+	}
+	return ""
 }
 
 // byColumnHeader maps the --by axis to its uppercase key-column header.

--- a/cmd/consumption_test.go
+++ b/cmd/consumption_test.go
@@ -2,9 +2,46 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
 )
+
+func renderConsumptionTextFixture(t *testing.T, by fleet.GroupByKind, res *fleet.ConsumptionResult) string {
+	t.Helper()
+	cmd := NewRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := renderConsumptionText(cmd, by, res); err != nil {
+		t.Fatalf("renderConsumptionText: %v", err)
+	}
+	return out.String()
+}
+
+func writeEmptyFleetConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `{"version":1,"profiles":{},"repos":{}}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "fleet.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fleet.json: %v", err)
+	}
+	return dir
+}
+
+func withAggregateConsumptionStub(
+	t *testing.T,
+	stub func(context.Context, *fleet.Config, fleet.FetchMode, fleet.GroupByKind, fleet.SourceKind) (*fleet.ConsumptionResult, []fleet.Diagnostic, error),
+) {
+	t.Helper()
+	prev := aggregateConsumption
+	t.Cleanup(func() { aggregateConsumption = prev })
+	aggregateConsumption = stub
+}
 
 // TestConsumption_MutualExclusion covers FR-004: cobra rejects combinations
 // of --latest / --trailing / --since with a "mutually exclusive" message.
@@ -92,3 +129,249 @@ func TestConsumption_InvalidSince(t *testing.T) {
 		t.Errorf("error %q does not name the accepted form (YYYY-MM-DD)", err.Error())
 	}
 }
+
+func TestRenderConsumptionText_BudgetColumn(t *testing.T) {
+	budget := 50.0
+	over, under := true, false
+	res := &fleet.ConsumptionResult{
+		Budget: &budget,
+		Groups: []fleet.ConsumptionGroup{
+			{
+				Key: "rshade/over", GitHubAPICalls: 10, SafeOutputCalls: 1, AIC: f64ptr(50.01),
+				Cost: f64ptr(0.50), ReportCount: 1, OverBudget: &over,
+			},
+			{
+				Key: "rshade/under", GitHubAPICalls: 5, SafeOutputCalls: 0, AIC: f64ptr(50),
+				Cost: f64ptr(0.49), ReportCount: 1, OverBudget: &under,
+			},
+		},
+	}
+
+	out := renderConsumptionTextFixture(t, fleet.GroupByRepo, res)
+
+	if !strings.Contains(out, "REPORTS  OVER") {
+		t.Fatalf("output missing OVER header:\n%s", out)
+	}
+	if !strings.Contains(out, "rshade/over") || !strings.Contains(out, "!") {
+		t.Fatalf("output missing over-budget marker:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "rshade/under") && strings.Contains(line, "!") {
+			t.Fatalf("under-budget row unexpectedly marked:\n%s", out)
+		}
+	}
+
+	noBudget := *res
+	noBudget.Budget = nil
+	for i := range noBudget.Groups {
+		noBudget.Groups[i].OverBudget = nil
+	}
+	noBudgetOut := renderConsumptionTextFixture(t, fleet.GroupByRepo, &noBudget)
+	if strings.Contains(noBudgetOut, "OVER") || strings.Contains(noBudgetOut, "!") {
+		t.Fatalf("no-budget output contains budget annotation:\n%s", noBudgetOut)
+	}
+}
+
+func TestConsumption_BudgetFlagValidation(t *testing.T) {
+	t.Run("negative budget rejected before config loading", func(t *testing.T) {
+		root := NewRootCmd()
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		root.SetArgs([]string{"--dir", t.TempDir(), "consumption", "--budget", "-1"})
+
+		err := root.Execute()
+
+		if err == nil {
+			t.Fatal("Execute: expected negative budget error; got nil")
+		}
+		if !strings.Contains(err.Error(), "--budget") || !strings.Contains(err.Error(), "non-negative") {
+			t.Fatalf("error %q does not describe non-negative --budget", err.Error())
+		}
+	})
+
+	t.Run("zero budget accepted", func(t *testing.T) {
+		root := NewRootCmd()
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		root.SetArgs([]string{
+			"--dir", writeEmptyFleetConfig(t),
+			"consumption", "--source", "artifacts", "--budget", "0",
+		})
+
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", err, out.String(), errBuf.String())
+		}
+	})
+
+	t.Run("non-numeric budget rejected by cobra", func(t *testing.T) {
+		root := NewRootCmd()
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		root.SetArgs([]string{"consumption", "--budget", "abc"})
+
+		err := root.Execute()
+
+		if err == nil {
+			t.Fatal("Execute: expected parse error; got nil")
+		}
+		if !strings.Contains(err.Error(), `invalid argument "abc"`) {
+			t.Fatalf("error %q does not report invalid float", err.Error())
+		}
+	})
+}
+
+func TestConsumption_BudgetBreachesExitZero(t *testing.T) {
+	cases := []struct {
+		name   string
+		budget string
+	}{
+		{name: "zero breaches", budget: "200"},
+		{name: "some breaches", budget: "50"},
+		{name: "all breaches", budget: "0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := NewRootCmd()
+			withAggregateConsumptionStub(
+				t,
+				func(
+					_ context.Context,
+					_ *fleet.Config,
+					_ fleet.FetchMode,
+					_ fleet.GroupByKind,
+					_ fleet.SourceKind,
+				) (*fleet.ConsumptionResult, []fleet.Diagnostic, error) {
+					return &fleet.ConsumptionResult{
+						LoadedFrom: "fleet.json",
+						FetchMode:  "latest",
+						GroupBy:    "repo",
+						Source:     "artifacts",
+						Groups: []fleet.ConsumptionGroup{
+							{Key: "a/one", AIC: f64ptr(25), ReportCount: 1},
+							{Key: "b/two", AIC: f64ptr(100), ReportCount: 1},
+						},
+					}, nil, nil
+				},
+			)
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{
+				"--dir", writeEmptyFleetConfig(t),
+				"consumption", "--source", "artifacts", "--budget", tc.budget,
+			})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", err, out.String(), errBuf.String())
+			}
+		})
+	}
+}
+
+func TestRenderConsumptionText_TopBurnersBudgetColumn(t *testing.T) {
+	budget := 50.0
+	over, under := true, false
+	res := &fleet.ConsumptionResult{
+		Budget: &budget,
+		TopBurners: []fleet.WorkflowConsumption{
+			{
+				Workflow: "top-over", Runs: 3, APICalls: 30,
+				AvgDurationS: 12.5, AIC: f64ptr(60),
+				Cost: f64ptr(0.60), OverBudget: &over,
+			},
+			{
+				Workflow: "top-under", Runs: 1, APICalls: 10,
+				AvgDurationS: 3.5, AIC: f64ptr(40),
+				Cost: f64ptr(0.40), OverBudget: &under,
+			},
+		},
+	}
+
+	out := renderConsumptionTextFixture(t, fleet.GroupByRepo, res)
+
+	if !strings.Contains(out, "AVG_DURATION  AIC    COST   OVER") {
+		t.Fatalf("top-burners output missing OVER header:\n%s", out)
+	}
+	if !strings.Contains(out, "top-over") || !strings.Contains(out, "!") {
+		t.Fatalf("top-burners output missing marker:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "top-under") && strings.Contains(line, "!") {
+			t.Fatalf("under-budget top burner unexpectedly marked:\n%s", out)
+		}
+	}
+}
+
+func TestConsumption_JSONNegativeBudgetEnvelope(t *testing.T) {
+	root := NewRootCmd()
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"--output", "json", "--dir", t.TempDir(), "consumption", "--budget", "-1"})
+
+	err := root.Execute()
+
+	if err == nil {
+		t.Fatal("Execute: expected negative budget error; got nil")
+	}
+	var env Envelope
+	if decodeErr := json.Unmarshal(out.Bytes(), &env); decodeErr != nil {
+		t.Fatalf("decode envelope: %v\nstdout=%s", decodeErr, out.String())
+	}
+	if env.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %d; want %d", env.SchemaVersion, SchemaVersion)
+	}
+	if env.Result != nil {
+		t.Fatalf("result = %#v; want nil", env.Result)
+	}
+	if len(env.Hints) == 0 || !strings.Contains(env.Hints[0].Message, "--budget") {
+		t.Fatalf("hints = %+v; want --budget failure hint", env.Hints)
+	}
+}
+
+func TestConsumption_SchemaVersionUnchangedForBudget(t *testing.T) {
+	root := NewRootCmd()
+	withAggregateConsumptionStub(
+		t,
+		func(
+			_ context.Context,
+			_ *fleet.Config,
+			_ fleet.FetchMode,
+			_ fleet.GroupByKind,
+			_ fleet.SourceKind,
+		) (*fleet.ConsumptionResult, []fleet.Diagnostic, error) {
+			return &fleet.ConsumptionResult{
+				LoadedFrom: "fleet.json",
+				FetchMode:  "latest",
+				GroupBy:    "repo",
+				Source:     "artifacts",
+				Groups: []fleet.ConsumptionGroup{
+					{Key: "a/one", AIC: f64ptr(25), ReportCount: 1},
+				},
+			}, nil, nil
+		},
+	)
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{
+		"--output", "json", "--dir", writeEmptyFleetConfig(t),
+		"consumption", "--source", "artifacts", "--budget", "1",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", err, out.String(), errBuf.String())
+	}
+	var env Envelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v\nstdout=%s", err, out.String())
+	}
+	if env.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %d; want %d", env.SchemaVersion, SchemaVersion)
+	}
+}
+
+func f64ptr(v float64) *float64 { return &v }

--- a/cmd/consumption_test.go
+++ b/cmd/consumption_test.go
@@ -190,6 +190,25 @@ func TestConsumption_BudgetFlagValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("non-finite budget rejected before config loading", func(t *testing.T) {
+		for _, val := range []string{"NaN", "Inf", "+Inf", "-Inf"} {
+			root := NewRootCmd()
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{"--dir", t.TempDir(), "consumption", "--budget", val})
+
+			err := root.Execute()
+
+			if err == nil {
+				t.Fatalf("Execute(--budget %s): expected non-finite budget error; got nil", val)
+			}
+			if !strings.Contains(err.Error(), "--budget") || !strings.Contains(err.Error(), "finite") {
+				t.Fatalf("--budget %s: error %q does not describe finite --budget", val, err.Error())
+			}
+		}
+	})
+
 	t.Run("zero budget accepted", func(t *testing.T) {
 		root := NewRootCmd()
 		var out, errBuf bytes.Buffer

--- a/internal/fleet/consumption.go
+++ b/internal/fleet/consumption.go
@@ -214,6 +214,9 @@ type WorkflowConsumption struct {
 	AvgDurationS float64  `json:"avg_duration_s"`
 	AIC          *float64 `json:"aic,omitempty"`
 	Cost         *float64 `json:"cost,omitempty"`
+	// OverBudget is present when a budget ceiling was supplied and reports
+	// whether this workflow row strictly exceeded that ceiling.
+	OverBudget *bool `json:"over_budget,omitempty"`
 }
 
 // ConsumptionGroup is one aggregated row in the consumption rollup. The Key
@@ -233,16 +236,21 @@ type ConsumptionGroup struct {
 	AIC             *float64 `json:"aic,omitempty"`
 	Cost            *float64 `json:"cost,omitempty"`
 	ReportCount     int      `json:"report_count"`
+	// OverBudget is present when a budget ceiling was supplied and reports
+	// whether this group row strictly exceeded that ceiling.
+	OverBudget *bool `json:"over_budget,omitempty"`
 }
 
 // ConsumptionResult is the JSON envelope payload for `gh-aw-fleet
 // consumption`. Slice fields are normalized to non-nil empty slices by
 // initSlices (cmd/output.go) so JSON marshaling renders them as [].
 type ConsumptionResult struct {
-	LoadedFrom string                `json:"loaded_from"`
-	FetchMode  string                `json:"fetch_mode"`
-	GroupBy    string                `json:"group_by"`
-	Source     string                `json:"source,omitempty"`
+	LoadedFrom string `json:"loaded_from"`
+	FetchMode  string `json:"fetch_mode"`
+	GroupBy    string `json:"group_by"`
+	Source     string `json:"source,omitempty"`
+	// Budget is the optional AIC ceiling supplied by the operator.
+	Budget     *float64              `json:"budget,omitempty"`
 	Groups     []ConsumptionGroup    `json:"groups"`
 	TopBurners []WorkflowConsumption `json:"top_burners"`
 }

--- a/internal/fleet/consumption_budget.go
+++ b/internal/fleet/consumption_budget.go
@@ -1,0 +1,24 @@
+package fleet
+
+// ApplyBudget annotates res in place with over-budget markers when budget is
+// non-nil. A row is over budget iff its AIC is non-nil and strictly greater
+// than *budget; nil-AIC rows and rows equal to the ceiling are never marked.
+// When budget is nil the function is a no-op, preserving byte-identical output
+// for invocations without --budget.
+func ApplyBudget(res *ConsumptionResult, budget *float64) {
+	if res == nil || budget == nil {
+		return
+	}
+	res.Budget = budget
+	for i := range res.Groups {
+		res.Groups[i].OverBudget = overBudgetPtr(res.Groups[i].AIC, *budget)
+	}
+	for i := range res.TopBurners {
+		res.TopBurners[i].OverBudget = overBudgetPtr(res.TopBurners[i].AIC, *budget)
+	}
+}
+
+func overBudgetPtr(aic *float64, budget float64) *bool {
+	over := aic != nil && *aic > budget
+	return &over
+}

--- a/internal/fleet/consumption_budget_test.go
+++ b/internal/fleet/consumption_budget_test.go
@@ -1,0 +1,144 @@
+package fleet
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func budgetTestResult(groups []ConsumptionGroup, topBurners []WorkflowConsumption) *ConsumptionResult {
+	return &ConsumptionResult{
+		LoadedFrom: "fleet.local.json",
+		FetchMode:  "latest",
+		GroupBy:    "repo",
+		Source:     "logs",
+		Groups:     groups,
+		TopBurners: topBurners,
+	}
+}
+
+func assertBoolPtr(t *testing.T, got *bool, want bool) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("bool pointer is nil; want %v", want)
+	}
+	wantPtr := boolPtr(want)
+	if *got != *wantPtr {
+		t.Fatalf("bool pointer = %v; want %v", *got, *wantPtr)
+	}
+}
+
+func TestApplyBudget_StrictThreshold(t *testing.T) {
+	budget := 5.0
+	res := budgetTestResult([]ConsumptionGroup{
+		{Key: "above", AIC: fptr(5.01)},
+		{Key: "below", AIC: fptr(4.99)},
+		{Key: "equal", AIC: fptr(5.0)},
+		{Key: "nil"},
+		{Key: "zero", AIC: fptr(0)},
+	}, nil)
+
+	ApplyBudget(res, &budget)
+
+	if res.Budget == nil || *res.Budget != budget {
+		t.Fatalf("Budget = %v; want %v", res.Budget, budget)
+	}
+	assertBoolPtr(t, res.Groups[0].OverBudget, true)
+	assertBoolPtr(t, res.Groups[1].OverBudget, false)
+	assertBoolPtr(t, res.Groups[2].OverBudget, false)
+	assertBoolPtr(t, res.Groups[3].OverBudget, false)
+	assertBoolPtr(t, res.Groups[4].OverBudget, false)
+
+	zeroBudget := 0.0
+	zeroRes := budgetTestResult([]ConsumptionGroup{
+		{Key: "positive", AIC: fptr(0.01)},
+		{Key: "zero", AIC: fptr(0)},
+	}, nil)
+	ApplyBudget(zeroRes, &zeroBudget)
+	assertBoolPtr(t, zeroRes.Groups[0].OverBudget, true)
+	assertBoolPtr(t, zeroRes.Groups[1].OverBudget, false)
+}
+
+func TestApplyBudget_AllGroupingAxes(t *testing.T) {
+	for _, groupBy := range []string{"repo", "profile", "cost-center", "workflow"} {
+		t.Run(groupBy, func(t *testing.T) {
+			budget := 10.0
+			res := budgetTestResult([]ConsumptionGroup{
+				{Key: groupBy + "-over", AIC: fptr(10.5)},
+				{Key: groupBy + "-under", AIC: fptr(9.5)},
+			}, nil)
+			res.GroupBy = groupBy
+
+			ApplyBudget(res, &budget)
+
+			assertBoolPtr(t, res.Groups[0].OverBudget, true)
+			assertBoolPtr(t, res.Groups[1].OverBudget, false)
+		})
+	}
+}
+
+func TestApplyBudget_TopBurners(t *testing.T) {
+	budget := 50.0
+	res := budgetTestResult(nil, []WorkflowConsumption{
+		{Workflow: "over", AIC: fptr(50.01)},
+		{Workflow: "equal", AIC: fptr(50)},
+		{Workflow: "below", AIC: fptr(49.99)},
+		{Workflow: "nil"},
+	})
+
+	ApplyBudget(res, &budget)
+
+	assertBoolPtr(t, res.TopBurners[0].OverBudget, true)
+	assertBoolPtr(t, res.TopBurners[1].OverBudget, false)
+	assertBoolPtr(t, res.TopBurners[2].OverBudget, false)
+	assertBoolPtr(t, res.TopBurners[3].OverBudget, false)
+}
+
+func TestConsumptionResult_JSONBudgetFields(t *testing.T) {
+	noBudget := budgetTestResult(
+		[]ConsumptionGroup{{Key: "repo", AIC: fptr(1)}},
+		[]WorkflowConsumption{{Workflow: "wf", AIC: fptr(1)}},
+	)
+	rawNoBudget, err := json.Marshal(noBudget)
+	if err != nil {
+		t.Fatalf("Marshal(no budget): %v", err)
+	}
+	sNoBudget := string(rawNoBudget)
+	for _, forbidden := range []string{`"budget"`, `"over_budget"`} {
+		if strings.Contains(sNoBudget, forbidden) {
+			t.Fatalf("no-budget JSON contains %s; want omitted: %s", forbidden, sNoBudget)
+		}
+	}
+
+	budget := 5.0
+	withBudget := budgetTestResult(
+		[]ConsumptionGroup{
+			{Key: "over", AIC: fptr(5.01)},
+			{Key: "under", AIC: fptr(4.99)},
+		},
+		[]WorkflowConsumption{
+			{Workflow: "top-over", AIC: fptr(7)},
+			{Workflow: "top-under", AIC: fptr(3)},
+		},
+	)
+	ApplyBudget(withBudget, &budget)
+
+	rawWithBudget, err := json.Marshal(withBudget)
+	if err != nil {
+		t.Fatalf("Marshal(with budget): %v", err)
+	}
+	sWithBudget := string(rawWithBudget)
+	for _, want := range []string{
+		`"budget":5`,
+		`"key":"over"`,
+		`"over_budget":true`,
+		`"key":"under"`,
+		`"over_budget":false`,
+		`"workflow":"top-over"`,
+		`"workflow":"top-under"`,
+	} {
+		if !strings.Contains(sWithBudget, want) {
+			t.Fatalf("budget JSON missing %s: %s", want, sWithBudget)
+		}
+	}
+}

--- a/skills/fleet-budget-review/SKILL.md
+++ b/skills/fleet-budget-review/SKILL.md
@@ -65,7 +65,19 @@ Four axes:
 
 Any value outside the four-axis set is a hard error — cobra rejects with `--by value "X" invalid: expected one of repo, profile, cost-center, workflow`.
 
-### Step 3 — invoke
+### Step 3 — optionally add a review ceiling
+
+Use `--budget <AIC>` when the user supplies a ceiling or asks for spend hotspots against a threshold.
+
+```bash
+gh-aw-fleet consumption --budget 50
+```
+
+The ceiling is in AIC, the native billing unit shown in the `AIC` column. A row is over budget only when its AIC is present and strictly greater than the ceiling; equal-to-ceiling rows and `-`/nil-AIC rows are not over budget. In text output, over-budget rows show `!` in a trailing `OVER` column. In JSON output, `result.budget` echoes the ceiling and each row carries `over_budget` when a budget was supplied.
+
+This is still read-only budget review. `--budget` does not cap spend, halt commands, alert externally, write comments/issues, or change the exit code for breaches. Any number of over-budget rows, including all rows, still exits 0. Only malformed input, such as a negative or non-numeric ceiling, is a usage error.
+
+### Step 4 — invoke
 
 ```bash
 gh-aw-fleet consumption [repo...] [--latest|--trailing Nd|--since YYYY-MM-DD] --by <axis>
@@ -77,7 +89,7 @@ Add `--output json` if you want to pipe through jq. The envelope is the standard
 
 The command prints a stderr breadcrumb (`(loaded fleet.json + fleet.local.json)`) and structured warnings; stdout carries the rollup table and the `TOP 10 BURNERS:` footer.
 
-### Step 4 — read the diagnostics
+### Step 5 — read the diagnostics
 
 The rollup may emit per-repo warnings on stderr. Two patterns to expect under the default `--source logs`:
 
@@ -88,16 +100,17 @@ Warnings are non-fatal. The command always exits 0 when discovery + fetch succee
 
 **Legacy `--source artifacts` notes:** If using the deprecated artifacts path, expect an additional warning: **`Run artifact for <repo> (run #N on <date>) is past the ~90-day run-log retention window.`** This occurs when the underlying workflow-run artifacts were garbage-collected by the platform. Long-trend questions beyond ~90 days are out of scope (FR-024); shorten the window or switch to `--source logs`.
 
-### Step 5 — frame the answer
+### Step 6 — frame the answer
 
 The raw table is rarely the answer. Pick the framing that matches the question:
 
 - **Snapshot question** ("how are we doing?"): lead with the fleet total AI credits (sum of the `AIC` column for `--by repo`), then call out the top 3 repos by credit usage. The `TOP 10 BURNERS:` footer names the highest-traffic individual workflows by AIC — quote 2-3 of them.
 - **Cost-concentration question** ("where do we trim?"): use `--by profile` or `--by cost-center` and call out the heaviest row. Note any `<unset>` bucket — those repos aren't attributed to a budget owner and that's usually a tagging gap to fix before any real trimming decision.
 - **Workflow-specific question** ("is `<workflow>` worth it?"): use `--by workflow`, pull out the named workflow's row, and compare its `AIC` / `COST` to the next-most-expensive workflow. Numbers in isolation rarely change anyone's mind; a comparison ("`workflow-X` is 3× the AIC of the next-most-expensive workflow `Y`") does.
+- **Threshold question** ("what is over budget?"): include `--budget <AIC>`, then lead with the rows marked `OVER`. Do not describe the marker as an alert or enforcement event; it is an operator-pulled highlight.
 - **Trend question** ("are we trending up?"): the command doesn't store historical state, so you can't directly compare windows. Run two invocations (`--trailing 7d` and `--trailing 14d`) and infer the delta (last 7d ÷ first 7d ≈ 2 means flat; >2 means growth, <2 means decline). Flag that this is approximate — daily variance can be large.
 
-### Step 6 — recommend (only if user asked)
+### Step 7 — recommend (only if user asked)
 
 If the user asks "what should I do?":
 
@@ -114,6 +127,7 @@ Never apply changes from this skill. Recommendations are read-only — operator 
 - **No caching.** Each invocation re-discovers. If the user runs the rollup twice in a session and gets slightly different numbers, that's because in-progress reports flipped to finalized between invocations — not a bug. Surface this when totals shift unexpectedly.
 - **Multi-profile additivity is the documented semantic.** Don't apologize for double-counting under `--by profile` — it's intentional (FR-014, research.md Decision 5). Operators learn to sum across profile rows only when they want a fleet total, not when comparing profile costs.
 - **AI credits and cost are nil-until-positive.** If `aic` / `cost` fields are zero or absent, the rollup renders `-` for those columns (FR-018, Decision 6). Don't treat the dash as "this repo costs zero dollars" — it means "no AIC data available." Under `--source logs`, all fields are populated from agentic run summaries when available; under `--source artifacts`, the cost field is structurally nil under the Copilot AI-Credits model (that path predates the AIC schema). Frame conclusions around API_CALLS when AIC is sparse.
+- **Budget highlighting is not enforcement.** `--budget` is a display filter over the already-aggregated AIC values. It never pushes an alert, opens a GitHub artifact, caps spend, or changes the exit code because rows breached the ceiling.
 - **The `<unset>` cost-center bucket is a real signal, not noise.** When the operator asks "where is my spend attributed?", an `<unset>` row means "you haven't told the tool, and I'm not going to invent an answer."
 - **Don't volunteer raw JSON unless asked.** The text-mode tabwriter is the operator-facing surface; the JSON envelope is for downstream piping. Show the table; only break out JSON if the user pipes through jq or asks for the wire format.
 
@@ -198,10 +212,13 @@ User: what's our consumption?
 You:
   - Run `gh-aw-fleet consumption`.
   - All repos emit "No consumption reports discovered" warnings.
-  - Report: "No consumption reports are available — the
-    api-consumption-report workflow isn't deployed to any repo in
-    the fleet yet. Add `observability-plus` to a repo's profile list
-    in fleet.local.json and re-run after its first daily run."
+  - Report: "No consumption reports are available — the default
+    logs source found no agentic workflow runs to aggregate yet.
+    Run `gh-aw-fleet list <repo>` to confirm workflows are deployed;
+    if none are present, add a profile that includes agentic workflows
+    and re-run after the first workflow execution. If you deliberately
+    used `--source artifacts`, deploy `observability-plus` and wait for
+    its first daily run."
   - Stop. Do not invent numbers.
 ```
 

--- a/specs/009-consumption-subcommand/decisions/0001-highlight-not-alarm.md
+++ b/specs/009-consumption-subcommand/decisions/0001-highlight-not-alarm.md
@@ -1,0 +1,34 @@
+# Decision 0001: Budget Highlighting Is Not an Alarm
+
+## Status
+
+Accepted for `017-consumption-budget`.
+
+## Context
+
+The 009 consumption subcommand specification requires that `gh-aw-fleet consumption`
+MUST NOT enforce a spending cap, budget alarm, or hard limit. Feature
+`017-consumption-budget` adds `--budget <AIC>`, which marks rows whose already-aggregated
+AIC exceeds an operator-supplied ceiling.
+
+## Decision
+
+`--budget` is a read-only highlight, not an alarm or enforcement mechanism.
+
+The feature only annotates output the operator explicitly pulled:
+
+- Text output adds an `OVER` marker column.
+- JSON output adds `result.budget` and per-row `over_budget` fields when a ceiling is supplied.
+- The command exit code remains independent of breach count.
+
+It does not push any external signal, write local or remote state, open issues or comments,
+halt deploy/sync/upgrade behavior, retry work, cap spend, or constrain fleet operations.
+Malformed flag input remains normal usage validation and may return non-zero; budget breaches
+do not.
+
+## Consequences
+
+The 009 "no alarm / no enforcement" requirement remains intact. Operators can use
+`--budget` to spot spend hotspots during a budget review, while actual budget enforcement
+continues to live outside this tool in platform spending controls or a future explicitly
+scoped feature.

--- a/specs/017-consumption-budget/checklists/requirements.md
+++ b/specs/017-consumption-budget/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Read-Only Over-Budget Highlighting in the Consumption Rollup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The three open questions raised in the source issue (single vs per-axis ceiling,
+  sort-to-top vs annotate-in-place, USD vs native-unit threshold, and whether the
+  decision record must block) are resolved as documented Assumptions, each citing
+  the issue's own recommendation. None left as [NEEDS CLARIFICATION].
+- The critical "highlight, not enforce" constraint is encoded as FR-010 / FR-011
+  (read-only, exit-code-invariant) and the FR-014 reconciliation decision record,
+  directly addressing the 009 spec's FR-023 ("no alarm").
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/017-consumption-budget/contracts/budget-flag.md
+++ b/specs/017-consumption-budget/contracts/budget-flag.md
@@ -1,0 +1,51 @@
+# CLI Contract: `--budget`
+
+Extends the `gh-aw-fleet consumption` command (009). Additive, read-only.
+
+## Flag
+
+```text
+--budget <AIC>   Highlight rollup rows whose AI-credit spend exceeds this
+                 per-row ceiling. Read-only: marks rows only — never caps,
+                 halts, alerts, or changes the exit code. Applies to the
+                 active --by axis and the TOP BURNERS footer. (default: unset)
+```
+
+- Type: float (cobra `Float64Var`).
+- Optional. Absent ⇒ no annotation; output byte-identical to pre-feature behavior.
+- Supplied-ness is detected with `cmd.Flags().Changed("budget")` because `0` is a valid
+  ceiling (flags every row with positive spend) and cannot double as "unset".
+- Composes with every `--by`, `--source`, and temporal flag; no new mutual-exclusion rules.
+
+## Semantics
+
+- A row is **over budget** iff its AIC is present (non-nil) and strictly greater than the
+  ceiling. Equal-to-ceiling and absent-AIC rows are **not** over budget.
+- The ceiling is in AI credits (AIC), the rollup's native billing unit — not USD.
+
+## Exit codes
+
+| Condition | Exit |
+|-----------|------|
+| Any number of rows over budget (including all rows) | 0 |
+| No rows over budget | 0 |
+| `--budget` negative | non-zero (input validation) |
+| `--budget` non-numeric | non-zero (cobra flag parse) |
+
+The number of breaching rows NEVER affects the exit code (FR-010/FR-011).
+
+## Examples
+
+```bash
+# Flag any repo burning more than 50 AIC in the latest report
+gh-aw-fleet consumption --budget 50
+
+# By cost-center, trailing 30 days, over 200 AIC
+gh-aw-fleet consumption --by cost-center --trailing 30d --budget 200
+
+# Everything with any spend (zero ceiling)
+gh-aw-fleet consumption --budget 0
+
+# Machine-readable: read which groups breached
+gh-aw-fleet consumption --by workflow --budget 25 --output json
+```

--- a/specs/017-consumption-budget/contracts/consumption-output.json
+++ b/specs/017-consumption-budget/contracts/consumption-output.json
@@ -1,0 +1,54 @@
+{
+  "_comment": "Additive deltas to the consumption JSON envelope (009 contract). schema_version stays 1 (FR-008). New fields when --budget is supplied: result.budget (omitempty), group.over_budget, top_burner.over_budget.",
+  "schema_version": 1,
+  "command": "consumption",
+  "result": {
+    "loaded_from": "fleet.local.json",
+    "fetch_mode": "latest",
+    "group_by": "repo",
+    "source": "logs",
+    "budget": 50.0,
+    "groups": [
+      {
+        "key": "rshade/finfocus",
+        "github_api_calls": 1200,
+        "safe_output_calls": 8,
+        "aic": 73.5,
+        "cost": 0.74,
+        "report_count": 1,
+        "over_budget": true
+      },
+      {
+        "key": "rshade/gh-aw-fleet",
+        "github_api_calls": 300,
+        "safe_output_calls": 2,
+        "aic": 12.0,
+        "cost": 0.12,
+        "report_count": 1,
+        "over_budget": false
+      },
+      {
+        "key": "rshade/all-failures",
+        "github_api_calls": 0,
+        "safe_output_calls": 0,
+        "report_count": 1,
+        "over_budget": false,
+        "_comment_nil_aic": "aic absent (all runs failed) -> never over budget (FR-009)"
+      }
+    ],
+    "top_burners": [
+      {
+        "workflow": "daily-malicious-code-scan",
+        "runs": 30,
+        "api_calls": 900,
+        "avg_duration_s": 42.5,
+        "aic": 61.0,
+        "cost": 0.61,
+        "over_budget": true
+      }
+    ]
+  },
+  "_no_budget_variant": {
+    "_comment": "When --budget is NOT supplied: `budget` and `over_budget` are omitted, preserving byte-identical pre-feature JSON output. schema_version remains unchanged."
+  }
+}

--- a/specs/017-consumption-budget/contracts/consumption-text-output.md
+++ b/specs/017-consumption-budget/contracts/consumption-text-output.md
@@ -1,0 +1,41 @@
+# Text-Output Contract: `OVER` column
+
+Additive delta to the 009 tabwriter text output. The `OVER` column appears **only when
+`--budget` is supplied**; without it, output is byte-identical to the pre-feature table.
+
+## With `--budget 50` (axis: repo)
+
+```text
+REPO                  API_CALLS  SAFE_WRITES  AIC    COST   REPORTS  OVER
+rshade/finfocus       1200       8            73.50  $0.74  1        !
+rshade/gh-aw-fleet    300        2            12.00  $0.12  1
+rshade/all-failures   0          0            -      -      1
+
+TOP 10 BURNERS:
+WORKFLOW                    RUNS  API_CALLS  AVG_DURATION  AIC    COST   OVER
+daily-malicious-code-scan   30    900        42.5s         61.00  $0.61  !
+nightly-docs                 4    120        10.0s         18.00  $0.18
+```
+
+- `OVER` cell is `!` for over-budget rows, empty otherwise.
+- Trailing position keeps existing columns and alignment unchanged.
+- A `-` AIC row (nil) is never marked.
+- The footer uses the same `OVER` column on the same AIC ceiling.
+
+## Without `--budget` (unchanged)
+
+```text
+REPO                  API_CALLS  SAFE_WRITES  AIC    COST   REPORTS
+rshade/finfocus       1200       8            73.50  $0.74  1
+rshade/gh-aw-fleet    300        2            12.00  $0.12  1
+
+TOP 10 BURNERS:
+WORKFLOW                    RUNS  API_CALLS  AVG_DURATION  AIC    COST
+daily-malicious-code-scan   30    900        42.5s         61.00  $0.61
+```
+
+## Header construction
+
+`renderConsumptionText` appends `\tOVER` to both header lines and an `OVER`-cell to each
+row only when `res.Budget != nil`; the over-cell renders `"!"` when the row's `OverBudget`
+is true and `""` otherwise.

--- a/specs/017-consumption-budget/data-model.md
+++ b/specs/017-consumption-budget/data-model.md
@@ -1,0 +1,78 @@
+# Phase 1 Data Model: Over-Budget Highlighting
+
+This feature adds three additive fields and one pure function. No entity is created from
+scratch; the change extends existing types in `internal/fleet/consumption.go` and keeps
+the new budget logic in `internal/fleet/consumption_budget.go`.
+
+## Modified entities
+
+### `ConsumptionResult` (envelope payload)
+
+| Field | Type | JSON | Change | Meaning |
+|-------|------|------|--------|---------|
+| `Budget` | `*float64` | `budget,omitempty` | **NEW** | The AIC ceiling the operator supplied via `--budget`. `nil`/omitted when no ceiling was supplied. Echoed so consumers see the basis of the determinations. |
+
+All existing fields (`LoadedFrom`, `FetchMode`, `GroupBy`, `Source`, `Groups`, `TopBurners`)
+are unchanged.
+
+### `ConsumptionGroup` (one rollup row)
+
+| Field | Type | JSON | Change | Meaning |
+|-------|------|------|--------|---------|
+| `OverBudget` | `*bool` | `over_budget,omitempty` | **NEW** | Present only when a ceiling was supplied. `true` iff this group's `AIC` is non-nil **and** `*AIC > Budget`; `false` when a budget was supplied and the row is nil-AIC, equal-to-ceiling, or below-ceiling. Omitted in no-budget output to preserve pre-feature JSON compatibility. |
+
+Existing fields (`Key`, `GitHubAPICalls`, `SafeOutputCalls`, `AIC`, `Cost`, `ReportCount`)
+unchanged. The comparison reads the existing `AIC` field — no new aggregation.
+
+### `WorkflowConsumption` (per-workflow row; used in `PerWorkflow` and `TopBurners`)
+
+| Field | Type | JSON | Change | Meaning |
+|-------|------|------|--------|---------|
+| `OverBudget` | `*bool` | `over_budget,omitempty` | **NEW** | Same rule as `ConsumptionGroup.OverBudget`, applied to the row's `AIC`. Annotated on `TopBurners` when a budget is supplied so the footer never disagrees with the body for a workflow appearing in both (spec edge case). Omitted in no-budget output. |
+
+Existing fields (`Workflow`, `Runs`, `APICalls`, `AvgDurationS`, `AIC`, `Cost`) unchanged.
+
+## New behavior
+
+### `ApplyBudget(res *ConsumptionResult, budget *float64)`
+
+Exported, pure, no I/O. Idempotent. Signature and contract:
+
+```go
+// ApplyBudget annotates res in place with over-budget markers when budget is
+// non-nil. A row is over budget iff its AIC is non-nil and strictly greater
+// than *budget; nil-AIC rows and rows equal to the ceiling are never marked.
+// When budget is nil the function is a no-op (no field is touched), preserving
+// byte-identical output for invocations without --budget. Sets res.Budget to
+// the supplied ceiling for the JSON echo.
+func ApplyBudget(res *ConsumptionResult, budget *float64)
+```
+
+Logic:
+
+1. If `budget == nil` → return immediately (no-op).
+2. Set `res.Budget = budget`.
+3. For each `g` in `res.Groups`: set `g.OverBudget` to a pointer whose value is `g.AIC != nil && *g.AIC > *budget`.
+4. For each `w` in `res.TopBurners`: set `w.OverBudget` to a pointer whose value is `w.AIC != nil && *w.AIC > *budget`.
+
+## Validation rules
+
+| Input | Outcome | Exit |
+|-------|---------|------|
+| `--budget` absent | No annotation; `res.Budget` nil; output identical to pre-feature | 0 |
+| `--budget 0` | Every row with strictly-positive AIC marked over budget | 0 (regardless of how many breach) |
+| `--budget 12.5` (any ≥ 0) | Rows with `AIC > 12.5` marked | 0 (regardless of how many breach) |
+| `--budget -1` (negative) | Rejected with actionable error (and `preResultFailureEnvelope` in JSON mode) | **non-zero** (input validation, FR-011/FR-012) |
+| `--budget abc` (non-numeric) | Rejected by cobra `Float64Var` parse | **non-zero** (flag parse) |
+
+Breach count never affects the exit code (FR-011): a fleet where every row is over budget
+still exits 0.
+
+## Relationships & invariants
+
+- `OverBudget` is derived solely from the existing `AIC` field and the supplied `Budget`;
+  it introduces no new data source and no network call (FR-013).
+- The all-or-nothing nil-merge semantics for `AIC` (`mergeFloat`) are inherited unchanged;
+  this feature only reads the resulting `*float64` (FR-009).
+- `cmd.SchemaVersion` is **not** bumped — all three fields are additive and omitted when
+  no budget is supplied (FR-008 / SC-003).

--- a/specs/017-consumption-budget/plan.md
+++ b/specs/017-consumption-budget/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Read-Only Over-Budget Highlighting in the Consumption Rollup
+
+**Branch**: `017-consumption-budget` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/017-consumption-budget/spec.md`
+
+## Summary
+
+Add an optional, read-only `--budget <AIC>` flag to `gh-aw-fleet consumption` that highlights which rollup rows exceed a per-row AI-credit ceiling. The determination is a pure post-aggregation pass over the `*ConsumptionResult` that `AggregateConsumption` already builds: a new `ApplyBudget` function sets a per-row over-budget flag (when the row's `AIC` is non-nil and strictly greater than the ceiling) on every `ConsumptionGroup` and every `TopBurners` row, and echoes the ceiling on the result envelope. The text renderer gains an `OVER` column (only when a budget is supplied); the JSON envelope gains additive `over_budget` (per group / per top-burner) and `budget` (envelope-level) fields only when a budget is supplied, preserving no-budget JSON compatibility and requiring no `cmd.SchemaVersion` bump. The feature stays strictly on the highlight side of the 009 spec's FR-023 ("no alarm"): no enforcement, no external signal, exit code unaffected by breaches (only malformed input — a negative or non-numeric ceiling — exits non-zero). A decision record under `specs/009-consumption-subcommand/decisions/` reconciles "highlight" with FR-023.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.4 (local development gate; `go.mod` directive `go 1.26.4`)
+**Primary Dependencies**: `github.com/spf13/cobra` v1.10.2 (CLI flag), `github.com/rs/zerolog` v1.35.1 (stderr warnings) — both pre-existing. Standard library only for new logic (`strconv` already imported in `internal/fleet/consumption.go`; `text/tabwriter` already imported in `cmd/consumption.go`). **No new third-party dependency.**
+**Storage**: N/A — pure read/post-process of the in-memory rollup result. No on-disk state, no cache, no network beyond what the rollup already performs (FR-013).
+**Testing**: `go test ./...` via `make test`; table-driven unit tests over the existing `internal/fleet/testdata/{consumption,logs}/` fixtures plus the `cmd/consumption_test.go` flag-validation pattern.
+**Target Platform**: Linux/macOS CLI (same as the rest of the tool).
+**Project Type**: Single-project Go CLI (thin orchestrator).
+**Performance Goals**: No added latency — the budget pass is O(groups + top-burners) over an already-materialized slice, no I/O. Well within the constitution's 5-minute ceiling (Principle IV).
+**Constraints**: Read-only / no enforcement (FR-010); exit code invariant under breaches (FR-011); `cmd.SchemaVersion` MUST NOT bump (FR-008); native AIC unit, not derived USD (spec Assumptions); strictly-greater-than semantics (FR-002); nil-AIC groups are not over budget (FR-009).
+**Scale/Scope**: Typical fleet ≤10 repos × ≤20 workflows. Net new code is small: one flag, one pure exported function (`ApplyBudget`), two additive struct fields, one render column, one decision record, and tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against the gh-aw-fleet Constitution v1.2.0:
+
+- **I. Thin-Orchestrator Code Quality** — PASS. No upstream-tool logic is re-implemented; the feature is local presentation/annotation over data the rollup already computes. No new `exec.Command` calls. `internal/fleet/consumption.go` is already beyond the 300-line refactor trigger, so only the unavoidable struct-field additions land there; the new budget pass lives in a focused sibling file (`internal/fleet/consumption_budget.go`) with focused tests. Errors wrapped with `%w`; exported identifiers get godoc (`ApplyBudget`, `ConsumptionResult.Budget`, `ConsumptionGroup.OverBudget`, `WorkflowConsumption.OverBudget`).
+- **II. Testing Standards** — PASS. The command is read-only, so the mutating-command dry-run requirement does not apply. `go build` / `go vet` clean is mandatory. Unit tests are not constitution-required but are an explicit acceptance criterion here and are a natural fit (stateless pure function); they run fully offline against existing fixtures (no live `gh`). Because this feature updates `skills/fleet-budget-review/SKILL.md`, the affected skill must also receive one realistic subagent test before shipping, with hard stops before destructive actions.
+- **III. User Experience Consistency** — PASS (with note). The three-turn mutation pattern governs commands that mutate external state; `consumption` mutates nothing, so it is out of that pattern's scope. The feature reinforces UX consistency by mirroring the existing flag/validation idioms (`ParseGroupBy`, `buildFetchMode`) and the `--output json` envelope contract.
+- **IV. Performance Requirements** — PASS. No new network or disk I/O; a single linear pass over already-materialized slices. No caching concerns (nothing fetched).
+- **Third-Party Dependencies** — PASS. No new direct dependency; no `go.mod` `require()` change; no amendment needed.
+
+**Result: PASS — no violations. Complexity Tracking table intentionally omitted.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-consumption-budget/
+├── plan.md              # This file (/speckit-plan command output)
+├── spec.md              # Feature spec (/speckit-specify output)
+├── research.md          # Phase 0 output (/speckit-plan)
+├── data-model.md        # Phase 1 output (/speckit-plan)
+├── quickstart.md        # Phase 1 output (/speckit-plan)
+├── contracts/           # Phase 1 output (/speckit-plan)
+│   ├── budget-flag.md            # CLI flag contract: --budget
+│   ├── consumption-output.json   # Updated JSON envelope (additive budget/over_budget)
+│   └── consumption-text-output.md # Updated text contract: OVER column
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (/speckit-specify output)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+internal/fleet/
+├── consumption.go             # ADD: unavoidable struct fields only:
+│                              #      ConsumptionResult.Budget,
+│                              #      ConsumptionGroup.OverBudget,
+│                              #      WorkflowConsumption.OverBudget.
+├── consumption_budget.go      # NEW: ApplyBudget(res, *float64) pure post-aggregation
+│                              #      pass. (AggregateConsumption unchanged.)
+└── consumption_budget_test.go # ADD: table-driven ApplyBudget tests (strictly-greater,
+                               #      equal, nil-AIC, zero-ceiling, top-burner annotation,
+                               #      every-axis, no-budget JSON compatibility).
+
+cmd/
+├── consumption.go        # ADD: --budget flag (Float64Var + Changed() supplied-detection),
+│                         #      negative/parse validation, ApplyBudget wiring, OVER column
+│                         #      in renderConsumptionText + top-burners footer.
+└── consumption_test.go   # ADD: flag-validation tests (negative rejected non-zero exit;
+                          #      zero accepted; absent → no OVER column / identical output;
+                          #      exit code unaffected by breach count).
+
+specs/009-consumption-subcommand/
+└── decisions/
+    └── 0001-highlight-not-alarm.md  # NEW: reconciles --budget highlight with FR-023 (FR-014).
+
+skills/fleet-budget-review/
+└── SKILL.md              # UPDATE: document --budget, unit, strictly-greater semantics,
+                          #         nil-AIC exclusion, and the highlight≠enforce statement (FR-015).
+```
+
+**Structure Decision**: Single-project Go CLI; the change keeps the existing split between `internal/fleet` aggregation/logic and `cmd` flag/rendering, but avoids adding new logic to the already-large `internal/fleet/consumption.go`. That file receives only the struct-field additions that must live with the existing types; the new budget pass and its focused tests live in `internal/fleet/consumption_budget.go` and `internal/fleet/consumption_budget_test.go`. The command layer remains in `cmd/consumption.go` plus command tests; `cmd/output.go` is a validation surface for the unchanged envelope schema, not a primary implementation surface. The decision record lands under the existing 009 spec directory (new `decisions/` subfolder); the skill update layers onto the current `skills/fleet-budget-review/SKILL.md` and is verified by a subagent skill test before shipping.
+
+## Complexity Tracking
+
+> No Constitution Check violations — table intentionally omitted.

--- a/specs/017-consumption-budget/quickstart.md
+++ b/specs/017-consumption-budget/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Over-Budget Highlighting
+
+## What it does
+
+`gh-aw-fleet consumption --budget <AIC>` flags rollup rows whose AI-credit spend exceeds a
+ceiling, so spend hotspots stand out without manual scanning. It is **read-only**: it marks
+rows only — it never caps, halts, alerts, or changes the exit code.
+
+## Try it
+
+```bash
+# Highlight repos over 50 AIC in the latest report
+gh-aw-fleet consumption --budget 50
+
+# Pivot by cost-center over the last 30 days, ceiling 200 AIC
+gh-aw-fleet consumption --by cost-center --trailing 30d --budget 200
+
+# Show everything with any spend
+gh-aw-fleet consumption --budget 0
+
+# Machine-readable
+gh-aw-fleet consumption --by workflow --budget 25 --output json | jq '.result.groups[] | select(.over_budget)'
+```
+
+Over-budget rows show `!` in a trailing `OVER` column (text) or `"over_budget": true` (JSON).
+The applied ceiling is echoed as `result.budget` in JSON.
+
+## Rules at a glance
+
+- **Over budget** = AIC present **and** strictly greater than the ceiling. Equal-to-ceiling
+  and rows with no AIC (`-`) are never flagged.
+- Unit is **AIC** (AI credits), the native billing unit — not USD.
+- No `--budget` ⇒ output is exactly as before (purely additive, opt-in).
+- Exit code is **always 0** for any number of breaches; only a **negative** or
+  **non-numeric** `--budget` exits non-zero (input validation).
+
+## Verify the implementation
+
+```bash
+make fmt && make vet && make lint && make test     # or: make ci
+go run . consumption --budget 50                   # eyeball the OVER column
+go run . consumption --budget 50 --output json | jq '.schema_version'   # must stay 1
+go run . consumption --budget -1; echo "exit=$?"   # must be non-zero
+go run . consumption --budget 0; echo "exit=$?"    # must be 0
+```
+
+### Acceptance checks (map to spec)
+
+- [ ] Rows with `AIC > budget` marked on **all four** `--by` axes (US1, US2; FR-002/FR-003).
+- [ ] Equal-to-ceiling and nil-AIC rows **not** marked (FR-002/FR-009).
+- [ ] No `--budget` ⇒ text and JSON identical to pre-feature (FR-006; SC-003).
+- [ ] With `--budget`, JSON carries additive `budget` + `over_budget`; `schema_version == 1` (FR-007/FR-008; SC-004).
+- [ ] Exit code 0 under any breach count; non-zero only for malformed input (FR-010/FR-011; SC-005).
+- [ ] Decision record present under `specs/009-consumption-subcommand/decisions/` (FR-014; SC-008).
+- [ ] `skills/fleet-budget-review/SKILL.md` documents `--budget` (FR-015).
+- [ ] No new dependency; `make ci` green (SC-006/SC-007).

--- a/specs/017-consumption-budget/research.md
+++ b/specs/017-consumption-budget/research.md
@@ -1,0 +1,130 @@
+# Phase 0 Research: Over-Budget Highlighting
+
+All open questions from the spec and the source issue (#129) are resolved below. No
+`NEEDS CLARIFICATION` markers remain in the Technical Context.
+
+## Decision 1 — Threshold unit: AIC (native), not derived USD
+
+**Decision**: The `--budget` ceiling is expressed in AI credits (AIC), compared against
+each row's `AIC` field.
+
+**Rationale**: AIC is the authoritative billing unit under the Copilot model; USD is a
+flat derivation (`aicToUSD` in `internal/fleet/consumption_logs.go`, rate `0.01`). The
+rollup already ranks the top-burners footer on AIC/cost, and the `AIC` column is the
+primary spend signal. A USD ceiling would just be `budget / aicToUSDRate` and adds a
+conversion surface for no behavioral gain. The issue explicitly recommends AIC.
+
+**Alternatives considered**: USD ceiling (`--budget` in dollars) — rejected as a redundant
+re-expression of the same number; deferred as a possible future `--budget-usd` if ever asked.
+
+## Decision 2 — Single global ceiling, not a per-axis map
+
+**Decision**: One global ceiling applied uniformly to every row of the active `--by` axis.
+
+**Rationale**: Per-key ceilings (e.g., a different ceiling per cost-center) multiply the
+flag surface and the validation/config story with no demonstrated demand. The issue
+recommends starting with a single global threshold. A per-axis map remains a clean future
+extension (it would read ceilings from `fleet.json`, a separate config-contract change).
+
+**Alternatives considered**: Per-axis threshold map keyed by group key — deferred (out of scope).
+
+## Decision 3 — Comparison semantics: strictly greater than
+
+**Decision**: A row is over budget iff its `AIC` is non-nil **and** `*AIC > budget`. Equal
+to the ceiling is within budget. A nil `AIC` (the all-or-nothing nil-merge case) is never
+over budget.
+
+**Rationale**: "Over budget" reads in plain language as *exceeding* the ceiling, not
+*reaching* it. The nil exclusion is forced by correctness — "exceeds an unknown value" is
+undefined, and `mergeFloat`'s all-or-nothing rule already yields nil for any group with a
+missing contributor (e.g., a repo whose runs all failed). Flagging nil would be a false
+positive and would also require a tri-state, which the boolean field deliberately avoids.
+
+**Alternatives considered**: `>=` (greater-or-equal) — rejected as surprising at the exact
+ceiling. Treating nil as over budget — rejected as a false positive.
+
+## Decision 4 — Flag plumbing: `Float64Var` + `Changed()` supplied-detection
+
+**Decision**: Declare `--budget` as a `cmd.Flags().Float64Var(&flags.budget, "budget", 0, ...)`
+and detect supplied-ness with `cmd.Flags().Changed("budget")`. When supplied, build a
+`*float64` and pass it to `ApplyBudget`; when not, pass `nil` (no annotation).
+
+**Rationale**: `0` is a *valid* ceiling ("flag every row with positive spend"), so the
+zero-value default cannot double as "unset". `Changed()` is cobra's idiomatic absent-vs-zero
+discriminator and mirrors the codebase's `*float64` "absent vs present-and-zero" pattern
+(`awInfoPayload.Cost`). Avoids a sentinel like `-1`.
+
+**Alternatives considered**: `Float64` flag with a `-1` sentinel — rejected as a magic value
+that collides with the negative-input validation path. `StringVar` parsed manually —
+rejected; `Float64Var` gives cobra-native parse errors for free, but see Decision 5 on
+where validation messages are surfaced.
+
+## Decision 5 — Input validation: negative rejected; non-numeric handled by cobra; zero accepted
+
+**Decision**: A negative ceiling is rejected in `runConsumption` with a clear error and a
+non-zero exit (and, in `--output json` mode, via `preResultFailureEnvelope`). A
+non-numeric value is rejected by cobra's `Float64Var` parser before `RunE` runs (standard
+cobra flag-parse error, non-zero exit). A zero ceiling is accepted and flags every row with
+strictly-positive AIC.
+
+**Rationale**: FR-011/FR-012 — malformed input is the *only* non-zero exit; it is categorically
+distinct from a budget breach, which never changes the exit code. Validating negativity in
+`runConsumption` (after `Changed()` detection, before/independent of aggregation) mirrors the
+existing `ParseGroupBy`/`buildFetchMode` validation placement and its jsonMode branching.
+
+**Alternatives considered**: Accepting negative as "flag everything" — rejected as nonsense
+input that almost certainly indicates operator error; an explicit error is friendlier.
+
+## Decision 6 — Apply point: pure post-aggregation pass `ApplyBudget`
+
+**Decision**: Add an exported `ApplyBudget(res *ConsumptionResult, budget *float64)` in
+`internal/fleet/consumption_budget.go` that, when `budget != nil`, sets `res.Budget = budget`,
+marks each `res.Groups[i].OverBudget` and each `res.TopBurners[i].OverBudget` by the
+Decision-3 rule, and is a no-op when `budget == nil`. `AggregateConsumption` is unchanged;
+`runConsumption` calls `ApplyBudget` on its result before rendering/enveloping.
+
+**Rationale**: FR-013 demands a pure function of the already-aggregated result — no new
+fetch, fully offline-testable. Keeping it out of `AggregateConsumption` preserves that
+function's signature and its network-bound test surface, and gives a tiny stateless unit
+under test. Annotating `TopBurners` (always workflow-keyed) as well as `Groups` satisfies
+the spec edge case that the footer not disagree with the body for a workflow appearing in both.
+
+**Alternatives considered**: Threading `budget` into `AggregateConsumption` — rejected; it
+would entangle the pure check with the network-bound aggregator and complicate its tests.
+A `cmd`-layer-only annotation — rejected; the JSON envelope (built in `cmd` from the
+`*ConsumptionResult`) needs the per-group boolean to be on the shared struct.
+
+## Decision 7 — Output surfaces: additive only
+
+**Decision**:
+- JSON: add `ConsumptionResult.Budget *float64 \`json:"budget,omitempty"\``,
+  `ConsumptionGroup.OverBudget *bool \`json:"over_budget,omitempty"\``, and
+  `WorkflowConsumption.OverBudget *bool \`json:"over_budget,omitempty"\``. `cmd.SchemaVersion` stays `1`.
+- Text: `renderConsumptionText` adds a trailing `OVER` column (value `!` for over-budget
+  rows, empty otherwise) to both the primary table and the top-burners footer — **only when
+  `res.Budget != nil`**. With no budget, output is byte-identical to today.
+
+**Rationale**: FR-006/FR-008 — opt-in, additive, no schema bump. `budget` and
+`over_budget` use `omitempty` so the envelope is unchanged when no ceiling is supplied.
+When a ceiling is supplied, `over_budget` is present on every row as true or false for
+predictable consumer parsing. A trailing column avoids disturbing existing column
+positions/alignment.
+
+**Alternatives considered**: Re-sorting over-budget rows to the top — deferred (spec
+Assumption: annotate in place; the rollup already orders by spend). A colorized marker —
+rejected; the tool emits plain tabwriter text, and color would not survive piping/JSON.
+
+## Decision 8 — Reconciliation decision record (FR-014)
+
+**Decision**: Add `specs/009-consumption-subcommand/decisions/0001-highlight-not-alarm.md`
+(a lightweight ADR) recording that read-only highlighting of operator-pulled output is
+distinct from alarming/enforcing, and that `--budget` stays on the highlight side of
+009's FR-023. Bundled in this feature's PR, not a separate blocking prerequisite.
+
+**Rationale**: The record's content is fully determined by this feature's read-only design,
+so there is nothing to learn by sequencing it first. A `decisions/` subfolder is the
+conventional home and keeps the amendment adjacent to the requirement it qualifies without
+rewriting 009's ratified spec text.
+
+**Alternatives considered**: Editing FR-023 in place — rejected; the requirement still holds
+(no enforcement), so amending its text would misrepresent history; an additive ADR is honest.

--- a/specs/017-consumption-budget/spec.md
+++ b/specs/017-consumption-budget/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Read-Only Over-Budget Highlighting in the Consumption Rollup
+
+**Feature Branch**: `017-consumption-budget`
+**Created**: 2026-06-22
+**Status**: Draft
+**Input**: User description: "feat(consumption): read-only over-budget highlighting in the rollup (--budget) — add an optional, read-only per-row AIC threshold to `gh-aw-fleet consumption` that highlights which rollup rows exceed a ceiling. Highlight, not enforce: no cap, no halt, no external alert, exit code unaffected by breaches. Additive `over_budget` JSON field, no schema bump. Tracks issue #129; reconciles with the 009 consumption spec's FR-023 (no alarm) via a decision record."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Flag over-threshold rows at a glance (Priority: P1)
+
+A fleet operator runs the consumption rollup every morning to watch spend. Today the output is an unannotated table; to find the rows that are running hot, the operator has to read every row and compare each value against a ceiling held in their head. With this feature, the operator supplies a single per-row budget ceiling, and the rollup marks every row whose consumption exceeds that ceiling — so the hotspots jump out of the table without manual scanning.
+
+**Why this priority**: This is the entire point of the feature — turning an unannotated table into one with an anomaly lens. Every other behavior (JSON field, sorting, footer annotation) layers on top of this core "mark the row" capability. If only this ships, the operator already gets the value: spend hotspots are visible at a glance.
+
+**Independent Test**: Run the rollup against a fixture fleet whose groups have known consumption values, pass a budget ceiling that sits between two of those values, and confirm that exactly the rows above the ceiling are marked and the rows at or below it are not.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fleet rollup where one group's consumption is above the supplied ceiling and another's is below it, **When** the operator runs the rollup with the budget ceiling, **Then** the over-ceiling group is visibly marked as over budget and the under-ceiling group is not.
+2. **Given** the same fleet, **When** the operator runs the rollup with no budget ceiling supplied, **Then** the output is byte-for-byte identical to the rollup's pre-feature behavior (no marker, no extra column).
+3. **Given** a budget ceiling equal to a group's exact consumption value, **When** the operator runs the rollup, **Then** that group is NOT marked (the threshold flags strictly-greater-than, not equal).
+
+---
+
+### User Story 2 - The threshold honors whichever grouping axis is active (Priority: P1)
+
+The rollup already pivots across four grouping axes (by repo, by profile, by cost center, by workflow). An operator who is reviewing spend by cost center wants the budget ceiling applied to the cost-center rows; an operator reviewing by repo wants it applied to repo rows. The ceiling must be a per-row check against whatever axis the operator is currently viewing, not a single hard-coded axis.
+
+**Why this priority**: P1 because a highlight that only worked on one axis would be a trap — the operator would silently get no annotation on three of four axes and misread that as "nothing is over budget." Correctness across all axes is part of the core promise, not an enhancement.
+
+**Independent Test**: For each of the four grouping axes, run the rollup with a fixed budget ceiling against a fixture whose per-axis aggregates straddle that ceiling, and confirm the correct rows are marked on every axis.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fleet grouped by cost center where one cost center's summed consumption exceeds the ceiling, **When** the operator runs the rollup by cost center with that ceiling, **Then** the over-ceiling cost-center row is marked.
+2. **Given** the same ceiling and a repo that participates in two profiles such that one profile's additive total exceeds the ceiling, **When** the operator runs the rollup by profile, **Then** the over-ceiling profile row is marked according to its additive total (consistent with the existing double-counting semantic).
+3. **Given** a fleet grouped by workflow, **When** the operator runs the rollup by workflow with a ceiling, **Then** the over-ceiling workflow rows are marked, including any that also appear in the top-burner footer block.
+
+---
+
+### User Story 3 - Machine-readable over-budget signal in JSON output (Priority: P2)
+
+An operator (or downstream automation) consuming the rollup's structured output wants the over-budget determination available as data, not just as a visual marker in the table — so a dashboard, a report generator, or a notebook can read which groups breached the ceiling and echo back the ceiling that was applied.
+
+**Why this priority**: P2 because the human-readable table (Stories 1–2) is already actionable on its own; the structured field is a useful additive surface for tooling but is not the entry point. It ships in the same slice because it reads the exact same per-group determination the table uses.
+
+**Independent Test**: Run the rollup in structured-output mode with a budget ceiling and confirm each group carries a boolean over-budget indicator matching the table, that the supplied ceiling is echoed in the envelope, and that the envelope's schema version is unchanged from the pre-feature value.
+
+**Acceptance Scenarios**:
+
+1. **Given** structured-output mode and a supplied ceiling, **When** the operator runs the rollup, **Then** every group in the structured output carries an over-budget boolean whose value matches the table marker for that group, and the envelope echoes the supplied ceiling.
+2. **Given** structured-output mode with no ceiling supplied, **When** the operator runs the rollup, **Then** the over-budget indicator and ceiling echo are omitted so the structured payload remains identical to the pre-feature behavior.
+3. **Given** any combination of ceiling and grouping axis, **When** the operator runs the rollup in structured-output mode, **Then** the envelope's schema version is identical to its pre-feature value (the field is additive).
+
+---
+
+### Edge Cases
+
+- **No data / nil consumption for a group**: A group whose consumption rolls up to an unknown value (e.g., a repo whose runs all failed, so the consumption metric is absent — the existing all-or-nothing nil-merge rule) MUST NOT be marked over budget. "Exceeds the ceiling" is undefined for an unknown value; the absence of data is not a breach. When a ceiling is supplied, such a group reports not-over-budget on both the table and the structured output.
+- **Zero-consumption group**: A group with a genuine consumption of zero is never over a non-negative ceiling and is never marked.
+- **Ceiling of zero**: A ceiling of zero is valid and flags every group with any positive consumption (strictly-greater-than zero). This is a legitimate "show me everything with any spend" mode, not an error.
+- **Negative ceiling**: A negative ceiling is invalid input. The command rejects it with a usage error and a non-zero exit code. This is input validation and is categorically different from a budget breach (see the read-only / exit-code requirement below) — a malformed flag value is an operator error, while an over-budget row is a normal observation.
+- **Non-numeric ceiling**: A ceiling that cannot be interpreted as a number is rejected with a usage error and a non-zero exit code.
+- **Ceiling supplied with an empty fleet / no groups**: The rollup produces its normal empty result; there are simply no rows to evaluate, and the command still exits successfully.
+- **Every row over budget**: All rows are marked; the command still exits successfully (a breach — even a fleet-wide one — never changes the exit code).
+- **Top-burner footer interaction**: The per-workflow top-burner footer block, when present, is annotated on the same consumption metric as the rows, so an operator does not see a workflow marked in the body but unmarked in the footer (or vice versa).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The consumption subcommand MUST accept an optional per-row budget ceiling input expressed in the rollup's native billing unit (the same unit the rollup already sums and displays).
+- **FR-002**: When a budget ceiling is supplied, the system MUST mark each output row whose aggregated consumption strictly exceeds the ceiling as "over budget," and MUST NOT mark rows whose consumption is equal to or below the ceiling.
+- **FR-003**: The over-budget determination MUST be applied to whichever grouping axis the operator has selected (repo, profile, cost center, or workflow), evaluating each row against the ceiling using that row's aggregated consumption for the active axis.
+- **FR-004**: For the profile grouping axis, the over-budget determination MUST use the same additive (double-counted) per-profile total the rollup already computes, so the highlight is consistent with the displayed value.
+- **FR-005**: When a budget ceiling is supplied, the human-readable output MUST visually distinguish over-budget rows from compliant rows (for example, a dedicated indicator column and/or an inline marker) such that an operator can identify breaching rows without comparing numbers by hand.
+- **FR-006**: When no budget ceiling is supplied, the human-readable output MUST be unchanged from its pre-feature form — no indicator column, no marker, no reordering.
+- **FR-007**: When a budget ceiling is supplied, the structured (machine-readable) output MUST carry, per group, an additive boolean indicating whether that group is over budget, and MUST echo the supplied ceiling at the envelope level so consumers can see the basis of the determination.
+- **FR-008**: The structured output's schema version MUST NOT change — every new field is additive, and any consumer that ignores the new fields MUST observe no behavioral change.
+- **FR-009**: A group whose aggregated consumption is unknown/absent (the existing nil-consumption case) MUST be treated as not over budget on every output surface.
+- **FR-010 (read-only / no enforcement)**: The feature MUST NOT cap, halt, gate, retry, or otherwise alter any fleet operation in response to a breach, and MUST NOT emit any external alert, notification, push, comment, or write of any kind. It only annotates the operator's own pulled output.
+- **FR-011 (exit code unaffected)**: The command's exit code MUST be independent of how many rows breach the ceiling — any number of over-budget rows (including all rows) still exits successfully. Only malformed input (e.g., a negative or non-numeric ceiling) produces a non-zero exit, and that is input validation, not breach enforcement.
+- **FR-012**: A ceiling of zero MUST be accepted and MUST flag every group with strictly-positive consumption; a negative or non-numeric ceiling MUST be rejected as invalid input with a clear, actionable message.
+- **FR-013**: The over-budget evaluation MUST be a pure function of the already-aggregated rollup result — it MUST NOT trigger any additional data fetch, network call, or external read beyond what the rollup already performs, and MUST remain fully exercisable offline against captured fixtures.
+- **FR-014 (reconciliation decision record)**: The project MUST record, under the existing consumption-subcommand specification, a short decision record that reconciles this feature with the prior requirement that the tool "MUST NOT enforce any spending cap, budget alarm, or hard limit." The record MUST articulate the distinction between *highlighting* (annotating read-only, operator-pulled output) and *alarming/enforcing* (pushing a signal outward or constraining behavior), and MUST affirm that this feature stays strictly on the highlight side of that line.
+- **FR-015**: Operator-facing guidance for the budget-review flow MUST document the new ceiling input, its unit, the strictly-greater-than semantics, the nil-consumption exclusion, and the explicit statement that the highlight does not enforce or alert.
+
+### Key Entities *(include if feature involves data)*
+
+- **Budget Ceiling**: A single optional per-row consumption threshold supplied by the operator at invocation time, expressed in the rollup's native billing unit. Global to the invocation (one ceiling applied to every row of the active axis), not a per-axis or per-key map. Echoed back in structured output so consumers can see what basis produced the determinations.
+- **Over-Budget Determination**: A per-group boolean derived purely from comparing the group's already-aggregated consumption against the supplied ceiling (strictly greater than → over budget; equal, below, or unknown → not over budget). When a ceiling is supplied, surfaced as a visual marker in human-readable output and as an additive boolean in structured output.
+- **Consumption Group** (existing): One row of the rollup, keyed by the active grouping axis. This feature reads its existing aggregated consumption value; it does not change how groups are formed, summed, or ordered.
+- **Result Envelope** (existing): The structured output container. When a ceiling is supplied, this feature adds the echoed ceiling and reads/propagates the per-group over-budget boolean, all additively, without altering the envelope's schema version.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator reviewing the rollup with a supplied ceiling can identify every over-budget row by the dedicated marker/column, with zero manual numeric comparison, on all four grouping axes.
+- **SC-002**: For every grouping axis, the set of rows marked over budget exactly equals the set of rows whose aggregated consumption strictly exceeds the supplied ceiling — verified by table-driven tests over captured fixtures, with no false positives (including the nil-consumption and equal-to-ceiling cases) and no false negatives.
+- **SC-003**: Running the rollup without a ceiling produces output identical to the pre-feature behavior in both human-readable and structured modes — confirming the feature is purely additive and opt-in.
+- **SC-004**: The structured output's schema version is unchanged after this feature ships; a consumer that ignores the new fields observes no difference.
+- **SC-005**: The command's exit status is invariant under the number of breaching rows — demonstrably 0 whether zero, some, or all rows are over budget — and is non-zero only for malformed ceiling input.
+- **SC-006**: The feature adds no new third-party runtime dependency and introduces no new network or disk interaction; all new logic is exercised offline against the existing fixtures.
+- **SC-007**: The full project quality gate (formatting, vetting, linting, and the complete test suite) passes cleanly with the new behavior and its fixtures included.
+- **SC-008**: A reader of the consumption-subcommand specification can locate a decision record that unambiguously distinguishes this highlight feature from budget enforcement/alarming and confirms it does not contradict the prior "no alarm" requirement.
+
+## Assumptions
+
+- **Single global ceiling, not a per-axis map**: The feature ships one global ceiling applied uniformly to every row of the active axis. Per-axis or per-key ceilings (e.g., a different ceiling per cost center) are a possible future enhancement but are out of scope here; the issue explicitly recommends starting with a single global threshold.
+- **Native billing unit, not a derived currency**: The ceiling is expressed in the rollup's native billing unit (the unit the rollup already sums and ranks on), because that is the authoritative unit and the displayed currency is a flat derivation of it. A currency-denominated ceiling, if ever desired, is a straightforward conversion of the native-unit ceiling and is not part of this slice.
+- **Rows are annotated in place; order is not changed**: Over-budget rows keep their existing position in the output rather than being re-sorted to the top. The rollup already orders rows by consumption, so the highest spenders — and thus the breaching rows — already cluster near the top; an explicit re-sort is deferred as an optional future refinement and is not required for the at-a-glance value. (The issue raises sort-to-top as an open question; in-place annotation is the chosen default.)
+- **Strictly-greater-than threshold semantics**: "Exceeds the ceiling" means strictly greater than the ceiling. A row exactly at the ceiling is within budget and is not marked. This matches the plain-language reading of "over budget."
+- **The decision record can land in the same change as the feature**: The reconciliation decision record under the consumption-subcommand spec is treated as part of this feature's deliverable rather than a separate blocking prerequisite, since the record's content (highlight ≠ alarm) is fully determined by this feature's read-only design. (The issue raises whether the amendment must block; bundling it is the chosen approach.)
+- **The nil-consumption rule is inherited, not redefined**: The existing all-or-nothing nil-merge behavior (a group with only failed runs rolls up to an unknown consumption value) is taken as-is; this feature only specifies that such a group is treated as not over budget.
+- **Read-only category is inherited**: This feature stays in the same pure-read category as the existing rollup — no mutation of any local or remote state, consistent with the consumption subcommand's existing read-only requirement.
+- **Documentation timing**: Operator-facing budget-review guidance is updated to describe the new ceiling input. If a separate drift fix to that guidance is in flight, this feature's documentation update is layered on top of the corrected baseline rather than forking it.
+
+## Out of Scope
+
+- Any form of enforcement: capping spend, halting or gating deploys/sync/upgrade, retrying, or constraining any fleet operation based on a breach.
+- Any external signal: alerts, notifications, pushes, comments, issues, or any write to a remote or local store in response to a breach.
+- Pre-spend forecasting / projection of future consumption (tracked separately).
+- Runtime cap-hit diagnostics that react to a platform cap being hit during a run (tracked separately).
+- Deploying or adopting an upstream cost-tracker workflow (a separate, intentionally-not-taken path).
+- Per-axis or per-key ceiling maps, currency-denominated ceilings, and re-sorting breaching rows to the top — all possible future enhancements, none required here.

--- a/specs/017-consumption-budget/tasks.md
+++ b/specs/017-consumption-budget/tasks.md
@@ -1,0 +1,207 @@
+# Tasks: Read-Only Over-Budget Highlighting in the Consumption Rollup
+
+**Input**: Design documents from `/specs/017-consumption-budget/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Required by the feature specification success criteria. Test tasks are listed before implementation tasks in each user-story phase.
+
+**Organization**: Tasks are grouped by user story so each increment can be implemented and validated independently.
+
+## Phase 1: Setup
+
+**Purpose**: Establish the exact implementation surface before editing.
+
+- [X] T001 Review the budget feature scope in `specs/017-consumption-budget/spec.md`, `specs/017-consumption-budget/plan.md`, and `specs/017-consumption-budget/research.md`
+- [X] T002 [P] Review existing consumption data structures and aggregation flow in `internal/fleet/consumption.go`
+- [X] T003 [P] Review existing consumption CLI flag, rendering, and validation patterns in `cmd/consumption.go` and `cmd/consumption_test.go`
+- [X] T004 [P] Review the operator budget-review guidance baseline in `skills/fleet-budget-review/SKILL.md`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Shared test scaffolding needed by all story phases.
+
+**Critical**: No user-story implementation should begin until these helpers exist.
+
+- [X] T005 Add shared float-pointer, bool-pointer, and minimal `ConsumptionResult` fixture helpers for budget tests in `internal/fleet/consumption_budget_test.go`
+- [X] T006 [P] Add a shared command/output-buffer helper for `renderConsumptionText` tests in `cmd/consumption_test.go`
+
+**Checkpoint**: Budget tests can be added without repeating fixture setup.
+
+---
+
+## Phase 3: User Story 1 - Flag Over-Threshold Rows at a Glance (Priority: P1) MVP
+
+**Goal**: `gh-aw-fleet consumption --budget <AIC>` marks primary table rows whose AIC strictly exceeds the supplied ceiling, while no-budget output remains unchanged.
+
+**Independent Test**: Run budget tests with rows above, below, equal to, and missing the ceiling value; confirm only rows with `AIC > budget` are marked and no `OVER` column appears when no budget was supplied.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Add `TestApplyBudget_StrictThreshold` covering above-ceiling, below-ceiling, equal-to-ceiling, nil-AIC, and zero-ceiling group rows in `internal/fleet/consumption_budget_test.go`
+- [X] T008 [P] [US1] Add `TestRenderConsumptionText_BudgetColumn` covering the primary table `OVER` column, `!` marker, empty compliant cells, and absent-budget output in `cmd/consumption_test.go`
+- [X] T009 [US1] Add `TestConsumption_BudgetFlagValidation` covering negative budget rejection, zero budget acceptance, and non-numeric cobra parse rejection in `cmd/consumption_test.go`
+- [X] T010 [US1] Add `TestConsumption_BudgetBreachesExitZero` covering zero, some, and all rows over budget with successful command exit in `cmd/consumption_test.go`
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Add `Budget *float64`, `ConsumptionGroup.OverBudget *bool`, and `WorkflowConsumption.OverBudget *bool` fields with godoc-compatible comments and `omitempty` JSON tags in `internal/fleet/consumption.go`
+- [X] T012 [US1] Implement `ApplyBudget(res *ConsumptionResult, budget *float64)` for primary `ConsumptionResult.Groups` rows using strict `AIC > budget` semantics in new `internal/fleet/consumption_budget.go`
+- [X] T013 [US1] Add the `--budget` cobra flag using `Float64Var` and `cmd.Flags().Changed("budget")` supplied-detection in `cmd/consumption.go`
+- [X] T014 [US1] Reject negative `--budget` values before config loading and pass a non-nil budget pointer to `fleet.ApplyBudget` after aggregation in `cmd/consumption.go`
+- [X] T015 [US1] Append the primary-table `OVER` header and per-group marker cells only when `res.Budget != nil` in `cmd/consumption.go`
+- [X] T016 [US1] Run targeted US1 validation for `internal/fleet/consumption_budget_test.go` and `cmd/consumption_test.go`
+
+**Checkpoint**: `--budget` works for the default repo table, no-budget text output stays unchanged, and malformed budget input fails as usage validation rather than breach enforcement.
+
+---
+
+## Phase 4: User Story 2 - Honor the Active Grouping Axis (Priority: P1)
+
+**Goal**: The budget threshold applies to whichever row set the active `--by` axis produced, including profile double-counting semantics and the top-burners footer.
+
+**Independent Test**: Run the rollup budget tests for repo, profile, cost-center, and workflow-shaped result rows plus top-burner rows; confirm the over-budget set matches each row's already-aggregated AIC.
+
+### Tests for User Story 2
+
+- [X] T017 [P] [US2] Add `TestApplyBudget_AllGroupingAxes` with repo, profile, cost-center, and workflow-shaped result fixtures in `internal/fleet/consumption_budget_test.go`
+- [X] T018 [US2] Add `TestApplyBudget_TopBurners` covering over, equal, below, and nil-AIC top-burner rows in `internal/fleet/consumption_budget_test.go`
+- [X] T019 [P] [US2] Add `TestRenderConsumptionText_TopBurnersBudgetColumn` covering the footer `OVER` header and marker cells in `cmd/consumption_test.go`
+
+### Implementation for User Story 2
+
+- [X] T020 [US2] Extend `ApplyBudget` to annotate `ConsumptionResult.TopBurners` using the same strict AIC comparison in `internal/fleet/consumption_budget.go`
+- [X] T021 [US2] Append the top-burners footer `OVER` header and per-workflow marker cells only when `res.Budget != nil` in `cmd/consumption.go`
+- [X] T022 [US2] Run targeted US2 validation for `internal/fleet/consumption_budget_test.go` and `cmd/consumption_test.go`
+
+**Checkpoint**: The threshold is a pure post-aggregation pass over the active axis and the footer cannot disagree with workflow rows.
+
+---
+
+## Phase 5: User Story 3 - Machine-Readable Over-Budget Signal (Priority: P2)
+
+**Goal**: JSON output exposes the same over-budget determination as data, echoes the supplied ceiling, and keeps the schema version unchanged.
+
+**Independent Test**: Marshal a budget-applied result and run JSON-mode validation; confirm `budget`, `over_budget`, and `schema_version` match the additive contract.
+
+### Tests for User Story 3
+
+- [X] T023 [P] [US3] Add `TestConsumptionResult_JSONBudgetFields` covering `budget,omitempty`, no-budget omission of `over_budget`, and present true/false group/top-burner `over_budget` fields when a budget is supplied in `internal/fleet/consumption_budget_test.go`
+- [X] T024 [P] [US3] Add `TestConsumption_JSONNegativeBudgetEnvelope` confirming JSON mode returns the standard pre-result failure envelope for negative `--budget` in `cmd/consumption_test.go`
+- [X] T025 [US3] Add `TestConsumption_SchemaVersionUnchangedForBudget` confirming `cmd.SchemaVersion` remains unchanged when budget fields are present in `cmd/consumption_test.go`
+
+### Implementation for User Story 3
+
+- [X] T026 [US3] Ensure `ConsumptionResult.Budget` uses `json:"budget,omitempty"` and both over-budget fields use `json:"over_budget,omitempty"` pointer tags in `internal/fleet/consumption.go`
+- [X] T027 [US3] Ensure `ApplyBudget(nil budget)` is a no-op and `ApplyBudget(non-nil budget)` sets `ConsumptionResult.Budget` plus per-row `OverBudget` pointers for envelope echoing in `internal/fleet/consumption_budget.go`
+- [X] T028 [US3] Keep `SchemaVersion` unchanged while writing annotated results through `writeEnvelope` in `cmd/output.go` and `cmd/consumption.go`
+- [X] T029 [US3] Run targeted US3 validation for `internal/fleet/consumption_budget_test.go`, `cmd/consumption_test.go`, and `cmd/output.go`
+
+**Checkpoint**: JSON consumers can read budget state additively, and consumers that ignore new fields keep working.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, governance, and local quality gate.
+
+- [X] T030 [P] Add the highlight-versus-alarm decision record in `specs/009-consumption-subcommand/decisions/0001-highlight-not-alarm.md`
+- [X] T031 [P] Update budget-review operator guidance for `--budget`, AIC units, strict comparison, nil-AIC exclusion, and no enforcement in `skills/fleet-budget-review/SKILL.md`
+- [X] T032 Run one realistic subagent test of `skills/fleet-budget-review/SKILL.md` with hard stops before destructive actions, and record the evidence in the implementation notes or PR body
+- [X] T033 [P] Validate quickstart examples and acceptance checks against the final CLI behavior in `specs/017-consumption-budget/quickstart.md`
+- [X] T034 Run `make fmt` and fix formatting in `internal/fleet/consumption.go`, `internal/fleet/consumption_budget.go`, `internal/fleet/consumption_budget_test.go`, `cmd/consumption.go`, and `cmd/consumption_test.go`
+- [X] T035 Run `make ci` and fix any gate failures in `internal/fleet/consumption.go`, `internal/fleet/consumption_budget.go`, `internal/fleet/consumption_budget_test.go`, `cmd/consumption.go`, `cmd/consumption_test.go`, `cmd/output.go`, and `skills/fleet-budget-review/SKILL.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks story test work.
+- **US1 (Phase 3)**: Depends on Foundational; provides the MVP table marker and CLI flag.
+- **US2 (Phase 4)**: Depends on US1's `ApplyBudget` and render plumbing; extends coverage to every axis and the top-burners footer.
+- **US3 (Phase 5)**: Depends on US1's fields and `ApplyBudget`; can run after US1, but should validate after US2 so top-burner JSON is covered too.
+- **Polish (Phase 6)**: Depends on the implemented story scope relevant to the docs and final gate.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Required MVP. No dependency on other stories after Foundational.
+- **US2 (P1)**: Depends on US1's core budget annotation but remains independently testable with prebuilt result fixtures for each axis.
+- **US3 (P2)**: Depends on US1's additive fields and budget echo; should be delivered after P1 behavior is stable.
+
+### Within Each User Story
+
+- Add tests first and confirm they fail for the missing behavior.
+- Add shared data fields before the pure `ApplyBudget` behavior that uses them.
+- Keep `ApplyBudget` in `internal/fleet/consumption_budget.go`; `internal/fleet/consumption.go` receives only the struct-field additions required by existing type definitions.
+- Wire CLI flag parsing before renderer changes that depend on `res.Budget`.
+- Keep breach detection independent from exit-code decisions; malformed input is the only non-zero path.
+
+---
+
+## Parallel Opportunities
+
+- T002, T003, and T004 can run in parallel during setup.
+- T005 and T006 touch different test files and can run in parallel.
+- T007 and T008 can run in parallel; T009 and T010 share `cmd/consumption_test.go` with T008 and should be sequenced by a single editor.
+- T017 and T019 can run in parallel; T018 shares `internal/fleet/consumption_budget_test.go` with T017 and should be sequenced by a single editor.
+- T023 and T024 can run in parallel; T025 shares `cmd/consumption_test.go` with T024 and should be sequenced by a single editor.
+- T030, T031, and T033 are documentation tasks in different files and can run in parallel; T032 must run after T031.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T007 [US1] Add TestApplyBudget_StrictThreshold in internal/fleet/consumption_budget_test.go"
+Task: "T008 [US1] Add TestRenderConsumptionText_BudgetColumn in cmd/consumption_test.go"
+```
+
+After those tests exist, sequence T009 and T010 with the same `cmd/consumption_test.go` editor, then implement T011 through T015 and run T016.
+
+---
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T017 [US2] Add TestApplyBudget_AllGroupingAxes in internal/fleet/consumption_budget_test.go"
+Task: "T019 [US2] Add TestRenderConsumptionText_TopBurnersBudgetColumn in cmd/consumption_test.go"
+```
+
+Sequence T018 after T017 because both edit `internal/fleet/consumption_budget_test.go`.
+
+---
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T023 [US3] Add TestConsumptionResult_JSONBudgetFields in internal/fleet/consumption_budget_test.go"
+Task: "T024 [US3] Add TestConsumption_JSONNegativeBudgetEnvelope in cmd/consumption_test.go"
+```
+
+Sequence T025 after T024 because both edit `cmd/consumption_test.go`.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1) with tests first.
+3. Validate strict greater-than behavior, nil-AIC exclusion, zero ceiling, negative input rejection, and no-budget table compatibility.
+4. Stop if only the MVP table highlight is needed.
+
+### Incremental Delivery
+
+1. Deliver US1 to make `--budget` useful for the default repo view.
+2. Add US2 so the same ceiling is correct for every `--by` axis and top-burner rows.
+3. Add US3 so downstream JSON consumers see the same determination and the budget echo.
+4. Finish Phase 6 docs, run the affected skill subagent test, and run the full local gate.
+
+### Single-Developer Sequence
+
+This feature touches `internal/fleet/consumption.go`, `internal/fleet/consumption_budget.go`, `internal/fleet/consumption_budget_test.go`, `cmd/consumption.go`, and `cmd/consumption_test.go` across all stories. A single developer should work in task order to avoid file conflicts, using only the marked documentation tasks for true parallel work.


### PR DESCRIPTION
## Summary

- Adds an optional `--budget <AIC>` flag to `gh-aw-fleet consumption` that marks every rollup row whose AI-credit total strictly exceeds the supplied ceiling, turning the unannotated table into an anomaly lens the operator can scan at a glance.
- Highlight, not enforcement: the ceiling never caps spend, halts a command, emits an external alert, or changes the exit code. Any number of breaching rows (including all of them) still exits 0; only a negative ceiling is a usage error.
- The check is per-row against whichever `--by` axis is active (repo, profile, cost-center, workflow) and also annotates the `TOP 10 BURNERS:` footer, so a marked row is correct on every axis and consistent with the existing multi-profile additive semantic.
- Strictly-greater-than threshold: a row equal to the ceiling is not marked, and nil-AIC rows (rendered `-`) are never marked.
- Wire contract stays additive — an absent flag yields byte-identical text output and no new JSON fields; `result.budget` and per-row `over_budget` appear only when a ceiling is supplied. No `cmd.SchemaVersion` or `fleet.SchemaVersion` bump.
- Records decision 0001 reconciling this highlight with the 009 consumption spec's FR-023 ("no alarm") — `--budget` is an operator-pulled display annotation, not the alarm FR-023 forbids.

## Test plan

- [x] `make fmt-check` passes
- [x] `make lint` passes with zero issues
- [x] `make test` passes (`go test ./cmd/... ./internal/fleet/...`)
- [x] `go build ./...` and `go vet ./...` pass
- [x] No-budget invocations verified byte-identical (no trailing column) via cmd render tests

## Changes

### New files

- `internal/fleet/consumption_budget.go` — `ApplyBudget` annotates the result in place with `over_budget` markers; no-op when the ceiling is nil to preserve pre-feature output.
- `internal/fleet/consumption_budget_test.go` — unit coverage for the strictly-greater-than rule, nil-AIC handling, and the nil-budget no-op.
- `specs/009-consumption-subcommand/decisions/0001-highlight-not-alarm.md` — decision record reconciling `--budget` with FR-023.
- `specs/017-consumption-budget/` — feature spec, plan, data model, research, contracts, checklist, and tasks.

### Modified files

- `cmd/consumption.go` — adds the `--budget` flag, `buildBudget` pointer translation, the `aggregateConsumption` test seam, the consolidated `consumptionFailure` helper, and the conditional `OVER` column in both the grouped table and the top-burners footer.
- `internal/fleet/consumption.go` — adds optional `Budget` to `ConsumptionResult` and `OverBudget` to `ConsumptionGroup` / `WorkflowConsumption`, all `omitempty` for additive JSON.
- `cmd/consumption_test.go` — cmd-level tests for `--budget` parsing (including the negative-value usage error), the trailing `OVER` column, and byte-identical no-budget output.
- `skills/fleet-budget-review/SKILL.md` — documents the `--budget` ceiling as a read-only threshold step, adds the threshold-question framing, and clarifies it is highlighting, not enforcement.
- `CLAUDE.md` — repoints the Spec Kit plan link to slice 017.

Closes #129