### PR TITLE
feat(security): add opt-in --strict gate for HIGH Layer 1 findings

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,37 +1,41 @@
 <!--
 SYNC IMPACT REPORT
-Version change: 1.1.0 -> 1.2.0
-Rationale: Adds `github.com/rshade/ax-go` as an approved direct dependency for
-the shared AX foundation phase-1 adoption. MINOR bump: material expansion of
-the Third-Party Dependencies approved list; no principle removed or redefined.
+Version change: 1.2.0 -> 1.3.0
+Rationale: Adds a documentation-currency obligation. MINOR bump: material
+expansion of Development Workflow guidance (a new conditional MUST rule for
+user-facing docs) plus the docs/ Starlight site added to the Governance
+Layering section. No principle removed or redefined.
 
 Modified principles: none (all four principles unchanged).
 
-Sections added:
-  - none
+Sections added: none.
 
 Sections modified:
-  - Third-Party Dependencies: approved `github.com/rshade/ax-go` with the
-    required three-alternatives rationale and import-isolation note.
+  - Development Workflow: new conditional MUST rule requiring `README.md` and
+    the docs/ Starlight site be updated in the same change that alters a
+    surface they document; internal-only changes are exempt; deliberately
+    hidden surfaces MUST NOT be documented; the assessment is recorded in each
+    plan.md Documentation Impact gate.
+  - Governance / Layering: docs/ Starlight site added alongside `README.md` as
+    a human-facing layer; precedence sentence updated to match.
 
 Sections removed: none.
 
 Templates requiring updates:
+  ✅ .specify/templates/plan-template.md — added a "Documentation Impact" gate
+     after Constitution Check, mirroring the new rule.
   ✅ .specify/templates/constitution-template.md — generic scaffold; no version-
      specific content to mirror.
-  ✅ .specify/templates/plan-template.md — Constitution Check slot is generic
-     ("Gates determined based on constitution file"); resolves to current
-     principles at plan time. No hardcoded references to update.
-  ✅ .specify/templates/spec-template.md — no constitution or dependency
-     references detected.
-  ✅ .specify/templates/tasks-template.md — no constitution or dependency
-     references detected.
+  ✅ .specify/templates/spec-template.md — no documentation-policy references;
+     no changes needed.
+  ✅ .specify/templates/tasks-template.md — no documentation-policy references;
+     no changes needed.
   ⚠ .specify/templates/commands/*.md — directory does not exist; nothing to
      audit.
-  ⚠ CLAUDE.md / AGENTS.md — update required in this phase to record ax-go,
-     the go directive bump, the import-isolation invariant, and deferred AX
-     follow-up phases.
-  ✅ README.md — no dependency-policy content; no changes needed.
+  ✅ CLAUDE.md / AGENTS.md — docs-currency is governance, not a new
+     architectural invariant or operational command; no update required.
+  ✅ README.md — the stale v0.1.0 status line was corrected separately; this
+     amendment needs no further README change.
 
 Follow-up TODOs: none.
 -->
@@ -112,6 +116,7 @@ Indirect (transitive) dependencies in `go.mod`'s second `require()` block are no
 - Proposed changes enter via PRs that include at minimum: `go build`/`go vet` clean, and for behavior changes, evidence from a dry-run or a subagent test of an affected skill.
 - The four skills in `skills/` MUST be updated when a command they reference gains or loses a flag, when a new failure class surfaces a new `CollectHints` pattern, or when the three-turn flow materially changes.
 - `CLAUDE.md` MUST be updated when a new architectural invariant is established (e.g., a new source repo added to `SourceLayout`, a new loader precedence rule).
+- User-facing documentation MUST be updated in the same change that alters a surface it documents: `README.md` and the `docs/` Starlight site when a command gains or loses a flag, a subcommand ships or changes behavior, install / configuration / reconcile / consumption guidance drifts, or the published release status changes. Internal-only changes (scanners, loaders, manifest logic) with no user-facing surface carry no documentation obligation. Deliberately hidden surfaces (e.g. the `__schema` command) MUST NOT be documented. Each feature's `plan.md` records this assessment in its **Documentation Impact** gate.
 - Release cadence is continuous on the tool's own `main` branch. Fleet deployments use tagged source refs (`v0.68.3` etc.) via `fleet.json`; this is independent of the tool's own versioning.
 - Complexity MUST be justified: added abstractions and new deny/allow entries in `.claude/settings.json` require a one-line rationale in the PR description. New direct dependencies require a constitution amendment per the **Third-Party Dependencies** section above — a one-line PR rationale is not sufficient.
 
@@ -129,10 +134,10 @@ Every PR that touches a principle-implicated file SHOULD note which principles a
 
 Layering:
 
-- `README.md` — audience: humans. Describes what the project does and how to run it.
+- `README.md` and the `docs/` Starlight site — audience: humans. Describe what the project does and how to run it.
 - `CLAUDE.md` — audience: AI agents working in this repo. Encodes the operational subset (commands, invariants, non-obvious patterns).
 - This constitution — audience: anyone proposing change. Cross-cutting policy, versioned, amendable.
 
-When the three disagree, the constitution wins, followed by CLAUDE.md, followed by README.md. Disagreements surface as amendment proposals.
+When these layers disagree, the constitution wins, followed by CLAUDE.md, followed by the human-facing docs (`README.md` and the `docs/` site). Disagreements surface as amendment proposals.
 
-**Version**: 1.2.0 | **Ratified**: 2026-04-18 | **Last Amended**: 2026-06-21
+**Version**: 1.3.0 | **Ratified**: 2026-04-18 | **Last Amended**: 2026-06-22

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -33,6 +33,14 @@
 
 [Gates determined based on constitution file]
 
+## Documentation Impact
+
+*GATE: Record which user-facing documentation surfaces this feature touches. Per the constitution's Development Workflow section, `README.md` and the `docs/` Starlight site MUST be updated in the same change that alters a surface they document. "None (internal-only)" is a valid, common answer.*
+
+- **Surfaces touched**: [e.g., README §Install, docs/configuration.md, docs/consumption.md — or "none (internal-only)"]
+- **Update planned**: [yes/no + one-line why; "no" is valid for internal-only changes]
+- **Hidden surfaces**: [any deliberately undocumented surface, e.g., the `__schema` command — or "none"]
+
 ## Project Structure
 
 ### Documentation (this feature)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Committed at repo root; shared with collaborators and subagents. Allows `go buil
 - N/A — pure read of a probed Renovate config in the work-dir clone; no on-disk state, no cache. Findings are transient on `DeployResult`/`SyncResult`/`UpgradeResult`. (012-renovate-conflict-scanner)
 - Go 1.26.4 local toolchain. + `gopkg.in/yaml.v3` (existing approved direct dep — YAML parse of the Dependabot config, already used by `internal/fleet/frontmatter`); stdlib `os`, `path/filepath`, `strings`. **No new third-party dependencies** (Constitution Principle I). (013-dependabot-conflict-scanner)
 - N/A — pure read of a probed Dependabot config in the work-dir clone; no on-disk state, no cache. Findings are transient on `DeployResult`/`SyncResult`/`UpgradeResult`. (013-dependabot-conflict-scanner)
+- Go 1.26.4 local toolchain; `go.mod` records the same floor. + Existing `github.com/spf13/cobra` v1.10.2 for flag wiring, existing `github.com/rs/zerolog` v1.x for stderr warnings, existing `internal/fleet/security`; stdlib `encoding/json`, `errors`, `fmt`, `os`, `path/filepath`, `strings`. No new third-party dependencies. (017-strict-security-gate)
+- No persistent config or cache. On strict abort only, write clone-root `findings.json` as a JSON array of all `security.Finding` values from that run; the file is a failure breadcrumb in the preserved work-dir clone. (017-strict-security-gate)
 
 ## Recent Changes
 - 016-ax-go-foundation: adopted `github.com/rshade/ax-go v0.2.0` the constitutional way; `internal/fleet/load.go` now uses import-isolated `config.ParseFile` / `config.Patch`, `cmd` exposes a hidden additive `__schema` command built on `schema.BuildSchema`/`schema.BuildMCPSchema` (mirroring `schema.NewSchemaCommand`, with MCP positional-argument augmentation), and `go.mod` now declares `go 1.26.4`. Import boundary is `config`/`schema`/`contract` only; no root `package ax`; `__schema`'s `error_envelope` is a phase-1 forward declaration.
@@ -125,5 +127,6 @@ Committed at repo root; shared with collaborators and subagents. Allows `go buil
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read
+[specs/017-strict-security-gate/plan.md](./specs/017-strict-security-gate/plan.md)
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation: <https://rshade.github.io/gh-aw-fleet/>
 
 ## Status
 
-Released as **v0.1.0** (April 2026). Pre-1.0: public surfaces (CLI flags,
+Pre-1.0 (see the latest-release badge above). Public surfaces (CLI flags,
 `fleet.json` schema) may still change before v1.0. The core reconcile loop
 (`deploy`, `sync`, `upgrade`, `add`) plus read-only drift detection
 (`status`) is functional. `template fetch` works but is still being

--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ Apply the deploy (commits, pushes, opens a PR in the target repo):
 gh-aw-fleet deploy acme/widgets --apply
 ```
 
+Fail a deploy dry-run or apply when the Layer 1 scanner reports HIGH findings:
+
+```bash
+gh-aw-fleet deploy acme/widgets --strict
+gh-aw-fleet deploy acme/widgets --strict --apply
+```
+
 Reconcile a repo (add missing workflows, flag unexpected ones):
 
 ```bash
@@ -349,9 +356,9 @@ gh-aw-fleet status -o json \
 | --- | --- |
 | `list` | List tracked repos and their resolved workflow sets |
 | `add <owner/repo>` | Add a repo to `fleet.local.json` (dry-run by default) |
-| `deploy <repo>` | Deploy the declared workflow set via `gh aw add` + PR |
-| `sync <repo>` | Reconcile to declared profile (add missing, flag drift) |
-| `upgrade [repo\|--all]` | Bump profile pins + run `gh aw upgrade` |
+| `deploy <repo>` | Deploy the declared workflow set via `gh aw add` + PR; `--strict` blocks HIGH Layer 1 security findings |
+| `sync <repo>` | Reconcile to declared profile (add missing, flag drift); `--strict` blocks HIGH Layer 1 security findings |
+| `upgrade [repo\|--all]` | Bump profile pins + run `gh aw upgrade`; `--strict` blocks HIGH Layer 1 security findings |
 | `consumption` | Fleet-wide AI-credit (AIC) rollup from `gh aw logs --json` (`--source logs`, default); group `--by repo\|profile\|cost-center\|workflow`, window `--latest\|--trailing Nd\|--since YYYY-MM-DD` |
 | `template fetch` | Refresh `templates.json` from gh-aw and agentics |
 | `status [repo]` | Diff desired vs actual workflow refs (read-only, no clones) |
@@ -588,6 +595,31 @@ Example `fleet.local.json` snippet:
 See [`specs/010-compile-strict-public/quickstart.md`](specs/010-compile-strict-public/quickstart.md)
 for the operator troubleshooting walkthrough.
 
+#### Security strict gate
+
+`deploy`, `sync`, and `upgrade` also accept `--strict`. This is a separate
+security gate, not the `compile_strict` config field above and not `gh aw
+compile --strict`. The flag is per invocation only and is never written to
+`fleet.json` or `fleet.local.json`.
+
+Without `--strict`, security findings remain advisory: they are emitted on
+stderr, included in JSON `warnings[]`, and added to PR bodies when a PR is
+created. With `--strict`, any HIGH Layer 1 finding blocks before commit, push, or
+PR creation. MEDIUM, LOW, INFO, and `promptinj:` findings remain advisory.
+
+Strict aborts write a clone-root `findings.json` containing every finding from
+that run and preserve the work-dir clone for inspection. The same gate applies
+to dry-runs, so CI can use commands such as:
+
+```bash
+gh-aw-fleet deploy acme/widgets --strict
+gh-aw-fleet sync acme/widgets --strict
+gh-aw-fleet upgrade --all --strict --output json
+```
+
+For `upgrade --all --strict --output json`, NDJSON records are emitted through
+the blocked repo and then processing stops at that first strict failure.
+
 ## Bundled Profiles
 
 Each entry below lists what the profile adds, who it's for, and the
@@ -658,6 +690,11 @@ never leaves a stale dispatcher/init layout behind.
 **Dry-run by default.** `deploy`, `sync`, and `upgrade` default to
 dry-run mode. Pass `--apply` to commit, push, and open PRs. This prevents
 surprises.
+
+**Security strict is opt-in.** Add `--strict` to `deploy`, `sync`, or `upgrade`
+when HIGH Layer 1 security findings should hard-stop the run before mutation.
+The failure preserves the clone and writes `findings.json` for post-mortem
+inspection.
 
 **Conventional Commits.** All generated commits follow the format
 `ci(workflows): <description>`, making them easy to filter from

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,17 +105,16 @@ and four docs items (#94 / #95 / #127 / #128).
 
 ### Observability / cross-repo wedge
 
-The free, local cross-repo health + cost + drift view — the validation wedge
-that proves demand for the hosted control plane (#146) before committing to it.
-Ship local first; the hosted plane becomes the obvious "I don't want to run
-this myself" upgrade.
+The local cross-repo health + cost + drift view. A separate hosted control
+plane (#146) consumes the same engine for org-wide observability; this CLI
+view ships standalone and locally first.
 
 - [ ] [#153](https://github.com/rshade/gh-aw-fleet/issues/153)
   `gh-aw-fleet overview` — unified cross-repo health + cost + drift view `[L]`
   `cost` `finops` `cross-repo`
   *One read-only dashboard joining run health (failures/success %), cost
   (AIC/USD), and drift per repo, reusing the `Status()` + `gh aw logs`
-  fan-outs. Ships free/local; validates EPIC #146. `unblocks: 146`.*
+  fan-outs. Ships standalone and locally; relates to EPIC #146. `unblocks: 146`.*
 - [ ] [#154](https://github.com/rshade/gh-aw-fleet/issues/154)
   `gh-aw-fleet debug [repo]` — aggregate failed agentic-run logs `[M]`
   `cross-repo`
@@ -401,7 +400,7 @@ ideas close the loop without becoming a daemon.
 Engine-side work to let a separate hosted control plane (`agentic-fleet.ai`,
 private repo `agentic-fleet/control-plane`) consume `gh-aw-fleet` — in-process
 via a public `pkg/` API, and by shelling out to the binary for deploys. The CLI
-stays the free, standalone OSS hook; the control plane is the org-wide
+stays standalone; the control plane is the org-wide
 observability / lifecycle layer. Long-horizon and strictly one-way (the engine
 never depends on the control plane). See `agentic-fleet/control-plane/docs/`.
 
@@ -411,11 +410,11 @@ never depends on the control plane). See `agentic-fleet/control-plane/docs/`.
 - [ ] [#141](https://github.com/rshade/gh-aw-fleet/issues/141) Extract a public
   `pkg/fleet` config API (model + load/merge) `[L]` `cross-repo`
   *Foundational — `internal/fleet` can't be imported across a module boundary;
-  unblocks #142 / #143 / #144.*
-- [ ] [#142](https://github.com/rshade/gh-aw-fleet/issues/142) Pluggable
+  unblocks #163 / #143 / #144.*
+- [ ] [#163](https://github.com/rshade/gh-aw-fleet/issues/163) Pluggable
   `ConfigSource`: `FileSource` (default) + `RemoteSource` + `--config-source`
   `[L]` `cross-repo`
-  *The PLG binding point — CLI can pull config from a remote control plane;
+  *The binding point — CLI can pull config from a remote control plane;
   vendor-neutral, local default. Depends on #141.*
 - [ ] [#143](https://github.com/rshade/gh-aw-fleet/issues/143) Version &
   document the remote fleet-config wire contract `[M]` `cross-repo` `spec-first`
@@ -428,7 +427,7 @@ never depends on the control plane). See `agentic-fleet/control-plane/docs/`.
   `deploy` / `sync` / `upgrade` for headless invocation by the control plane
   `[M]` `cross-repo`
   *Stable JSON envelopes, non-interactive, deterministic exit codes for the
-  shell-out path. Relates to #142.*
+  shell-out path. Relates to #163.*
 
   *Phase 1 (#156) of the broader `ax-go` adoption shipped 2026-06-22 — see
   Completed Milestones. Remaining ax-go phases (error-envelope adoption,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,18 +61,25 @@ changes) is exempt — the rule applies to feature-bearing releases.
 
 Latest tag is **v0.2.3** (2026-06-17), which shipped the supply-chain conflict
 scanners (#101 / #100, security) and the `ensureInit` drift fix (#98). Since
-v0.2.3, `main` has merged the cost-oriented trigger-risk lint (#104, cost) and
-the public `pkg/fleet` config-contract export (#148) — both now closed, awaiting
-the next release-please tag (see Completed Milestones). Immediate Focus holds the
-following pair, both carrying `roadmap/current`: the over-budget rollup highlight
-(#129, cost) and the security `--strict` promotion (#38, security — an #36 epic
-child, eligible since Layer 1 #37 shipped). They fill the next release's cost +
-security composition slots.
+v0.2.3, `main` has merged the cost-oriented trigger-risk lint (#104, cost), the
+public `pkg/fleet` config-contract export (#148), and the `ax-go` foundation
+phase 1 (#156) — all now closed, awaiting the next release-please tag (see
+Completed Milestones). Immediate Focus holds the following pair, both carrying
+`roadmap/current`: the over-budget rollup highlight (#129, cost) and the security
+`--strict` promotion (#38, security — an #36 epic child, eligible since the
+Layer 1 scanner #37 shipped). They fill the next release's cost + security
+composition slots.
 
-> `/roadmap sync` (2026-06-21) notes depth 2 > target 1 (single-WIP discipline).
+> `/roadmap sync` (2026-06-22) notes depth 2 > target 1 (single-WIP discipline).
 > Composition is balanced (cost #129 + security #38). No demotion recommended —
-> each item anchors a distinct required composition slot; demote toward
-> single-WIP once one of the pair lands.
+> each item anchors a distinct required composition slot, so demoting either
+> would re-open a required slot and bump the effective target back to 2. Demote
+> toward single-WIP once one of the pair lands.
+>
+> **Sequencing (operator, 2026-06-22)**: land `--strict` #38 (the smaller
+> security half) first; the cross-repo `overview` wedge #153 (cost) is the
+> designated promotion into Immediate Focus when #38 closes — it anchors the
+> next release's cost slot and unblocks the #154/#155 observability cluster.
 
 - [ ] [#129](https://github.com/rshade/gh-aw-fleet/issues/129) Read-only
   over-budget highlighting in the rollup (`--budget`) `[M]` `cost` `finops`
@@ -422,14 +429,11 @@ never depends on the control plane). See `agentic-fleet/control-plane/docs/`.
   `[M]` `cross-repo`
   *Stable JSON envelopes, non-interactive, deterministic exit codes for the
   shell-out path. Relates to #142.*
-- [ ] [#156](https://github.com/rshade/gh-aw-fleet/issues/156) Adopt `ax-go`
-  as the AX foundation — phase 1 (amend constitution + config primitives +
-  `__schema` discoverability) `[L]` `cross-repo` `spec-first`
-  *Adopt the portfolio's Agentic Experience foundation as the shared
-  output/error/config/logging substrate. Phase 1 = constitution amendment
-  (MINOR bump, like hujson #73) + `ax.ParseConfig`/`PatchConfig` swap in
-  `load.go` + net-new `__schema` discoverability. `unblocks: 145`. Multi-phase;
-  tracking epic optional.*
+
+  *Phase 1 (#156) of the broader `ax-go` adoption shipped 2026-06-22 — see
+  Completed Milestones. Remaining ax-go phases (error-envelope adoption,
+  `--output json` payload alignment, logger convergence, idempotency/mode/
+  dry-run context) are unscheduled; open them as work picks up.*
 
 ### Miscellaneous
 
@@ -464,6 +468,15 @@ were deferred at v1 to keep the initial command surface small.
 
 ### 2026-Q2
 
+- [x] [#156](https://github.com/rshade/gh-aw-fleet/issues/156) Adopt `ax-go` as
+  the AX foundation — phase 1 (amend constitution + config primitives +
+  `__schema` discoverability) `[L]` `cross-repo` `spec-first`
+  *Closed 2026-06-22 (PR #159). Adopted `github.com/rshade/ax-go v0.2.0` the
+  constitutional way: `internal/fleet/load.go` now parses/patches via
+  import-isolated `config.ParseFile` / `config.Patch`, `cmd` exposes a hidden
+  additive `__schema` command, and `go.mod` declares `go 1.26.4`. Import
+  boundary is `config`/`schema`/`contract` only. Remaining ax-go phases stay
+  unscheduled (see Control-plane enablement).*
 - [x] [#148](https://github.com/rshade/gh-aw-fleet/issues/148) Export fleet
   config contract into public `pkg/fleet` (types + SchemaVersion + JSON) —
   minimal first slice of #141 `[S]` `cross-repo`

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -10,6 +10,9 @@ import (
 	"github.com/rshade/gh-aw-fleet/internal/fleet"
 )
 
+//nolint:gochecknoglobals // test seam for command-level option propagation.
+var runFleetDeploy = fleet.Deploy
+
 func newDeployCmd(flagDir *string) *cobra.Command {
 	var (
 		flagApply   bool
@@ -17,6 +20,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 		flagBranch  string
 		flagPRTitle string
 		flagWorkDir string
+		flagStrict  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "deploy <repo>",
@@ -40,17 +44,18 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 				return notTrackedErr
 			}
 			opts := fleet.DeployOpts{
-				Apply:   flagApply,
-				Force:   flagForce,
-				Branch:  flagBranch,
-				PRTitle: flagPRTitle,
-				WorkDir: flagWorkDir,
+				Apply:    flagApply,
+				Force:    flagForce,
+				Branch:   flagBranch,
+				PRTitle:  flagPRTitle,
+				WorkDir:  flagWorkDir,
+				Security: fleet.SecurityOpts{Strict: flagStrict},
 			}
-			res, deployErr := fleet.Deploy(cmd.Context(), cfg, repo, opts)
+			res, deployErr := runFleetDeploy(cmd.Context(), cfg, repo, opts)
 			if jsonMode {
 				return emitDeployEnvelope(cmd, repo, flagApply, res, deployErr)
 			}
-			printDeploy(cmd, res, flagApply)
+			printDeploy(cmd, res, flagApply, deployErr)
 			return deployErr
 		},
 	}
@@ -64,10 +69,11 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 		"PR title (default: auto-generated)")
 	cmd.Flags().StringVar(&flagWorkDir, "work-dir", "",
 		"Existing clone to deploy into (skips git clone + auto-cleanup; resumes at commit/push gate if staged changes or unpushed commits exist)")
+	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
 	return cmd
 }
 
-func printDeploy(cmd *cobra.Command, res *fleet.DeployResult, apply bool) {
+func printDeploy(cmd *cobra.Command, res *fleet.DeployResult, apply bool, deployErr error) {
 	if res == nil {
 		return
 	}
@@ -115,7 +121,7 @@ func printDeploy(cmd *cobra.Command, res *fleet.DeployResult, apply bool) {
 			res.CompileStrictSource)
 	}
 	emitDeployWarnings(res)
-	if !apply {
+	if !apply && !fleet.IsStrictSecurityError(deployErr) {
 		fmt.Fprintln(w, "\nRe-run with --apply to commit, push, and open the PR.")
 	}
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -34,6 +34,9 @@ const (
 	commandUpgrade     = "upgrade"
 )
 
+// strictFlagUsage is the shared --strict help text for deploy, sync, and upgrade.
+const strictFlagUsage = "Fail when HIGH Layer 1 security findings are present (does not change gh aw compile --strict)"
+
 const (
 	diagnosticFieldRepo   = "repo"
 	diagnosticFieldSecret = "secret"

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -126,6 +126,34 @@ func TestSchemaCommandMCPIncludesPositionalArgs(t *testing.T) {
 	}
 }
 
+func TestSchemaCommandIncludesStrictFlags(t *testing.T) {
+	stdout, stderr, err := executeSchemaCommand("__schema")
+	if err != nil {
+		t.Fatalf("__schema returned error: %v\nstderr: %s", err, stderr)
+	}
+
+	var got axschema.Schema
+	if decodeErr := json.Unmarshal([]byte(stdout), &got); decodeErr != nil {
+		t.Fatalf("__schema stdout is not valid schema JSON: %v\nstdout: %s", decodeErr, stdout)
+	}
+
+	for _, use := range []string{"deploy <repo>", "sync <repo>", "upgrade [repo|--all]"} {
+		cmd := requireSchemaCommand(t, got.Command, use)
+		flag := requireSchemaFlag(t, cmd, "strict")
+		if flag.Type != "bool" {
+			t.Fatalf("%s --strict type = %q; want bool", use, flag.Type)
+		}
+		if flag.Default != "false" {
+			t.Fatalf("%s --strict default = %q; want false", use, flag.Default)
+		}
+		for _, want := range []string{"HIGH Layer 1 security findings", "does not change gh aw compile --strict"} {
+			if !strings.Contains(flag.Usage, want) {
+				t.Fatalf("%s --strict usage = %q; want substring %q", use, flag.Usage, want)
+			}
+		}
+	}
+}
+
 func TestSchemaCommandRejectsUnknownFormat(t *testing.T) {
 	_, _, err := executeSchemaCommand("__schema", "--as", "bogus")
 	if err == nil {
@@ -193,6 +221,28 @@ func requireMCPProperty(t *testing.T, tool axschema.MCPTool, name string) map[st
 		t.Fatalf("%s inputSchema.properties missing %q; properties=%v", tool.Name, name, properties)
 	}
 	return property
+}
+
+func requireSchemaCommand(t *testing.T, root axschema.CommandSchema, use string) axschema.CommandSchema {
+	t.Helper()
+	for _, cmd := range root.Commands {
+		if cmd.Use == use {
+			return cmd
+		}
+	}
+	t.Fatalf("__schema command tree missing %q", use)
+	return axschema.CommandSchema{}
+}
+
+func requireSchemaFlag(t *testing.T, cmd axschema.CommandSchema, name string) axschema.FlagSchema {
+	t.Helper()
+	for _, flag := range cmd.Flags {
+		if flag.Name == name {
+			return flag
+		}
+	}
+	t.Fatalf("%s missing flag %q", cmd.Use, name)
+	return axschema.FlagSchema{}
 }
 
 func assertMCPStringProperty(t *testing.T, toolName string, property map[string]any) {

--- a/cmd/strict_gate_test.go
+++ b/cmd/strict_gate_test.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+	logpkg "github.com/rshade/gh-aw-fleet/internal/log"
+	"github.com/rshade/gh-aw-fleet/internal/testutil"
+)
+
+func TestDeployStrictFlagPropagatesAndCleanNoOps(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetDeploy
+	t.Cleanup(func() { runFleetDeploy = orig })
+
+	var got []fleet.DeployOpts
+	runFleetDeploy = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.DeployOpts) (*fleet.DeployResult, error) {
+		got = append(got, opts)
+		return &fleet.DeployResult{Repo: repo, SecurityFindings: []security.Finding{}}, nil
+	}
+
+	if err := executeStandaloneCommand(newDeployCmd(&dir), "acme/widgets"); err != nil {
+		t.Fatalf("non-strict deploy error = %v", err)
+	}
+	if err := executeStandaloneCommand(newDeployCmd(&dir), "acme/widgets", "--strict"); err != nil {
+		t.Fatalf("strict deploy error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("deploy calls = %d; want 2", len(got))
+	}
+	if got[0].Security.Strict {
+		t.Fatal("non-strict deploy propagated Strict=true")
+	}
+	if !got[1].Security.Strict {
+		t.Fatal("strict deploy propagated Strict=false")
+	}
+}
+
+func TestSyncStrictFlagPropagates(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetSync
+	t.Cleanup(func() { runFleetSync = orig })
+
+	var got fleet.SyncOpts
+	runFleetSync = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.SyncOpts) (*fleet.SyncResult, error) {
+		got = opts
+		return &fleet.SyncResult{Repo: repo, SecurityFindings: []security.Finding{}}, nil
+	}
+
+	if err := executeStandaloneCommand(newSyncCmd(&dir), "acme/widgets", "--strict"); err != nil {
+		t.Fatalf("sync error = %v", err)
+	}
+	if !got.Security.Strict {
+		t.Fatal("sync propagated Strict=false")
+	}
+}
+
+func TestUpgradeStrictFlagPropagatesAndAuditAccepted(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetUpgrade
+	t.Cleanup(func() { runFleetUpgrade = orig })
+
+	var got fleet.UpgradeOpts
+	runFleetUpgrade = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.UpgradeOpts) (*fleet.UpgradeResult, error) {
+		got = opts
+		return &fleet.UpgradeResult{Repo: repo, AuditJSON: json.RawMessage(`{"issues":0}`)}, nil
+	}
+
+	if err := executeStandaloneCommand(newUpgradeCmd(&dir), "acme/widgets", "--audit", "--strict"); err != nil {
+		t.Fatalf("upgrade --audit --strict error = %v", err)
+	}
+	if !got.Audit {
+		t.Fatal("upgrade propagated Audit=false")
+	}
+	if !got.Security.Strict {
+		t.Fatal("upgrade propagated Strict=false")
+	}
+}
+
+func TestStrictFlagsAppearInHelp(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "deploy", cmd: newDeployCmd(&dir)},
+		{name: "sync", cmd: newSyncCmd(&dir)},
+		{name: "upgrade", cmd: newUpgradeCmd(&dir)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := tc.cmd.Flags().Lookup("strict")
+			if flag == nil {
+				t.Fatal("--strict flag missing")
+			}
+			for _, want := range []string{"HIGH Layer 1 security findings", "does not change gh aw compile --strict"} {
+				if !strings.Contains(flag.Usage, want) {
+					t.Fatalf("--strict usage = %q; want substring %q", flag.Usage, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeployAndSyncStrictEnvelopeIncludesFindingWarnings(t *testing.T) {
+	finding := strictCommandFinding()
+	strictErr := strictCommandError("x/y", finding)
+
+	t.Run("deploy", func(t *testing.T) {
+		cmd, stdout := envelopeCommandWithBuffer()
+		stderr := testutil.CaptureStderr(t, func() {
+			if err := logpkg.Configure("info", "json"); err != nil {
+				t.Fatal(err)
+			}
+			err := emitDeployEnvelope(
+				cmd,
+				"x/y",
+				false,
+				&fleet.DeployResult{Repo: "x/y", SecurityFindings: []security.Finding{finding}},
+				strictErr,
+			)
+			if !errors.Is(err, strictErr) {
+				t.Fatalf("emitDeployEnvelope error = %v; want %v", err, strictErr)
+			}
+		})
+		assertStrictEnvelopeWarning(t, stdout.Bytes(), stderr, finding.RuleID)
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		cmd, stdout := envelopeCommandWithBuffer()
+		stderr := testutil.CaptureStderr(t, func() {
+			if err := logpkg.Configure("info", "json"); err != nil {
+				t.Fatal(err)
+			}
+			err := emitSyncEnvelope(
+				cmd,
+				"x/y",
+				false,
+				&fleet.SyncResult{Repo: "x/y", SecurityFindings: []security.Finding{finding}},
+				strictErr,
+			)
+			if !errors.Is(err, strictErr) {
+				t.Fatalf("emitSyncEnvelope error = %v; want %v", err, strictErr)
+			}
+		})
+		assertStrictEnvelopeWarning(t, stdout.Bytes(), stderr, finding.RuleID)
+	})
+}
+
+func TestUpgradeStrictEnvelopeIncludesFindingWarnings(t *testing.T) {
+	finding := strictCommandFinding()
+	strictErr := strictCommandError("x/y", finding)
+	cmd, stdout := envelopeCommandWithBuffer()
+
+	stderr := testutil.CaptureStderr(t, func() {
+		if err := logpkg.Configure("info", "json"); err != nil {
+			t.Fatal(err)
+		}
+		err := emitUpgradeEnvelope(
+			cmd,
+			"x/y",
+			false,
+			&fleet.UpgradeResult{Repo: "x/y", SecurityFindings: []security.Finding{finding}},
+			strictErr,
+		)
+		if !errors.Is(err, strictErr) {
+			t.Fatalf("emitUpgradeEnvelope error = %v; want %v", err, strictErr)
+		}
+	})
+	assertStrictEnvelopeWarning(t, stdout.Bytes(), stderr, finding.RuleID)
+}
+
+func TestUpgradeAllJSONStrictStopsAfterBlockedRepo(t *testing.T) {
+	orig := runFleetUpgrade
+	t.Cleanup(func() { runFleetUpgrade = orig })
+
+	finding := strictCommandFinding()
+	strictErr := strictCommandError("a/blocked", finding)
+	var calls []string
+	runFleetUpgrade = func(_ context.Context, _ *fleet.Config, repo string, _ fleet.UpgradeOpts) (*fleet.UpgradeResult, error) {
+		calls = append(calls, repo)
+		if repo != "a/blocked" {
+			t.Fatalf("runFleetUpgrade called for %s after strict blocker", repo)
+		}
+		return &fleet.UpgradeResult{Repo: repo, SecurityFindings: []security.Finding{finding}}, strictErr
+	}
+
+	cfg := &fleet.Config{
+		Repos: map[string]fleet.RepoSpec{
+			"z/later":   {},
+			"a/blocked": {},
+		},
+	}
+	cmd, stdout := envelopeCommandWithBuffer()
+	err := runUpgradeAllJSON(cmd, cfg, fleet.UpgradeOpts{Security: fleet.SecurityOpts{Strict: true}}, false)
+	if !errors.Is(err, strictErr) {
+		t.Fatalf("runUpgradeAllJSON error = %v; want %v", err, strictErr)
+	}
+	if len(calls) != 1 || calls[0] != "a/blocked" {
+		t.Fatalf("calls = %v; want only a/blocked", calls)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("NDJSON lines = %d; want 1; output=%s", len(lines), stdout.String())
+	}
+	var env Envelope
+	if decodeErr := json.Unmarshal([]byte(lines[0]), &env); decodeErr != nil {
+		t.Fatalf("decode envelope: %v", decodeErr)
+	}
+	if env.Repo != "a/blocked" {
+		t.Fatalf("envelope repo = %q; want a/blocked", env.Repo)
+	}
+	if len(env.Warnings) != 1 || env.Warnings[0].Fields["rule_id"] != finding.RuleID {
+		t.Fatalf("warnings = %#v; want finding diagnostic", env.Warnings)
+	}
+}
+
+func writeStrictCommandConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := `{"version":1,"profiles":{"default":{"sources":{},"workflows":[]}},"repos":{"acme/widgets":{"profiles":["default"]}}}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "fleet.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write fleet.json: %v", err)
+	}
+	return dir
+}
+
+func executeStandaloneCommand(cmd *cobra.Command, args ...string) error {
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func envelopeCommandWithBuffer() (*cobra.Command, *bytes.Buffer) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd, &stdout
+}
+
+func strictCommandFinding() security.Finding {
+	return security.Finding{
+		RuleID:   "fleet.permissions.write-on-schedule",
+		Severity: security.SeverityHigh,
+		File:     ".github/workflows/test.md",
+		Line:     7,
+		Message:  "synthetic security finding",
+		Remedy:   "Fix the synthetic finding.",
+	}
+}
+
+func strictCommandError(repo string, finding security.Finding) *fleet.StrictSecurityError {
+	return &fleet.StrictSecurityError{
+		Repo:             repo,
+		BlockingCount:    1,
+		BlockingFindings: []security.Finding{finding},
+		BreadcrumbPath:   "/tmp/gh-aw-fleet-test/findings.json",
+	}
+}
+
+func assertStrictEnvelopeWarning(t *testing.T, stdout []byte, stderr, ruleID string) {
+	t.Helper()
+	if !strings.Contains(stderr, ruleID) {
+		t.Fatalf("stderr = %q; want rule ID %q", stderr, ruleID)
+	}
+	var env Envelope
+	if err := json.Unmarshal(stdout, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v; raw=%s", err, stdout)
+	}
+	if len(env.Warnings) != 1 {
+		t.Fatalf("len(warnings) = %d; want 1: %#v", len(env.Warnings), env.Warnings)
+	}
+	if env.Warnings[0].Fields["rule_id"] != ruleID {
+		t.Fatalf("warning rule_id = %v; want %s", env.Warnings[0].Fields["rule_id"], ruleID)
+	}
+	if len(env.Hints) != 1 || !strings.Contains(env.Hints[0].Message, "strict security gate") {
+		t.Fatalf("hints = %#v; want strict security gate failure hint", env.Hints)
+	}
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -12,12 +12,16 @@ import (
 	"github.com/rshade/gh-aw-fleet/internal/fleet"
 )
 
+//nolint:gochecknoglobals // test seam for command-level option propagation.
+var runFleetSync = fleet.Sync
+
 func newSyncCmd(flagDir *string) *cobra.Command {
 	var (
 		flagApply   bool
 		flagPrune   bool
 		flagForce   bool
 		flagWorkDir string
+		flagStrict  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "sync <repo>",
@@ -48,16 +52,17 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 				return notTrackedErr
 			}
 			opts := fleet.SyncOpts{
-				Apply:   flagApply,
-				Prune:   flagPrune,
-				Force:   flagForce,
-				WorkDir: flagWorkDir,
+				Apply:    flagApply,
+				Prune:    flagPrune,
+				Force:    flagForce,
+				WorkDir:  flagWorkDir,
+				Security: fleet.SecurityOpts{Strict: flagStrict},
 			}
-			res, syncErr := fleet.Sync(cmd.Context(), cfg, repo, opts)
+			res, syncErr := runFleetSync(cmd.Context(), cfg, repo, opts)
 			if jsonMode {
 				return emitSyncEnvelope(cmd, repo, flagApply, res, syncErr)
 			}
-			printSync(cmd, res, flagApply, flagPrune)
+			printSync(cmd, res, flagApply, flagPrune, syncErr)
 			return syncErr
 		},
 	}
@@ -69,10 +74,11 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 		"Overwrite existing workflow files (passes --force to gh aw add)")
 	cmd.Flags().StringVar(&flagWorkDir, "work-dir", "",
 		"Existing clone to sync (skips git clone + auto-cleanup)")
+	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
 	return cmd
 }
 
-func printSync(cmd *cobra.Command, res *fleet.SyncResult, apply, prune bool) {
+func printSync(cmd *cobra.Command, res *fleet.SyncResult, apply, prune bool, syncErr error) {
 	if res == nil {
 		return
 	}
@@ -95,7 +101,7 @@ func printSync(cmd *cobra.Command, res *fleet.SyncResult, apply, prune bool) {
 		fmt.Fprintln(w, "\n  Run with --prune --apply to remove drift workflows (this is destructive).")
 	}
 
-	if !apply {
+	if !apply && !fleet.IsStrictSecurityError(syncErr) {
 		fmt.Fprintln(w, "\nRe-run with --apply to add missing workflows and (with --prune) remove drift.")
 	}
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -12,6 +12,9 @@ import (
 	"github.com/rshade/gh-aw-fleet/internal/fleet"
 )
 
+//nolint:gochecknoglobals // test seam for command-level option propagation.
+var runFleetUpgrade = fleet.Upgrade
+
 func newUpgradeCmd(flagDir *string) *cobra.Command {
 	var (
 		flagApply   bool
@@ -20,6 +23,7 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 		flagForce   bool
 		flagWorkDir string
 		flagAll     bool
+		flagStrict  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "upgrade [repo|--all]",
@@ -48,11 +52,12 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 				return err
 			}
 			opts := fleet.UpgradeOpts{
-				Apply:   flagApply,
-				Audit:   flagAudit,
-				Major:   flagMajor,
-				Force:   flagForce,
-				WorkDir: flagWorkDir,
+				Apply:    flagApply,
+				Audit:    flagAudit,
+				Major:    flagMajor,
+				Force:    flagForce,
+				WorkDir:  flagWorkDir,
+				Security: fleet.SecurityOpts{Strict: flagStrict},
 			}
 			if flagAll {
 				return runUpgradeAll(cmd, cfg, opts, flagApply, flagAudit, jsonMode)
@@ -72,6 +77,7 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 		"Existing clone to upgrade in (skips git clone + auto-cleanup)")
 	cmd.Flags().BoolVar(&flagAll, "all", false,
 		"Upgrade all repos in fleet.json")
+	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
 	return cmd
 }
 
@@ -244,7 +250,7 @@ func runUpgradeSingle(
 		}
 		return notTrackedErr
 	}
-	res, upErr := fleet.Upgrade(cmd.Context(), cfg, repo, opts)
+	res, upErr := runFleetUpgrade(cmd.Context(), cfg, repo, opts)
 	if jsonMode {
 		return emitUpgradeEnvelope(cmd, repo, apply, res, upErr)
 	}
@@ -291,12 +297,15 @@ func runUpgradeAllJSON(cmd *cobra.Command, cfg *fleet.Config, opts fleet.Upgrade
 	}
 	sort.Strings(repos)
 	for _, repo := range repos {
-		res, upErr := fleet.Upgrade(cmd.Context(), cfg, repo, opts)
+		res, upErr := runFleetUpgrade(cmd.Context(), cfg, repo, opts)
 		if writeErr := emitUpgradeEnvelope(cmd, repo, apply, res, upErr); writeErr != nil && firstErr == nil {
 			firstErr = writeErr
 		}
 		if upErr != nil && firstErr == nil {
 			firstErr = upErr
+		}
+		if fleet.IsStrictSecurityError(upErr) {
+			break
 		}
 	}
 	return firstErr

--- a/docs/src/content/docs/reconcile.md
+++ b/docs/src/content/docs/reconcile.md
@@ -60,6 +60,27 @@ One asymmetry matters: `gh aw update` follows each workflow's own frontmatter
 workflows during `upgrade`; use `sync --apply --force` when you need installed
 workflow frontmatter to match current fleet refs.
 
+## Security strict gate
+
+`deploy`, `sync`, and `upgrade` accept `--strict` when HIGH Layer 1 security
+findings should block the run. The flag is opt-in per invocation and is not
+stored in `fleet.json` or `fleet.local.json`.
+
+This is different from `gh aw compile --strict`. Compile-strict validates
+generated GitHub Actions syntax and is controlled by `compile_strict` repo config.
+The `gh-aw-fleet --strict` gate consumes the existing security scanner findings.
+
+When the gate blocks:
+
+- findings are still emitted on stderr and in JSON `warnings[]`;
+- `findings.json` is written at the work-dir clone root;
+- the clone is preserved for inspection, including dry-run temp clones;
+- commit, push, and PR creation do not run.
+
+Lower-severity findings and `promptinj:` findings remain advisory. For
+`upgrade --all --strict --output json`, NDJSON records are emitted through the
+blocked repo and then processing stops.
+
 ## The three-turn pattern
 
 Any command that mutates external repositories follows this operator flow:
@@ -76,6 +97,10 @@ force-pushes or commits directly to `main`.
 Scratch clones under `/tmp/gh-aw-fleet-*` are preserved after an apply failure.
 Do not delete them while debugging. Re-run with `--work-dir <clone>` to resume an
 interrupted apply once the cause is fixed.
+
+Strict security aborts preserve clones even during dry-run and add
+`findings.json` to the clone root so the operator can inspect the exact scanner
+output that caused the block.
 
 ## Diagnostics
 

--- a/internal/fleet/constants.go
+++ b/internal/fleet/constants.go
@@ -4,6 +4,8 @@ const addToken = "add"
 
 const logsToken = "logs"
 
+const githubContentTypeFile = "file"
+
 const (
 	engineCopilot = "copilot"
 	engineClaude  = "claude"

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -40,9 +40,10 @@ type DeployOpts struct {
 	Force          bool // pass --force to gh aw add
 	Branch         string
 	PRTitle        string
-	WorkDir        string // if set, use this clone path; otherwise tmp.
-	InternalClone  bool   // WorkDir was prepared by this process; not a user resume request.
-	InitAlreadyRan bool   // caller already ran gh aw init on WorkDir during this operation.
+	WorkDir        string       // if set, use this clone path; otherwise tmp.
+	InternalClone  bool         // WorkDir was prepared by this process; not a user resume request.
+	InitAlreadyRan bool         // caller already ran gh aw init on WorkDir during this operation.
+	Security       SecurityOpts // security policy for this invocation.
 }
 
 // DeployResult aggregates what happened for a single-repo deploy.
@@ -225,9 +226,12 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 	if err != nil {
 		return res, err
 	}
-	if opts.WorkDir == "" && !opts.Apply {
-		defer os.RemoveAll(res.CloneDir)
-	}
+	cleanupClone := opts.WorkDir == "" && !opts.Apply
+	defer func() {
+		if cleanupClone {
+			_ = os.RemoveAll(res.CloneDir)
+		}
+	}()
 
 	if opts.WorkDir != "" && !opts.InternalClone {
 		resumed, handled, resumeErr := handleWorkDirResume(ctx, cfg, repo, res, opts)
@@ -268,6 +272,11 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 	res.ActionsDisabled, res.WorkflowTokenReadOnly = checkActionsSettings(ctx, repo)
 
 	res.SecurityFindings = security.Run(ctx, res.CloneDir)
+	if gateErr := evaluateStrictGatePreservingClone(
+		repo, res.CloneDir, opts.Security, res.SecurityFindings, &cleanupClone,
+	); gateErr != nil {
+		return res, gateErr
+	}
 
 	if !opts.Apply {
 		// Dry-run path: resolve and log the would-be policy without invoking

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -97,11 +97,12 @@ type DeployResult struct {
 	// result."
 	CompileStrictSource string `json:"compile_strict_source"`
 
-	// SecurityFindings is the sorted output of security.Run; nil when the
-	// scanner has not run (e.g. resume-from-work-dir paths that bypass
-	// addResolvedWorkflows). Findings are advisory: they never block the
-	// deploy. Surfaced on stderr (zerolog), in the JSON envelope
-	// warnings[], and in the PR body's `## Security Findings` section.
+	// SecurityFindings is the sorted output of security.Run; nil only when
+	// the scanner has not run. Findings are advisory by default but become
+	// blocking under the opt-in --strict gate (EvaluateStrictSecurityGate),
+	// which is evaluated on both the fresh and the --work-dir resume paths.
+	// Surfaced on stderr (zerolog), in the JSON envelope warnings[], and in
+	// the PR body's `## Security Findings` section.
 	SecurityFindings []security.Finding `json:"security_findings"`
 }
 
@@ -347,6 +348,20 @@ func handleWorkDirResume(
 				"omit --branch to resume on the existing branch",
 			opts.Branch, branch,
 		)
+	}
+
+	// Re-run the Layer 1 scanner before any resume mutation so --strict blocks
+	// a resumed run exactly as it does a fresh one. Without this, pointing
+	// --work-dir at a clone the gate just preserved would commit/push past the
+	// HIGH finding that aborted the original run. opts.WorkDir is non-empty on
+	// every resume, so the deferred cleanup is already disabled — the clone and
+	// its findings.json breadcrumb persist without the cleanup-flag dance the
+	// fresh tmp-clone path needs.
+	res.SecurityFindings = security.Run(ctx, res.CloneDir)
+	if gateErr := EvaluateStrictSecurityGate(
+		repo, res.CloneDir, opts.Security, res.SecurityFindings,
+	); gateErr != nil {
+		return res, true, gateErr
 	}
 
 	if staged {

--- a/internal/fleet/deploy_test.go
+++ b/internal/fleet/deploy_test.go
@@ -1680,6 +1680,64 @@ func TestDeployCommitGateResumeApply_WritesManifestBeforeCommit(t *testing.T) {
 	}
 }
 
+// TestDeployStrictResumeBlocksBeforeMutation proves the strict gate is enforced
+// on the --work-dir resume path, not just the fresh pipeline: resuming a clone
+// that carries a HIGH Layer 1 finding must abort before any compile or commit,
+// preserve the clone, and write the findings.json breadcrumb. Without the gate
+// in handleWorkDirResume, an operator could bypass --strict by re-pointing
+// --work-dir at the very clone the gate preserved.
+func TestDeployStrictResumeBlocksBeforeMutation(t *testing.T) {
+	dir := newTestRepo(t, func(d string) {
+		cmd := exec.Command("git", "checkout", "-b", "fleet/deploy-test")
+		cmd.Dir = d
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("create deploy branch: %v", err)
+		}
+		wf := filepath.Join(d, ".github", "workflows", "strict-high.md")
+		if err := os.MkdirAll(filepath.Dir(wf), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		content := "---\non:\n  schedule:\n    - cron: \"0 0 * * *\"\npermissions: write-all\n---\n"
+		if err := os.WriteFile(wf, []byte(content), 0o644); err != nil {
+			t.Fatalf("write workflow: %v", err)
+		}
+	})
+
+	// Any downstream compile seam firing means the gate did not abort first.
+	origStrict := runGhAwCompileStrict
+	origPlain := runGhAwCompile
+	t.Cleanup(func() {
+		runGhAwCompileStrict = origStrict
+		runGhAwCompile = origPlain
+	})
+	runGhAwCompileStrict = func(_ context.Context, _ string) (string, error) {
+		t.Fatal("runGhAwCompileStrict invoked; strict gate must abort the resume first")
+		return "", nil
+	}
+	runGhAwCompile = func(_ context.Context, _ string) (string, error) {
+		t.Fatal("runGhAwCompile invoked; strict gate must abort the resume first")
+		return "", nil
+	}
+
+	res := &DeployResult{Repo: "acme/widgets", CloneDir: dir}
+	_, handled, err := handleWorkDirResume(
+		context.Background(), strictGateTestConfig("acme/widgets"), "acme/widgets", res,
+		DeployOpts{Apply: true, WorkDir: dir, Security: SecurityOpts{Strict: true}},
+	)
+	if !handled {
+		t.Fatal("handled = false; want true (resume signal present)")
+	}
+	assertStrictSecurityError(t, err, "acme/widgets")
+	assertClonePreservedWithFindings(t, dir)
+	if !hasStrictHighFinding(res.SecurityFindings) {
+		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
+	}
+	if res.BranchPushed != "" || res.PRURL != "" {
+		t.Fatalf("BranchPushed/PRURL = %q/%q; want no mutation on strict resume abort",
+			res.BranchPushed, res.PRURL)
+	}
+}
+
 func TestDeployPushGateResumeApply_RefreshesCompileStrictBeforePush(t *testing.T) {
 	dir := newTestRepo(t, func(d string) {
 		cmd := exec.Command("git", "checkout", "-b", "fleet/deploy-test")

--- a/internal/fleet/fetch.go
+++ b/internal/fleet/fetch.go
@@ -117,7 +117,7 @@ func fetchSource(ctx context.Context, source string) (TemplateSource, FetchResul
 		name, _ := m["name"].(string)
 		path, _ := m["path"].(string)
 		sha, _ := m["sha"].(string)
-		if typ != "file" || !strings.HasSuffix(name, ".md") {
+		if typ != githubContentTypeFile || !strings.HasSuffix(name, ".md") {
 			continue
 		}
 		raw, rawErr := ghAPIRaw(ctx, fmt.Sprintf("/repos/%s/contents/%s?ref=%s", source, path, branchMain))

--- a/internal/fleet/security_gate.go
+++ b/internal/fleet/security_gate.go
@@ -1,0 +1,117 @@
+package fleet
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+)
+
+const promptInjectionRulePrefix = "promptinj:"
+
+// SecurityOpts controls invocation-scoped security policy.
+type SecurityOpts struct {
+	Strict bool // block on HIGH non-promptinj security findings
+}
+
+// StrictSecurityError is returned when the opt-in strict security gate blocks.
+type StrictSecurityError struct {
+	Repo               string             // repository owner/name being processed
+	BlockingCount      int                // number of blocking HIGH Layer 1 findings
+	BlockingFindings   []security.Finding // blocking HIGH non-promptinj findings
+	BreadcrumbPath     string             // path where findings.json was written or attempted
+	BreadcrumbWriteErr error              // write failure, when findings.json could not be saved
+}
+
+// Error returns the actionable strict security gate failure message.
+func (e *StrictSecurityError) Error() string {
+	if e == nil {
+		return ""
+	}
+	msg := fmt.Sprintf(
+		"strict security gate blocked %d HIGH Layer 1 finding(s) for %s; "+
+			"fix the findings or re-run without --strict to proceed advisory-only",
+		e.BlockingCount,
+		e.Repo,
+	)
+	if e.BreadcrumbPath == "" {
+		return msg
+	}
+	if e.BreadcrumbWriteErr != nil {
+		return fmt.Sprintf(
+			"%s (failed to save findings to %s: %v)",
+			msg,
+			e.BreadcrumbPath,
+			e.BreadcrumbWriteErr,
+		)
+	}
+	return fmt.Sprintf("%s (findings saved to %s)", msg, e.BreadcrumbPath)
+}
+
+// Unwrap returns the breadcrumb write error, when one occurred.
+func (e *StrictSecurityError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.BreadcrumbWriteErr
+}
+
+// BlockingSecurityFindings returns HIGH findings that strict mode treats as blockers.
+//
+// HIGH findings whose rule ID starts with "promptinj:" are intentionally
+// excluded: prompt-injection findings are Layer 3 advisory results, not Layer 1
+// blockers. The returned slice preserves the input order and does not mutate
+// the original findings.
+func BlockingSecurityFindings(findings []security.Finding) []security.Finding {
+	var blockers []security.Finding
+	for _, finding := range findings {
+		if finding.Severity != security.SeverityHigh {
+			continue
+		}
+		if strings.HasPrefix(finding.RuleID, promptInjectionRulePrefix) {
+			continue
+		}
+		blockers = append(blockers, finding)
+	}
+	return blockers
+}
+
+// EvaluateStrictSecurityGate writes a findings breadcrumb and returns an error when strict blocks.
+func EvaluateStrictSecurityGate(repo, cloneDir string, opts SecurityOpts, findings []security.Finding) error {
+	if !opts.Strict {
+		return nil
+	}
+	blockers := BlockingSecurityFindings(findings)
+	if len(blockers) == 0 {
+		return nil
+	}
+
+	breadcrumbPath := filepath.Join(cloneDir, "findings.json")
+	writeErr := writeJSON(breadcrumbPath, findings)
+	return &StrictSecurityError{
+		Repo:               repo,
+		BlockingCount:      len(blockers),
+		BlockingFindings:   blockers,
+		BreadcrumbPath:     breadcrumbPath,
+		BreadcrumbWriteErr: writeErr,
+	}
+}
+
+func evaluateStrictGatePreservingClone(
+	repo, cloneDir string,
+	opts SecurityOpts,
+	findings []security.Finding,
+	cleanupClone *bool,
+) error {
+	err := EvaluateStrictSecurityGate(repo, cloneDir, opts, findings)
+	preserveCloneForStrictError(err, cleanupClone)
+	return err
+}
+
+// IsStrictSecurityError reports whether err is (or wraps) a *StrictSecurityError.
+func IsStrictSecurityError(err error) bool {
+	var strictErr *StrictSecurityError
+	return errors.As(err, &strictErr)
+}

--- a/internal/fleet/security_gate_test.go
+++ b/internal/fleet/security_gate_test.go
@@ -1,0 +1,171 @@
+package fleet
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+)
+
+func TestEvaluateStrictSecurityGateDefaultAndNonBlocking(t *testing.T) {
+	high := testSecurityFinding("fleet.high", security.SeverityHigh)
+	lower := []security.Finding{
+		testSecurityFinding("fleet.info", security.SeverityInfo),
+		testSecurityFinding("fleet.low", security.SeverityLow),
+		testSecurityFinding("fleet.medium", security.SeverityMedium),
+	}
+
+	tests := []struct {
+		name     string
+		opts     SecurityOpts
+		findings []security.Finding
+	}{
+		{name: "default opts are advisory", findings: []security.Finding{high}},
+		{name: "strict clean proceeds", opts: SecurityOpts{Strict: true}, findings: []security.Finding{}},
+		{name: "strict lower severities proceed", opts: SecurityOpts{Strict: true}, findings: lower},
+		{
+			name:     "strict prompt injection high proceeds",
+			opts:     SecurityOpts{Strict: true},
+			findings: []security.Finding{testSecurityFinding("promptinj:indirect", security.SeverityHigh)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EvaluateStrictSecurityGate("acme/widgets", t.TempDir(), tt.opts, tt.findings)
+			if err != nil {
+				t.Fatalf("EvaluateStrictSecurityGate returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEvaluateStrictSecurityGateBlocksAndWritesBreadcrumb(t *testing.T) {
+	dir := t.TempDir()
+	findings := []security.Finding{
+		testSecurityFinding("fleet.permissions.write-on-schedule", security.SeverityHigh),
+		testSecurityFinding("fleet.safe-outputs.draft-false", security.SeverityMedium),
+	}
+
+	err := EvaluateStrictSecurityGate("acme/widgets", dir, SecurityOpts{Strict: true}, findings)
+	var strictErr *StrictSecurityError
+	if !errors.As(err, &strictErr) {
+		t.Fatalf("error = %T %[1]v; want *StrictSecurityError", err)
+	}
+	if strictErr.BlockingCount != 1 {
+		t.Fatalf("BlockingCount = %d; want 1", strictErr.BlockingCount)
+	}
+	if strictErr.Repo != "acme/widgets" {
+		t.Errorf("Repo = %q; want acme/widgets", strictErr.Repo)
+	}
+	if strictErr.BreadcrumbPath != filepath.Join(dir, "findings.json") {
+		t.Errorf("BreadcrumbPath = %q; want findings.json under clone", strictErr.BreadcrumbPath)
+	}
+	for _, want := range []string{"strict security gate", "1 HIGH", "acme/widgets", "without --strict", strictErr.BreadcrumbPath} {
+		if !strings.Contains(strictErr.Error(), want) {
+			t.Errorf("Error() missing %q: %s", want, strictErr.Error())
+		}
+	}
+
+	data, readErr := os.ReadFile(strictErr.BreadcrumbPath)
+	if readErr != nil {
+		t.Fatalf("read breadcrumb: %v", readErr)
+	}
+	var decoded []security.Finding
+	if decodeErr := json.Unmarshal(data, &decoded); decodeErr != nil {
+		t.Fatalf("decode breadcrumb: %v", decodeErr)
+	}
+	if !reflect.DeepEqual(decoded, findings) {
+		t.Fatalf("decoded findings = %#v; want %#v", decoded, findings)
+	}
+
+	var raw []map[string]any
+	if decodeErr := json.Unmarshal(data, &raw); decodeErr != nil {
+		t.Fatalf("decode raw breadcrumb: %v", decodeErr)
+	}
+	first := raw[0]
+	for _, key := range []string{"rule_id", "severity", "file", "line", "message", "remedy"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("breadcrumb finding missing JSON field %q: %#v", key, first)
+		}
+	}
+	if first["severity"] != float64(security.SeverityHigh) {
+		t.Errorf("severity = %v; want numeric %d", first["severity"], security.SeverityHigh)
+	}
+}
+
+func TestEvaluateStrictSecurityGatePreservesFindingOrderAndContent(t *testing.T) {
+	findings := []security.Finding{
+		testSecurityFinding("fleet.z", security.SeverityHigh),
+		testSecurityFinding("fleet.a", security.SeverityLow),
+		testSecurityFinding("fleet.m", security.SeverityHigh),
+	}
+	before := append([]security.Finding(nil), findings...)
+
+	err := EvaluateStrictSecurityGate("acme/widgets", t.TempDir(), SecurityOpts{Strict: true}, findings)
+	if err == nil {
+		t.Fatal("EvaluateStrictSecurityGate returned nil; want strict error")
+	}
+	if !reflect.DeepEqual(findings, before) {
+		t.Fatalf("findings mutated:\ngot  %#v\nwant %#v", findings, before)
+	}
+}
+
+func TestEvaluateStrictSecurityGateReportsBreadcrumbWriteFailure(t *testing.T) {
+	cloneFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(cloneFile, []byte("file\n"), 0o644); err != nil {
+		t.Fatalf("write cloneFile: %v", err)
+	}
+
+	err := EvaluateStrictSecurityGate(
+		"acme/widgets",
+		cloneFile,
+		SecurityOpts{Strict: true},
+		[]security.Finding{testSecurityFinding("fleet.high", security.SeverityHigh)},
+	)
+	var strictErr *StrictSecurityError
+	if !errors.As(err, &strictErr) {
+		t.Fatalf("error = %T %[1]v; want *StrictSecurityError", err)
+	}
+	if strictErr.BlockingCount != 1 {
+		t.Fatalf("BlockingCount = %d; want 1", strictErr.BlockingCount)
+	}
+	if errors.Unwrap(strictErr) == nil {
+		t.Fatal("Unwrap() = nil; want breadcrumb write error")
+	}
+	if !strings.Contains(strictErr.Error(), "failed to save findings") {
+		t.Fatalf("Error() = %q; want breadcrumb write failure", strictErr.Error())
+	}
+}
+
+func TestBlockingSecurityFindingsPromptInjectionCarveOut(t *testing.T) {
+	prompt := testSecurityFinding("promptinj:indirect", security.SeverityHigh)
+	layer1 := testSecurityFinding("fleet.permissions.write-on-schedule", security.SeverityHigh)
+
+	if got := BlockingSecurityFindings([]security.Finding{prompt}); len(got) != 0 {
+		t.Fatalf("promptinj-only blockers = %#v; want empty", got)
+	}
+	got := BlockingSecurityFindings([]security.Finding{prompt, layer1})
+	if len(got) != 1 {
+		t.Fatalf("mixed blockers = %#v; want one Layer 1 blocker", got)
+	}
+	if got[0].RuleID != layer1.RuleID {
+		t.Fatalf("blocker RuleID = %q; want %q", got[0].RuleID, layer1.RuleID)
+	}
+}
+
+func testSecurityFinding(ruleID string, severity security.Severity) security.Finding {
+	return security.Finding{
+		RuleID:   ruleID,
+		Severity: severity,
+		File:     ".github/workflows/test.md",
+		Line:     7,
+		Message:  "synthetic security finding",
+		Remedy:   "Fix the synthetic finding.",
+	}
+}

--- a/internal/fleet/status.go
+++ b/internal/fleet/status.go
@@ -144,7 +144,7 @@ func (ghStatusFetcher) listWorkflowsDir(ctx context.Context, repo string) ([]str
 		}
 		typ, _ := m["type"].(string)
 		name, _ := m["name"].(string)
-		if typ != "file" || !strings.HasSuffix(name, ".md") {
+		if typ != githubContentTypeFile || !strings.HasSuffix(name, ".md") {
 			continue
 		}
 		out = append(out, name)

--- a/internal/fleet/strict_gate_flow_test.go
+++ b/internal/fleet/strict_gate_flow_test.go
@@ -26,7 +26,7 @@ func TestDeployStrictDryRunPreservesTempClone(t *testing.T) {
 	assertStrictSecurityError(t, err, repo)
 	assertClonePreservedWithFindings(t, res.CloneDir)
 	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
-	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+	if !hasStrictHighFinding(res.SecurityFindings) {
 		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
 	}
 	if res.CompileStrictSource != "" {
@@ -74,7 +74,7 @@ func TestDeployNonStrictHighFindingRemainsAdvisory(t *testing.T) {
 		t.Fatal("Deploy returned no clone")
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
-	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+	if !hasStrictHighFinding(res.SecurityFindings) {
 		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
 	}
 	if _, statErr := os.Stat(filepath.Join(res.CloneDir, FleetManifestPath)); statErr != nil {
@@ -97,7 +97,7 @@ func TestSyncStrictDelegatedDeployBlocksAndPreservesClone(t *testing.T) {
 	if res.DeployPreflight == nil {
 		t.Fatal("DeployPreflight = nil; want delegated Deploy strict result")
 	}
-	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+	if !hasStrictHighFinding(res.SecurityFindings) {
 		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
 	}
 }
@@ -278,8 +278,8 @@ func assertClonePreservedWithFindings(t *testing.T, cloneDir string) {
 	}
 }
 
-func hasSecurityRule(findings []security.Finding, ruleID string) bool {
+func hasStrictHighFinding(findings []security.Finding) bool {
 	return slices.ContainsFunc(findings, func(finding security.Finding) bool {
-		return finding.RuleID == ruleID
+		return finding.RuleID == strictHighRuleID
 	})
 }

--- a/internal/fleet/strict_gate_flow_test.go
+++ b/internal/fleet/strict_gate_flow_test.go
@@ -1,0 +1,285 @@
+package fleet
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+)
+
+const strictHighRuleID = "fleet.permissions.write-on-schedule"
+
+func TestDeployStrictDryRunPreservesTempClone(t *testing.T) {
+	repo := "rshade/strict-deploy-dry-run"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+
+	res, err := Deploy(context.Background(), strictGateTestConfig(repo), repo, DeployOpts{
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	assertClonePreservedWithFindings(t, res.CloneDir)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
+	}
+	if res.CompileStrictSource != "" {
+		t.Fatalf("CompileStrictSource = %q; want empty because strict gate aborts first", res.CompileStrictSource)
+	}
+}
+
+func TestDeployStrictApplyBlocksBeforeManifestAndPR(t *testing.T) {
+	repo := "rshade/strict-deploy-apply"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	stubGhAwVersionForStrictTests(t)
+
+	res, err := Deploy(context.Background(), strictGateTestConfig(repo), repo, DeployOpts{
+		Apply:    true,
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	assertClonePreservedWithFindings(t, res.CloneDir)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if res.BranchPushed != "" || res.PRURL != "" {
+		t.Fatalf("BranchPushed/PRURL = %q/%q; want no mutation", res.BranchPushed, res.PRURL)
+	}
+	if _, statErr := os.Stat(filepath.Join(res.CloneDir, FleetManifestPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest stat err = %v; want absent because strict gate aborts before manifest", statErr)
+	}
+}
+
+func TestDeployNonStrictHighFindingRemainsAdvisory(t *testing.T) {
+	repo := "rshade/strict-deploy-advisory"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	stubGhAwVersionForStrictTests(t)
+
+	res, err := Deploy(context.Background(), strictGateTestConfig(repo), repo, DeployOpts{Apply: true})
+	if err == nil {
+		t.Fatal("Deploy returned nil error; want later PR creation failure proving advisory flow proceeded")
+	}
+	if !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("Deploy error = %v; want gh pr create after advisory finding", err)
+	}
+	if res == nil || res.CloneDir == "" {
+		t.Fatal("Deploy returned no clone")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
+	}
+	if _, statErr := os.Stat(filepath.Join(res.CloneDir, FleetManifestPath)); statErr != nil {
+		t.Fatalf("manifest missing; non-strict advisory flow should reach manifest write: %v", statErr)
+	}
+}
+
+func TestSyncStrictDelegatedDeployBlocksAndPreservesClone(t *testing.T) {
+	repo := "rshade/strict-sync-missing"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	assertClonePreservedWithFindings(t, res.CloneDir)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if res.DeployPreflight == nil {
+		t.Fatal("DeployPreflight = nil; want delegated Deploy strict result")
+	}
+	if !hasSecurityRule(res.SecurityFindings, strictHighRuleID) {
+		t.Fatalf("SecurityFindings = %#v; want %s", res.SecurityFindings, strictHighRuleID)
+	}
+}
+
+func TestSyncStrictPruneOnlyBlocksBeforePruneCommit(t *testing.T) {
+	repo := "rshade/strict-sync-prune"
+	remote := newTestRepo(t, func(dir string) {
+		seedDeclaredWorkflow(dir)
+		seedHighSecurityWorkflow(dir)
+	})
+	_ = installFakeGhForSync(t, remote)
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{
+		Apply:    true,
+		Prune:    true,
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if len(res.Pruned) != 0 {
+		t.Fatalf("Pruned = %v; want empty because strict gate runs before prune", res.Pruned)
+	}
+	if !slices.Contains(res.Drift, "strict-high") {
+		t.Fatalf("Drift = %v; want strict-high drift workflow", res.Drift)
+	}
+	if _, statErr := os.Stat(filepath.Join(res.CloneDir, ".github", "workflows", "strict-high.md")); statErr != nil {
+		t.Fatalf("strict-high workflow missing; strict gate should abort before prune: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(res.CloneDir, FleetManifestPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest stat err = %v; want absent because strict gate aborts before manifest", statErr)
+	}
+}
+
+func TestUpgradeStrictDryRunBlocksAndPreservesClone(t *testing.T) {
+	repo := "rshade/strict-upgrade-dry-run"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	installFakeGhForUpgrade(t, remote)
+
+	res, err := Upgrade(context.Background(), strictGateTestConfig(repo), repo, UpgradeOpts{
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	assertClonePreservedWithFindings(t, res.CloneDir)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if res.CompileStrictSource != "" || res.CompileStrictEffective || res.CompileStrictApplied {
+		t.Fatalf("compile-strict fields changed before strict abort: %#v", res)
+	}
+}
+
+func TestUpgradeStrictApplyBlocksBeforeManifestAndPR(t *testing.T) {
+	repo := "rshade/strict-upgrade-apply"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	installFakeGhForUpgrade(t, remote)
+	stubGhAwVersionForStrictTests(t)
+
+	res, err := Upgrade(context.Background(), strictGateTestConfig(repo), repo, UpgradeOpts{
+		Apply:    true,
+		Security: SecurityOpts{Strict: true},
+	})
+	assertStrictSecurityError(t, err, repo)
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if res.BranchPushed != "" || res.PRURL != "" {
+		t.Fatalf("BranchPushed/PRURL = %q/%q; want no mutation", res.BranchPushed, res.PRURL)
+	}
+	if _, statErr := os.Stat(filepath.Join(res.CloneDir, FleetManifestPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest stat err = %v; want absent because strict gate aborts before manifest", statErr)
+	}
+}
+
+func TestUpgradeAllStrictFailsFast(t *testing.T) {
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	installFakeGhForUpgrade(t, remote)
+	cfg := strictGateTestConfig("rshade/strict-upgrade-one")
+	cfg.Repos["rshade/strict-upgrade-two"] = RepoSpec{Profiles: []string{"default"}, CompileStrict: boolPtr(false)}
+
+	results, err := UpgradeAll(context.Background(), cfg, UpgradeOpts{Security: SecurityOpts{Strict: true}})
+	assertStrictSecurityError(t, err, "")
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d; want fail-fast after first strict blocker", len(results))
+	}
+	if results[0] != nil && results[0].CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(results[0].CloneDir) })
+	}
+}
+
+func strictGateTestConfig(repo string) *Config {
+	return &Config{
+		Version: SchemaVersion,
+		Profiles: map[string]Profile{
+			"default": {
+				Sources:   map[string]SourcePin{},
+				Workflows: []ProfileWorkflow{},
+			},
+		},
+		Repos: map[string]RepoSpec{
+			repo: {Profiles: []string{"default"}, CompileStrict: boolPtr(false)},
+		},
+	}
+}
+
+func strictGateMissingWorkflowConfig(repo string) *Config {
+	cfg := strictGateTestConfig(repo)
+	cfg.Profiles["default"] = Profile{
+		Sources: map[string]SourcePin{
+			"githubnext/agentics": {Ref: "v1.0.0"},
+		},
+		Workflows: []ProfileWorkflow{
+			{Name: "ci-doctor", Source: "githubnext/agentics"},
+		},
+	}
+	return cfg
+}
+
+func seedHighSecurityWorkflow(dir string) {
+	wf := filepath.Join(dir, ".github", "workflows", "strict-high.md")
+	if err := os.MkdirAll(filepath.Dir(wf), 0o755); err != nil {
+		panic(err)
+	}
+	content := `---
+on:
+  schedule:
+    - cron: "0 0 * * *"
+permissions: write-all
+---
+`
+	if err := os.WriteFile(wf, []byte(content), 0o644); err != nil {
+		panic(err)
+	}
+	gitInDir(dir, "add", ".github/workflows/strict-high.md")
+	gitInDir(dir, "commit", "-m", "seed strict high workflow")
+}
+
+func installHealthyDeployAPIs(t *testing.T, repo string) {
+	t.Helper()
+	withGhAPIJSON(t, map[string]fakeJSONResponse{
+		"/repos/" + repo + "/actions/permissions": {
+			body: map[string]any{"enabled": true},
+		},
+		"/repos/" + repo + "/actions/permissions/workflow": {
+			body: map[string]any{"default_workflow_permissions": "write"},
+		},
+	})
+}
+
+func stubGhAwVersionForStrictTests(t *testing.T) {
+	t.Helper()
+	origVersion := ghAwVersion
+	t.Cleanup(func() { ghAwVersion = origVersion })
+	ghAwVersion = func(_ context.Context) (string, error) {
+		return "v0.79.2", nil
+	}
+}
+
+func assertStrictSecurityError(t *testing.T, err error, repo string) {
+	t.Helper()
+	var strictErr *StrictSecurityError
+	if !errors.As(err, &strictErr) {
+		t.Fatalf("error = %T %[1]v; want *StrictSecurityError", err)
+	}
+	if strictErr.BlockingCount != 1 {
+		t.Fatalf("BlockingCount = %d; want 1", strictErr.BlockingCount)
+	}
+	if repo != "" && strictErr.Repo != repo {
+		t.Fatalf("Repo = %q; want %q", strictErr.Repo, repo)
+	}
+}
+
+func assertClonePreservedWithFindings(t *testing.T, cloneDir string) {
+	t.Helper()
+	if cloneDir == "" {
+		t.Fatal("CloneDir is empty")
+	}
+	if _, statErr := os.Stat(cloneDir); statErr != nil {
+		t.Fatalf("clone not preserved at %s: %v", cloneDir, statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(cloneDir, "findings.json")); statErr != nil {
+		t.Fatalf("findings.json missing in preserved clone: %v", statErr)
+	}
+}
+
+func hasSecurityRule(findings []security.Finding, ruleID string) bool {
+	return slices.ContainsFunc(findings, func(finding security.Finding) bool {
+		return finding.RuleID == ruleID
+	})
+}

--- a/internal/fleet/sync.go
+++ b/internal/fleet/sync.go
@@ -13,10 +13,11 @@ import (
 
 // SyncOpts controls sync behavior.
 type SyncOpts struct {
-	Apply   bool   // if true, call Deploy to add missing workflows
-	Prune   bool   // if true and Apply=true, delete drift files before Deploy
-	Force   bool   // passed through to Deploy
-	WorkDir string // optional existing clone
+	Apply    bool         // if true, call Deploy to add missing workflows
+	Prune    bool         // if true and Apply=true, delete drift files before Deploy
+	Force    bool         // passed through to Deploy
+	WorkDir  string       // optional existing clone.
+	Security SecurityOpts // security policy for this invocation.
 }
 
 // SyncResult aggregates what happened for a single-repo sync.
@@ -51,9 +52,12 @@ func Sync(ctx context.Context, cfg *Config, repo string, opts SyncOpts) (*SyncRe
 	if err != nil {
 		return res, err
 	}
-	if opts.WorkDir == "" && !opts.Apply {
-		defer os.RemoveAll(res.CloneDir)
-	}
+	cleanupClone := opts.WorkDir == "" && !opts.Apply
+	defer func() {
+		if cleanupClone {
+			_ = os.RemoveAll(res.CloneDir)
+		}
+	}()
 
 	fleetPin := resolvedGhAwPin(cfg, repo)
 	initRan, initErr := ensureInit(ctx, res.CloneDir, fleetPin)
@@ -68,20 +72,89 @@ func Sync(ctx context.Context, cfg *Config, repo string, opts SyncOpts) (*SyncRe
 		return res, errors.New("--prune requires --apply")
 	}
 
-	if opts.Apply {
-		if applyErr := applyDeployOrPrune(ctx, cfg, repo, res, opts, workflowsDir, initRan); applyErr != nil {
-			res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
-			return res, applyErr
-		}
-	} else if len(res.Missing) > 0 {
-		if preErr := runPreflight(ctx, cfg, repo, res, opts, initRan); preErr != nil {
-			res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
-			return res, preErr
-		}
+	if syncErr := runSyncActions(
+		ctx, cfg, repo, res, opts, workflowsDir, initRan, &cleanupClone,
+	); syncErr != nil {
+		return res, syncErr
 	}
 
-	res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
+	if res.SecurityFindings == nil {
+		res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
+	}
+	if gateErr := evaluateStrictGatePreservingClone(
+		repo, res.CloneDir, opts.Security, res.SecurityFindings, &cleanupClone,
+	); gateErr != nil {
+		return res, gateErr
+	}
 	return res, nil
+}
+
+func runSyncActions(
+	ctx context.Context,
+	cfg *Config,
+	repo string,
+	res *SyncResult,
+	opts SyncOpts,
+	workflowsDir string,
+	initRan bool,
+	cleanupClone *bool,
+) error {
+	if opts.Apply {
+		return runSyncApply(ctx, cfg, repo, res, opts, workflowsDir, initRan, cleanupClone)
+	}
+	if len(res.Missing) == 0 {
+		return nil
+	}
+	return runSyncPreflight(ctx, cfg, repo, res, opts, initRan, cleanupClone)
+}
+
+func runSyncApply(
+	ctx context.Context,
+	cfg *Config,
+	repo string,
+	res *SyncResult,
+	opts SyncOpts,
+	workflowsDir string,
+	initRan bool,
+	cleanupClone *bool,
+) error {
+	if len(res.Missing) == 0 {
+		res.SecurityFindings = security.Run(ctx, res.CloneDir)
+		if gateErr := evaluateStrictGatePreservingClone(
+			repo, res.CloneDir, opts.Security, res.SecurityFindings, cleanupClone,
+		); gateErr != nil {
+			return gateErr
+		}
+	}
+	if applyErr := applyDeployOrPrune(ctx, cfg, repo, res, opts, workflowsDir, initRan); applyErr != nil {
+		res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
+		preserveCloneForStrictError(applyErr, cleanupClone)
+		return applyErr
+	}
+	return nil
+}
+
+func runSyncPreflight(
+	ctx context.Context,
+	cfg *Config,
+	repo string,
+	res *SyncResult,
+	opts SyncOpts,
+	initRan bool,
+	cleanupClone *bool,
+) error {
+	if preErr := runPreflight(ctx, cfg, repo, res, opts, initRan); preErr != nil {
+		res.SecurityFindings = collectSyncSecurityFindings(ctx, res)
+		preserveCloneForStrictError(preErr, cleanupClone)
+		return preErr
+	}
+	return nil
+}
+
+func preserveCloneForStrictError(err error, cleanupClone *bool) {
+	if IsStrictSecurityError(err) && cleanupClone != nil {
+		*cleanupClone = false
+	}
 }
 
 // collectSyncSecurityFindings returns the security findings to surface on
@@ -159,6 +232,7 @@ func applyDeployOrPrune(
 			WorkDir:        res.CloneDir,
 			InternalClone:  opts.WorkDir == "",
 			InitAlreadyRan: initRan,
+			Security:       opts.Security,
 		}
 		var deployErr error
 		res.Deploy, deployErr = Deploy(ctx, cfg, repo, deployOpts)
@@ -214,6 +288,7 @@ func runPreflight(ctx context.Context, cfg *Config, repo string, res *SyncResult
 		WorkDir:        res.CloneDir,
 		InternalClone:  opts.WorkDir == "",
 		InitAlreadyRan: initRan,
+		Security:       opts.Security,
 	}
 	var err error
 	res.DeployPreflight, err = Deploy(ctx, cfg, repo, deployOpts)

--- a/internal/fleet/upgrade.go
+++ b/internal/fleet/upgrade.go
@@ -19,11 +19,12 @@ import (
 // runs `gh aw audit` instead of the upgrade pipeline; Major=true permits
 // major-version source bumps; Force=true passes through to `gh aw upgrade`.
 type UpgradeOpts struct {
-	Apply   bool
-	Audit   bool
-	Major   bool
-	Force   bool
-	WorkDir string
+	Apply    bool
+	Audit    bool
+	Major    bool
+	Force    bool
+	WorkDir  string       // optional existing clone.
+	Security SecurityOpts // security policy for this invocation.
 }
 
 // UpgradeResult aggregates what happened for a single-repo upgrade. OutputLog
@@ -102,9 +103,12 @@ func Upgrade(ctx context.Context, cfg *Config, repo string, opts UpgradeOpts) (*
 	if err != nil {
 		return res, err
 	}
-	if opts.WorkDir == "" && !opts.Apply {
-		defer os.RemoveAll(res.CloneDir)
-	}
+	cleanupClone := opts.WorkDir == "" && !opts.Apply
+	defer func() {
+		if cleanupClone {
+			_ = os.RemoveAll(res.CloneDir)
+		}
+	}()
 
 	if opts.Audit {
 		return runAudit(ctx, res)
@@ -139,19 +143,13 @@ func Upgrade(ctx context.Context, cfg *Config, repo string, opts UpgradeOpts) (*
 	}
 	res.ChangedFiles = changed
 	res.SecurityFindings = security.Run(ctx, res.CloneDir)
+	if gateErr := evaluateStrictGatePreservingClone(
+		repo, res.CloneDir, opts.Security, res.SecurityFindings, &cleanupClone,
+	); gateErr != nil {
+		return res, gateErr
+	}
 	if len(changed) == 0 {
-		if !opts.Apply {
-			res.NoChanges = true
-			return res, nil
-		}
-		manifestBackfilled, manifestErr := backfillUpgradeManifest(ctx, cfg, repo, res)
-		if manifestErr != nil {
-			return res, manifestErr
-		}
-		if !manifestBackfilled {
-			return res, nil
-		}
-		return createUpgradePR(ctx, res)
+		return finishNoChangeUpgrade(ctx, cfg, repo, res, opts)
 	}
 
 	if !opts.Apply {
@@ -175,6 +173,23 @@ func Upgrade(ctx context.Context, cfg *Config, repo string, opts UpgradeOpts) (*
 		return res, manifestErr
 	}
 
+	return createUpgradePR(ctx, res)
+}
+
+func finishNoChangeUpgrade(
+	ctx context.Context, cfg *Config, repo string, res *UpgradeResult, opts UpgradeOpts,
+) (*UpgradeResult, error) {
+	if !opts.Apply {
+		res.NoChanges = true
+		return res, nil
+	}
+	manifestBackfilled, manifestErr := backfillUpgradeManifest(ctx, cfg, repo, res)
+	if manifestErr != nil {
+		return res, manifestErr
+	}
+	if !manifestBackfilled {
+		return res, nil
+	}
 	return createUpgradePR(ctx, res)
 }
 

--- a/skills/fleet-deploy/SKILL.md
+++ b/skills/fleet-deploy/SKILL.md
@@ -21,14 +21,30 @@ Skip for:
 - Bumping workflow refs to latest — see `fleet-upgrade-review`.
 - Refreshing the upstream template catalog — see `fleet-eval-templates`.
 
-## Security findings (advisory)
+## Security findings
 
 The deploy pipeline now scans fetched workflow markdown for embedded
 credentials, fleet-structural anti-patterns, and (when actionlint is
 installed) compiled-YAML lint issues. Findings appear on stderr during
 dry-run and apply, and in a `## Security Findings` section in the opened
-PR body. Findings are advisory — they do not block the deploy. Review
-the section before merging the PR.
+PR body.
+
+By default, findings are advisory and do not block deploy or sync. When the user
+explicitly wants a hard gate, add `--strict` to the dry-run or apply command:
+
+```bash
+go run . deploy <owner>/<repo> --strict
+go run . deploy <owner>/<repo> --strict --apply
+go run . sync <owner>/<repo> --strict
+```
+
+`--strict` blocks HIGH Layer 1 findings before commit, push, or PR creation. It
+does not change `gh aw compile --strict`; that compile-strict policy is still
+reported separately as `compile-strict:`. MEDIUM, LOW, INFO, and `promptinj:`
+findings remain advisory. On a strict abort, the tool preserves the clone and
+writes `<clone>/findings.json` with every finding from the run. Report that path
+to the user and inspect it before deciding whether to fix the workflow or rerun
+without `--strict`.
 
 ## The flow
 
@@ -50,6 +66,12 @@ Then dry-run:
 go run . deploy <owner>/<repo>
 ```
 
+If the user asked for strict gating, dry-run with:
+
+```bash
+go run . deploy <owner>/<repo> --strict
+```
+
 The output includes (as applicable):
 
 - `gh aw init: ran (repo was not yet initialized)` — the target didn't have the dispatcher agent; init ran in the scratch clone.
@@ -57,6 +79,7 @@ The output includes (as applicable):
 - `skipped: N` — already-present workflows.
 - `failed: N` — each with a line or two of error text, followed by `hint: ...` lines surfaced by `fleet.CollectHints`.
 - On stderr (zerolog), exactly one `compile_strict_resolved` info event names the deploy-time compile-strict policy that will apply on `--apply`. Fields: `repo`, `effective` (bool), `source` (`explicit` | `auto-public` | `auto-private` | `auto-fallback`). When the resolver fell back to fail-secure on a visibility-lookup failure, an additional `compile_strict_lookup_failed` warn event names the truncated reason. Read these before approving — they signal whether `gh aw compile --strict` will run during `--apply`.
+- If `--strict` blocks, the command returns non-zero after rendering findings, preserves the clone, and writes `findings.json`. Do not proceed to Turn 2 unless the user chooses to fix the findings or intentionally rerun without `--strict`.
 
 **Init refresh**: The first deploy after a `github/gh-aw` pin advance (or for repos never fleet-deployed) will run `gh aw init` and produce a larger PR diff including init artifacts. Subsequent deploys at the same version skip init via manifest version comparison.
 
@@ -78,9 +101,16 @@ If the user edits fleet.json between turns (for a pin change or new exclude), re
 go run . deploy <owner>/<repo> --apply
 ```
 
+If Turn 1 used strict gating and the user approved applying with the same policy:
+
+```bash
+go run . deploy <owner>/<repo> --strict --apply
+```
+
 Expected outcomes:
 
 - **Clean success**: output ends with `PR: https://github.com/...`. Report the URL to the user; declare the deploy complete.
+- **Strict security abort**: output includes security findings, exits non-zero, writes `<clone>/findings.json`, and creates no PR. Report the blocking count, clone path, and breadcrumb path. Ask whether to fix the findings or rerun without `--strict`; do not auto-downgrade the policy.
 - **gpg signing failure**: exit status 1, output contains `gpg failed to sign the data` or `gpg: signing failed`. The tool preserves the clone dir (`/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>`) with all files staged on the deploy branch. Two recovery options exist:
   1. **Resume via `--work-dir`** (preferred): re-run `go run . deploy <owner>/<repo> --apply --work-dir <clone-dir>`. The tool detects the staged changes, skips clone/init/add, and re-enters at the commit gate.
   2. **Manual-finish paste**: compose the shell paste below for the user to run in their own terminal where gpg-agent can prompt. Use this when the user explicitly asks for manual steps or when `--work-dir` resume is not desired.

--- a/skills/fleet-upgrade-review/SKILL.md
+++ b/skills/fleet-upgrade-review/SKILL.md
@@ -76,6 +76,22 @@ If any repo needs attention, ask the user which to address first (or all, one at
 go run . upgrade <owner>/<repo>
 ```
 
+If the user wants HIGH Layer 1 security findings to fail the review, include
+`--strict`:
+
+```bash
+go run . upgrade <owner>/<repo> --strict
+go run . upgrade --all --strict
+go run . upgrade --all --strict --output json
+```
+
+This security gate is separate from `gh aw compile --strict`. It consumes the
+existing scanner findings and blocks before compile-strict, manifest, branch,
+commit, push, or PR steps. On strict abort, the clone is preserved and
+`<clone>/findings.json` contains every finding from the run. `upgrade --all
+--strict` stops at the first blocked repo; JSON mode emits the blocked repo's
+envelope before stopping.
+
 Dry-run output shows:
 - `gh aw upgrade` log (dispatcher updates, action bumps).
 - `gh aw update` log (per-workflow pulls, 3-way merges, compile results).
@@ -85,6 +101,7 @@ Dry-run output shows:
 
 Report everything to the user. Pay particular attention to:
 - **Compile failures** with hints — typical cause is upstream workflow using features the installed CLI doesn't know about. The hint usually says "pin to tagged release via `fleet sync --apply --force`."
+- **Strict security aborts** — HIGH Layer 1 findings block the run when `--strict` is present. Surface the finding warnings, preserved clone path, and `findings.json`; ask whether to fix findings or rerun without `--strict`.
 - **Conflicts** — files where local modifications collide with upstream changes. Do NOT proceed to `--apply`. Surface the conflict list, recommend opening the clone dir (preserved at `/tmp/gh-aw-fleet-...`) to resolve manually.
 - **No changes** — report "no-op, skip."
 
@@ -98,8 +115,15 @@ Same blast-radius rule as `fleet-deploy`: `--apply` pushes a branch and opens a 
 go run . upgrade <owner>/<repo> --apply
 ```
 
+If the approved dry-run used strict gating, keep the same policy:
+
+```bash
+go run . upgrade <owner>/<repo> --strict --apply
+```
+
 Outcomes match `fleet-deploy`:
 - **Clean success**: output ends with `PR: <url>`. Report the URL.
+- **Strict security abort**: no branch, commit, push, or PR is created. Report the clone path and `findings.json`; do not rerun without `--strict` unless the user explicitly chooses advisory-only behavior.
 - **gpg signing failure**: same failure mode; generate the manual-finish paste.
 - **Conflict (missed in dry-run)**: report, don't retry.
 
@@ -145,6 +169,7 @@ Same as `fleet-deploy`, repeated here because the skill will be invoked independ
 - **Never** run `git add`, `git commit`, `git push` from Claude Code's Bash tool.
 - **Never** bypass commit signing.
 - **Dry-run is the default**. Explicit user go-ahead before `--apply`.
+- **Strict security remains opt-in**. Only pass `--strict` when requested or when the operator flow explicitly requires HIGH Layer 1 findings to block.
 - **Conflicts block the pipeline** — do not proceed to `--apply` when `CONFLICTS:` appears. User resolves in the preserved clone, then re-runs `fleet upgrade <repo> --apply --work-dir <clone>` (the resume path is supported).
 - **Commit messages are commitlint-valid**. `ci(workflows)` scope.
 - **`--major`** is opt-in. Only pass it when the user explicitly requests major-version bumps (the dashboard flagged something requiring it).

--- a/specs/017-strict-security-gate/checklists/requirements.md
+++ b/specs/017-strict-security-gate/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: --strict security gate
+
+**Purpose**: Validate spec completeness and quality before planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec keeps the issue's `--strict` flag name and documents the compile-strict
+  naming-collision risk as an explicit assumption (FR-011 plus help/doc disambiguation)
+  rather than leaving it as an open clarification. If the operator wants a disambiguated
+  flag name, raise it during `/speckit-clarify` or `/speckit-plan`.
+- Multi-repo gate semantics are resolved against the codebase's existing fail-fast
+  `upgrade` loop (FR-010), so no clarification was required.
+- A few success criteria reference product-domain observables (exit status, PR creation,
+  `findings.json`). These are user-facing behaviors of a CLI tool, not implementation
+  internals, and are kept intentionally.

--- a/specs/017-strict-security-gate/contracts/strict-gate-contract.md
+++ b/specs/017-strict-security-gate/contracts/strict-gate-contract.md
@@ -1,0 +1,208 @@
+# Contract: Strict Security Gate
+
+This CLI has no network API. The strict gate contract is the user-visible CLI flag
+behavior plus the internal policy helper that prevents mutation when strict mode
+finds blocking Layer 1 findings.
+
+## C1 - CLI flags
+
+The following commands accept a new boolean flag:
+
+| Command | Flag | Default | Meaning |
+|---------|------|---------|---------|
+| `deploy <repo>` | `--strict` | false | Fail if HIGH Layer 1 security findings are present. |
+| `sync <repo>` | `--strict` | false | Fail if HIGH Layer 1 security findings are present. |
+| `upgrade [repo|--all]` | `--strict` | false | Fail if HIGH Layer 1 security findings are present. |
+
+Help text must disambiguate this from compile-strict. Suggested wording:
+
+```text
+Fail when HIGH Layer 1 security findings are present (does not change gh aw compile --strict)
+```
+
+No read-only commands (`list`, `status`, `consumption`) gain the flag.
+
+## C2 - Internal option propagation
+
+`cmd` must pass the flag into `internal/fleet`:
+
+```go
+type SecurityOpts struct {
+    Strict bool // block on HIGH non-promptinj security findings
+}
+
+type DeployOpts struct {
+    ...
+    Security SecurityOpts
+}
+
+type SyncOpts struct {
+    ...
+    Security SecurityOpts
+}
+
+type UpgradeOpts struct {
+    ...
+    Security SecurityOpts
+}
+```
+
+`Sync` must pass `opts.Security` into any delegated `Deploy` call.
+
+## C3 - Blocking predicate
+
+The gate blocks only when all conditions are true:
+
+```text
+SecurityOpts.Strict == true
+finding.Severity == security.SeverityHigh
+!strings.HasPrefix(finding.RuleID, "promptinj:")
+```
+
+Non-blocking cases:
+
+| Finding set | Strict result |
+|-------------|---------------|
+| Empty | proceed |
+| INFO/LOW/MEDIUM only | proceed |
+| HIGH `promptinj:*` only | proceed |
+| HIGH non-`promptinj:*`, strict false | proceed advisory-only |
+| HIGH non-`promptinj:*`, strict true | abort |
+
+The gate must not mutate the finding slice, sort order, severities, messages, or
+remedies.
+
+## C4 - Abort placement by command
+
+### `deploy`
+
+Order:
+
+```text
+prepare clone
+ensure gh aw init
+gh aw add / compile-added workaround
+preflight checks
+security.Run
+strict gate
+dry-run return OR apply compile/manifest/commit/push/PR
+```
+
+Strict abort occurs before `runCompileStrictIfNeeded`, manifest write, branch/stage,
+commit, push, and PR creation.
+
+### `sync`
+
+Order:
+
+```text
+prepare clone
+ensure gh aw init
+compute drift/missing
+if missing workflows:
+  delegate to Deploy with SecurityOpts
+else:
+  security.Run directly
+  strict gate
+  return dry-run OR prune/commit/push
+```
+
+Strict abort occurs before any prune commit/push. If delegated Deploy blocks, Sync
+propagates that strict error and preserves the same clone.
+
+### `upgrade`
+
+Order:
+
+```text
+prepare clone
+optional audit path (strict no-op)
+ensure gh aw init
+gh aw upgrade + update
+check conflicts
+get changed files
+security.Run
+strict gate
+no-change/dry-run return OR compile/manifest/commit/push/PR
+```
+
+Strict abort occurs before compile-strict, manifest write, branch/stage, commit,
+push, and PR creation.
+
+## C5 - Error contract
+
+When the gate blocks, return a typed error whose message contains:
+
+- the phrase `strict security gate`;
+- the blocking HIGH finding count;
+- the repo slug;
+- the unblock path: fix findings or re-run without `--strict`;
+- the `findings.json` path when written.
+
+Example:
+
+```text
+strict security gate blocked 2 HIGH Layer 1 findings for acme/widgets; fix the findings or re-run without --strict to proceed advisory-only (findings saved to /tmp/gh-aw-fleet-acme-widgets-123/findings.json)
+```
+
+The command must return non-zero after rendering existing output surfaces.
+
+## C6 - Findings rendering contract
+
+Strict mode must not suppress existing output. For a blocked run:
+
+- stderr contains one warning per finding via `emitSecurityFindingWarnings`;
+- JSON mode includes finding diagnostics in `warnings[]`;
+- text mode prints the normal command summary available in the result;
+- apply-mode PR body is not created because no PR is created.
+
+No `cmd.SchemaVersion` bump. No `fleet.SchemaVersion` bump.
+
+## C7 - Breadcrumb contract
+
+On strict abort:
+
+```text
+<clone>/findings.json
+```
+
+must exist and contain a JSON array of every finding from the run. The array uses the
+existing `security.Finding` JSON field names:
+
+```json
+[
+  {
+    "rule_id": "fleet.permissions.write-on-schedule",
+    "severity": 3,
+    "file": ".github/workflows/daily.md",
+    "line": 5,
+    "message": "Workflow has write permissions and a schedule trigger",
+    "remedy": "Restrict permissions to read-only or remove the schedule trigger."
+  }
+]
+```
+
+The clone must be preserved after strict abort, including dry-run temp clones that
+would otherwise be removed.
+
+## C8 - `upgrade --all` behavior
+
+Non-strict behavior remains unchanged.
+
+Strict behavior:
+
+- Text mode stops at the first repo whose gate blocks.
+- JSON mode emits complete per-repo envelopes through the blocked repo, then stops.
+- The blocked repo's envelope contains the normal result and warning diagnostics.
+- The command returns the strict error as the process error.
+
+This is a strict-only override of the non-strict NDJSON continue-after-error loop.
+
+## C9 - Non-contract / out of scope
+
+- No per-finding ignore file.
+- No config-level strict policy.
+- No MEDIUM/LOW promotion.
+- No prompt-injection classifier.
+- No scanner rule content changes.
+- No compile-strict behavior changes.

--- a/specs/017-strict-security-gate/data-model.md
+++ b/specs/017-strict-security-gate/data-model.md
@@ -1,0 +1,151 @@
+# Phase 1 Data Model: Strict Security Gate
+
+This feature introduces no persistent fleet configuration and no new scanner output
+type. It adds invocation-level options and one transient strict gate decision that
+consumes existing `security.Finding` values.
+
+## Entity 1 - Security options
+
+`SecurityOpts` is an invocation-scoped grouping carried by `DeployOpts`, `SyncOpts`,
+and `UpgradeOpts`.
+
+| Field | Type | Validation | Notes |
+|-------|------|------------|-------|
+| `Strict` | `bool` | default false | When true, HIGH non-`promptinj:` findings block before mutation. |
+
+Relationships:
+
+- `DeployOpts.Security SecurityOpts`
+- `SyncOpts.Security SecurityOpts`
+- `UpgradeOpts.Security SecurityOpts`
+
+Rules:
+
+- Must not be read from or written to `fleet.json` / `fleet.local.json`.
+- Must not alter scanner execution or finding content.
+- Must not alter compile-strict resolution fields (`CompileStrictApplied`,
+  `CompileStrictEffective`, `CompileStrictSource`).
+
+## Entity 2 - Security finding (existing)
+
+The gate consumes the existing `security.Finding` type:
+
+| Field | Gate use |
+|-------|----------|
+| `RuleID` | Exempt when prefixed with `promptinj:`. |
+| `Severity` | Blocks only when `SeverityHigh`. |
+| `File` | Copied into `findings.json`; useful for operator inspection. |
+| `Line` | Copied into `findings.json`; useful for operator inspection. |
+| `Message` | Rendered by existing stderr/JSON surfaces and copied into breadcrumb. |
+| `Remedy` | Rendered by existing stderr/JSON surfaces and copied into breadcrumb. |
+
+Blocking predicate:
+
+```text
+Severity == HIGH AND RuleID does not start with "promptinj:"
+```
+
+Validation:
+
+- One blocking finding is sufficient.
+- MEDIUM, LOW, and INFO never block.
+- HIGH `promptinj:` findings never block.
+- The full finding set and ordering must remain exactly what `security.Run` returns.
+
+## Entity 3 - Strict gate decision
+
+A per-repo evaluation performed after scanner output is available.
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `Strict` | `bool` | `SecurityOpts.Strict` | False means always proceed. |
+| `Findings` | `[]security.Finding` | command result | All findings from current run. |
+| `BlockingFindings` | `[]security.Finding` | derived | HIGH non-`promptinj:` findings. |
+| `BreadcrumbPath` | `string` | derived from clone dir | `<clone>/findings.json` when blocked. |
+| `Outcome` | enum-like | derived | `proceed` or `abort`. |
+
+State flow:
+
+```text
+scanner did not run
+  -> findings nil
+  -> no strict decision possible; proceed
+
+scanner ran clean
+  -> findings []
+  -> blocking []
+  -> proceed
+
+scanner returned lower-severity findings only
+  -> blocking []
+  -> proceed
+
+scanner returned HIGH promptinj findings only
+  -> blocking []
+  -> proceed
+
+scanner returned >=1 HIGH non-promptinj finding and strict=false
+  -> advisory only
+  -> proceed
+
+scanner returned >=1 HIGH non-promptinj finding and strict=true
+  -> write findings.json
+  -> preserve clone
+  -> abort with StrictSecurityError
+```
+
+## Entity 4 - Strict security error
+
+A typed error returned when the gate blocks.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `Repo` | `string` | yes | Owner/name for actionable output. |
+| `BlockingCount` | `int` | yes | Must be >=1. |
+| `BlockingFindings` | `[]security.Finding` | yes | High non-`promptinj:` findings only. |
+| `BreadcrumbPath` | `string` | yes | Path to written `findings.json`. |
+
+Error message contract:
+
+```text
+strict security gate blocked <N> HIGH Layer 1 finding(s) for <repo>; fix the findings or re-run without --strict to proceed advisory-only (findings saved to <path>)
+```
+
+Validation:
+
+- Must include blocking count.
+- Must include unblock path: fix findings or re-run without `--strict`.
+- Must include breadcrumb path when the file was written.
+- Must wrap or clearly report breadcrumb write failures without hiding the blocking
+  count.
+
+## Entity 5 - Findings breadcrumb
+
+`findings.json` is a transient failure artifact written at the clone root when
+strict blocks.
+
+| Attribute | Value |
+|-----------|-------|
+| Path | `<clone>/findings.json` |
+| Format | JSON array |
+| Element type | existing `security.Finding` JSON shape |
+| Contents | all findings from the run, not just blockers |
+| Lifetime | preserved with the work-dir clone after strict abort |
+
+Example:
+
+```json
+[
+  {
+    "rule_id": "gitleaks:aws-access-key",
+    "severity": 3,
+    "file": ".github/workflows/daily-scan.md",
+    "line": 12,
+    "message": "AWS Access Key (<redacted>)",
+    "remedy": "Rotate the credential. Remove from source. Use the engine.env / GitHub Actions secrets mechanism to inject at runtime."
+  }
+]
+```
+
+Note: `Severity` currently marshals as its numeric typed-int value in the existing
+`Finding` JSON shape. The feature does not change that representation.

--- a/specs/017-strict-security-gate/plan.md
+++ b/specs/017-strict-security-gate/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Strict Security Gate
+
+**Branch**: `017-strict-security-gate` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/017-strict-security-gate/spec.md`
+
+## Summary
+
+Add an opt-in `--strict` flag to `deploy`, `sync`, and `upgrade` that promotes
+HIGH-severity Layer 1 security findings from advisory warnings to blocking
+failures. The existing scanner remains unchanged: strict mode consumes the same
+`security.Finding` slice already surfaced on stderr, in JSON `warnings[]`, and in
+PR bodies. When strict mode finds at least one blocking HIGH finding, the command
+writes all findings to `findings.json` at the work-dir clone root, preserves the
+clone for inspection, returns a non-zero actionable error, and stops before any
+commit, push, or PR creation.
+
+The implementation is a small policy layer around the existing scanner output:
+add a `SecurityOpts` grouping to `DeployOpts`, `SyncOpts`, and `UpgradeOpts`; add
+the Cobra `--strict` flag to the three commands; add a shared strict-gate helper
+that counts `SeverityHigh` findings excluding `promptinj:` rule IDs; and call the
+helper immediately after `security.Run` populates the result and before any
+mutation gate. No scanner rules, finding ordering, output schema versions, or
+compile-strict behavior change.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.4 local toolchain; `go.mod` records the same floor.  
+**Primary Dependencies**: Existing `github.com/spf13/cobra` v1.10.2 for flag wiring, existing `github.com/rs/zerolog` v1.x for stderr warnings, existing `internal/fleet/security`; stdlib `encoding/json`, `errors`, `fmt`, `os`, `path/filepath`, `strings`. No new third-party dependencies.  
+**Storage**: No persistent config or cache. On strict abort only, write clone-root `findings.json` as a JSON array of all `security.Finding` values from that run; the file is a failure breadcrumb in the preserved work-dir clone.  
+**Testing**: Unit tests for the strict predicate, prompt-injection carve-out, breadcrumb writer, command flag propagation, JSON/text warning behavior, and `deploy`/`sync`/`upgrade` abort placement using existing seams and temp dirs. Full gate: `make ci` (fmt-check, vet, lint, test).  
+**Target Platform**: Linux / macOS developer and CI environments running the `gh-aw-fleet` CLI.  
+**Project Type**: Single Go module CLI orchestrator (`cmd/` plus `internal/fleet/...`).  
+**Performance Goals**: Negligible overhead beyond the scanner that already runs. Strict evaluation is O(number of findings); breadcrumb write is one small local JSON write on failure. No network fanout and no extra scanner pass.  
+**Constraints**: Strict is opt-in per invocation only; never persisted to `fleet.json` / `fleet.local.json`; gate fires in dry-run and apply; abort occurs before commit/push/PR; findings are rendered before the command returns the strict error; HIGH `promptinj:` findings remain advisory; `cmd.SchemaVersion` and `fleet.SchemaVersion` do not change; `--strict` does not affect `gh aw compile --strict` resolution.  
+**Scale/Scope**: Per-repo gate over typical fleets of <=10 repos and <=20 workflows each. `upgrade --all --strict` processes repos serially and stops at the first blocked repo, preserving the blocked clone.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against Constitution v1.3.0.
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| **I. Thin-Orchestrator Code Quality** | PASS | The feature does not rewrite workflow markdown and does not re-implement scanner detection. It adds a small policy decision over the existing `security.Finding` slice and one JSON breadcrumb writer. Existing upstream orchestration (`gh aw`, `git`, `gh`) remains delegated. New exported identifiers (`SecurityOpts`, strict error type if exported) require godoc. |
+| **II. Testing Standards** | PASS | The gate is pure enough for focused unit tests, and command paths can be covered without live PR creation by using existing seams and dry-run mode. Before implementation is complete, `make ci` is required. Any live `--apply` validation remains subject to explicit user approval. |
+| **III. User Experience Consistency** | PASS | Dry-run remains the default. In apply mode strict aborts before branch/commit/push/PR, preserving the three-turn mutation pattern. The abort message is actionable and findings are still emitted on the existing stderr/JSON surfaces before the error is returned. |
+| **IV. Performance Requirements** | PASS | The gate adds one in-memory scan over findings and, only on failure, one local JSON write. No new network calls, no cache invalidation, and no parallelism concerns. |
+| **Declarative Reconcile Invariants** | PASS | Strict is invocation state, not fleet state. The feature does not mutate `fleet.json` / `fleet.local.json`, does not bypass signing, and does not introduce any direct operator git commands. |
+| **Third-Party Dependencies** | PASS | No new direct dependency. The implementation uses stdlib JSON/file APIs and existing project packages. |
+| **Documentation Impact** | PASS | User-facing CLI flags are added, so README and the Starlight reconcile docs must be updated. Operator skills that show deploy/upgrade flows should mention the strict option. |
+
+**Result**: All gates pass. No Complexity Tracking entries required.
+
+## Documentation Impact
+
+- **Surfaces touched**: Cobra help for `deploy`, `sync`, and `upgrade`; `README.md` reconcile/quickstart usage; `docs/src/content/docs/reconcile.md`; `skills/fleet-deploy/SKILL.md`; `skills/fleet-upgrade-review/SKILL.md`.
+- **Update planned**: yes. The feature adds visible CLI flags and changes failure behavior when those flags are present, so human-facing docs and operator skill flows must explain strict versus compile-strict and the `findings.json` breadcrumb.
+- **Hidden surfaces**: none. `__schema` will expose the new flags through the existing hidden schema generator automatically; it remains deliberately undocumented.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-strict-security-gate/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── strict-gate-contract.md
+└── tasks.md             # Phase 2 output (/speckit-tasks, not created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── deploy.go              # add --strict flag; pass SecurityOpts into fleet.Deploy
+├── deploy_test.go         # flag/help and strict error surface coverage
+├── sync.go                # add --strict flag; pass SecurityOpts into fleet.Sync
+├── sync_test.go           # sync strict propagation and warning coverage
+├── upgrade.go             # add --strict flag; pass SecurityOpts into fleet.Upgrade/UpgradeAll
+├── upgrade_test.go        # single-repo and --all strict fail-fast coverage
+├── findings.go            # no behavior change expected; warning emission remains shared
+├── output.go              # no schema-version change; ensure strict errors appear as hints/failures
+└── schema_test.go         # update schema/help expectations for new flags if covered
+
+internal/fleet/
+├── deploy.go              # DeployOpts.Security; call gate after security.Run, before dry-run/apply split
+├── deploy_test.go         # strict abort before compile/commit/PR; breadcrumb and clone-preservation tests
+├── sync.go                # SyncOpts.Security; direct gate for clean/prune-only paths; propagate Deploy gate
+├── sync_test.go           # dry-run, apply, prune-only, and missing-workflow strict cases
+├── upgrade.go             # UpgradeOpts.Security; call gate after security.Run, before compile/PR/no-change return
+├── upgrade_test.go        # dry-run/apply/--all strict cases
+├── security_gate.go       # NEW: SecurityOpts, StrictSecurityError, BlockingFindings, EvaluateStrictSecurityGate
+├── security_gate_test.go  # NEW: predicate, promptinj carve-out, breadcrumb JSON, error message
+└── result_json.go         # no schema change; existing security_findings behavior retained
+
+internal/fleet/security/
+├── finding.go             # no scanner-output behavior change
+└── constants.go           # optionally add local prompt-injection prefix only if shared in package
+
+README.md
+docs/src/content/docs/reconcile.md
+skills/fleet-deploy/SKILL.md
+skills/fleet-upgrade-review/SKILL.md
+AGENTS.md                 # managed Spec Kit plan reference
+```
+
+**Structure Decision**: Keep the gate in `internal/fleet`, not in
+`internal/fleet/security`, because it is command policy over scanner results rather
+than detection logic. The security package continues to mean "produce findings";
+the fleet package decides whether a command invocation treats findings as advisory
+or blocking.
+
+## Phase 0: Outline & Research
+
+The spec contains no unresolved `NEEDS CLARIFICATION` markers. Phase 0 resolves
+implementation placement and compatibility details for the opt-in strict gate. See
+[research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+- [data-model.md](./data-model.md) defines the strict gate decision, security
+  options, strict error/breadcrumb, and how the existing `Finding` shape is consumed.
+- [contracts/strict-gate-contract.md](./contracts/strict-gate-contract.md) defines
+  the CLI flags, blocking predicate, abort/error behavior, breadcrumb format, and
+  command-specific semantics.
+- [quickstart.md](./quickstart.md) documents runnable validation scenarios.
+- Agent context: the managed Spec Kit block in `AGENTS.md` is retargeted to this plan.
+
+## Post-Design Constitution Check
+
+All Phase 1 artifacts preserve the pre-design decisions:
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| **I. Thin-Orchestrator Code Quality** | PASS | The contract keeps scanner logic separate from command policy and avoids new abstractions beyond `SecurityOpts` plus a focused gate helper. |
+| **II. Testing Standards** | PASS | Quickstart requires focused tests plus `make ci`; live `--apply` remains manual-approval only. |
+| **III. User Experience Consistency** | PASS | Contracts require findings to render before abort and require clone preservation on strict failures, matching failure-breadcrumb conventions. |
+| **IV. Performance Requirements** | PASS | No extra network or scanner pass introduced. |
+| **Documentation Impact** | PASS | User-facing docs and relevant skills are explicitly listed for update. |
+
+## Complexity Tracking
+
+No constitution violations or justified complexity exceptions.

--- a/specs/017-strict-security-gate/quickstart.md
+++ b/specs/017-strict-security-gate/quickstart.md
@@ -1,0 +1,167 @@
+# Quickstart: Strict Security Gate
+
+How to validate the strict gate during implementation. Assumes the standard local
+toolchain from `AGENTS.md`: Go 1.26.4 and the full `make ci` gate.
+
+## Build & gate
+
+```bash
+go build ./...
+go vet ./...
+go test ./internal/fleet/security/... ./internal/fleet/... ./cmd/...
+make ci
+```
+
+`make ci` is required before the implementation is considered done.
+
+## Unit validation matrix
+
+Cover the pure gate helper first:
+
+| Case | Findings | Strict | Expected |
+|------|----------|--------|----------|
+| clean | `[]` | true | proceed |
+| lower severity only | LOW/MEDIUM/INFO | true | proceed |
+| one HIGH Layer 1 | HIGH `gitleaks:*` | true | abort, count 1 |
+| multiple HIGH Layer 1 | two HIGH non-`promptinj:` | true | abort, count 2 |
+| HIGH prompt injection only | HIGH `promptinj:*` | true | proceed |
+| mixed prompt and Layer 1 | HIGH `promptinj:*` plus HIGH `fleet.*` | true | abort, count 1 |
+| strict disabled | HIGH non-`promptinj:` | false | proceed advisory-only |
+
+Also cover:
+
+- `findings.json` contains every finding, not just blockers.
+- Strict abort preserves a dry-run temp clone instead of deleting it.
+- Strict error text includes count, repo, unblock path, and breadcrumb path.
+- Breadcrumb write failure is reported without losing the blocking count.
+
+## Command validation
+
+### `deploy --strict`
+
+Expected behavior with a HIGH Layer 1 finding:
+
+```bash
+go run . deploy <owner/repo> --strict
+```
+
+- exits non-zero;
+- prints/records the finding on stderr;
+- writes `<clone>/findings.json`;
+- preserves the clone;
+- does not say "Re-run with --apply..." as a successful dry-run completion if the
+  command returns a strict error.
+
+Apply-path test must use seams or an explicitly approved live run:
+
+```bash
+go run . deploy <owner/repo> --strict --apply
+```
+
+Expected:
+
+- exits non-zero before commit/push/PR;
+- creates zero PRs;
+- still renders findings before the error.
+
+### `sync --strict`
+
+Validate three paths:
+
+```bash
+go run . sync <owner/repo> --strict
+go run . sync <owner/repo> --strict --apply
+go run . sync <owner/repo> --strict --prune --apply
+```
+
+Expected:
+
+- missing-workflow paths delegate to Deploy and block before deploy PR creation;
+- clean/drift-only dry-run paths still scan and block on existing HIGH findings;
+- prune-only apply blocks before commit/push when current workflows have HIGH
+  findings.
+
+### `upgrade --strict`
+
+Validate normal dry-run:
+
+```bash
+go run . upgrade <owner/repo> --strict
+```
+
+Expected:
+
+- exits non-zero when upgraded clone content has a blocking HIGH finding;
+- writes `findings.json`;
+- preserves the clone;
+- does not change compile-strict behavior.
+
+Validate fleet-wide fail-fast:
+
+```bash
+go run . upgrade --all --strict
+go run . upgrade --all --strict --output json
+```
+
+Expected:
+
+- text mode stops at the first blocked repo;
+- JSON mode emits complete envelopes through the blocked repo and then stops;
+- non-strict `upgrade --all --output json` remains continue-all.
+
+### `upgrade --audit --strict`
+
+```bash
+go run . upgrade <owner/repo> --audit --strict
+```
+
+Expected:
+
+- audit behavior is unchanged;
+- strict has no scanner findings to evaluate on the audit path.
+
+## JSON surface checks
+
+For a blocked run:
+
+```bash
+go run . deploy <owner/repo> --strict --output json
+```
+
+Expected:
+
+- process exits non-zero;
+- JSON envelope is still written;
+- `warnings[]` contains the security finding diagnostics;
+- `result.security_findings` is present when the scanner ran;
+- schema version remains unchanged.
+
+Example checks:
+
+```bash
+go run . deploy <owner/repo> --strict --output json \
+  | jq '.warnings[] | select(.fields.severity == "HIGH")'
+```
+
+## Documentation checks
+
+Implementation tasks must update:
+
+- `README.md`;
+- `docs/src/content/docs/reconcile.md`;
+- `skills/fleet-deploy/SKILL.md`;
+- `skills/fleet-upgrade-review/SKILL.md`.
+
+The docs must distinguish:
+
+- security strict gate: `gh-aw-fleet deploy|sync|upgrade --strict`;
+- compile strict: the existing `gh aw compile --strict` policy surfaced as
+  `compile-strict:` in command output.
+
+## Done criteria
+
+- Blocking predicate, prompt-injection carve-out, and breadcrumb behavior covered by
+  unit tests.
+- `deploy`, `sync`, `upgrade`, and `upgrade --all` strict paths covered.
+- User-facing docs and relevant skills updated.
+- `make ci` passes locally.

--- a/specs/017-strict-security-gate/research.md
+++ b/specs/017-strict-security-gate/research.md
@@ -1,0 +1,184 @@
+# Phase 0 Research: Strict Security Gate
+
+The feature spec has no unresolved clarification markers. This research records the
+implementation decisions that bind the strict gate to the current scanner,
+command, JSON, and work-dir behavior.
+
+## Decision 1 - `--strict` remains the flag name
+
+**Decision**: Add `--strict` to `deploy`, `sync`, and `upgrade`. The flag is
+invocation-only, defaults false, and is not persisted in fleet config.
+
+**Rationale**: The issue explicitly asks for `--strict`, and the spec resolves the
+name collision with compile-strict through documentation rather than renaming. The
+existing compile-strict policy is about `gh aw compile --strict`; this feature is
+about the Layer 1 security gate. Help text must name that distinction.
+
+**Alternatives considered**:
+- `--security-strict` or `--fail-on-high`. Rejected because it diverges from the
+  issue and spec language.
+- Config-level strict policy. Rejected by FR-012; team-wide defaults remain
+  advisory.
+
+## Decision 2 - Gate after scanner output, before mutation
+
+**Decision**: Evaluate strict mode immediately after `security.Run` populates the
+command result and before any compile, manifest, branch, commit, push, or PR path.
+
+**Rationale**: The command layer already renders `SecurityFindings` on stderr and in
+JSON envelopes after the fleet operation returns. Returning `res, StrictSecurityError`
+lets text and JSON modes render the same findings they render today, then return a
+non-zero error. Placing the gate in `internal/fleet` keeps mutation prevention close
+to the mutation gates and avoids duplicating policy in `cmd`.
+
+**Command placement**:
+- `Deploy`: after `res.SecurityFindings = security.Run(ctx, res.CloneDir)`, before
+  the dry-run return and before `runCompileStrictIfNeeded`.
+- `Upgrade`: after `res.SecurityFindings = security.Run(ctx, res.CloneDir)`, before
+  no-change/dry-run/apply branches.
+- `Sync`: for paths that delegate to `Deploy`, pass strict through so Deploy blocks
+  before its commit/PR path. For direct sync paths (clean, drift-only, prune-only),
+  run/evaluate the scanner before any prune commit.
+
+**Alternatives considered**:
+- Gate in `cmd` after printing. Rejected because apply-mode mutation may already
+  have happened by then.
+- Gate inside `internal/fleet/security.Run`. Rejected because scanner output must
+  stay advisory and reusable; strict is command policy, not detection.
+
+## Decision 3 - Blocking predicate
+
+**Decision**: A blocking finding is:
+
+```text
+finding.Severity == security.SeverityHigh
+AND NOT strings.HasPrefix(finding.RuleID, "promptinj:")
+```
+
+The gate keys on severity tier, not count or rule family. The `promptinj:` prefix is
+the Layer 3 carve-out.
+
+**Rationale**: Current scanner findings do not carry an explicit layer enum. The
+spec defines `promptinj:` as the future Layer 3 identifier, so a prefix carve-out is
+the minimum stable contract. Everything else at HIGH severity remains Layer 1 for
+gate purposes.
+
+**Alternatives considered**:
+- Add a layer field to `security.Finding`. Rejected because it would expand the JSON
+  finding shape and introduce more churn than the spec requires.
+- Block on diagnostic code families. Rejected because the spec says severity tier,
+  not rule count or family, and because future Layer 1 HIGH rules should block
+  automatically.
+
+## Decision 4 - Breadcrumb file and clone preservation
+
+**Decision**: On strict abort, write `findings.json` at the work-dir clone root. The
+file is a JSON array of every finding from that run, not just blockers. Preserve the
+clone even for dry-run temp clones.
+
+**Rationale**: FR-007 and SC-004 require a post-mortem artifact. Writing all findings
+keeps context for lower-severity related issues and matches the existing
+`security_findings` result surface. Dry-run currently removes throwaway clones; strict
+abort is a failure breadcrumb exception and must cancel cleanup.
+
+**File contract**:
+- Path: `<clone>/findings.json`.
+- Format: pretty or compact JSON array of `security.Finding` values.
+- Permissions: normal user-readable project artifact permissions are acceptable.
+- Write failure: return an error that still makes clear strict mode found blockers;
+  tests should cover the happy path and one write-failure path.
+
+**Alternatives considered**:
+- Write only blocking findings. Rejected because the spec asks for all findings.
+- Put the file under `.github/aw/`. Rejected because the spec fixes clone-root
+  `findings.json`, and root is easier for operators to inspect.
+
+## Decision 5 - Error and output behavior
+
+**Decision**: Return a typed strict error carrying the blocking count, breadcrumb
+path, and blocking findings. Its `Error()` message must state the count and the
+unblock path: fix the findings or re-run without `--strict` to proceed
+advisory-only.
+
+**Rationale**: A typed error gives tests and JSON/text emitters a stable way to
+recognize the strict gate without string matching. The message satisfies FR-008 and
+is usable as the standard failure hint in current envelope logic.
+
+**Output behavior**:
+- Text mode prints the normal command result and emits existing warning lines, then
+  returns the strict error.
+- JSON mode emits the normal single-repo envelope (or NDJSON line) with the existing
+  result shape and `warnings[]`, then returns the strict error.
+- No `cmd.SchemaVersion` bump; warnings and error/hint entries are additive.
+- No `fleet.SchemaVersion` bump; config shape is unchanged.
+
+**Alternatives considered**:
+- Add a new `strict_blocked` field to result JSON. Rejected for this slice; the
+  existing non-zero error plus warnings already expresses failure. A future AX error
+  envelope phase can standardize richer error metadata.
+
+## Decision 6 - `sync` path handling
+
+**Decision**: `sync --strict` uses two gate paths:
+
+1. If sync delegates to `Deploy` for missing workflows, pass strict through to
+   `Deploy` so generated workflow content is scanned and blocked before deploy
+   commits/pushes/opens a PR.
+2. If sync does not delegate to `Deploy` (clean, drift-only, or prune-only), scan the
+   current clone directly and evaluate before returning or before any prune commit.
+
+**Rationale**: Sync has more than one mutation path. Delegating missing-workflow
+cases to Deploy avoids duplicate scans and catches findings in newly added workflow
+content. Direct sync paths still need strict behavior because pre-existing workflows
+can contain HIGH findings and prune-only apply can otherwise commit before the
+current end-of-function scan.
+
+**Alternatives considered**:
+- Gate only on `SyncResult.SecurityFindings` after `applyDeployOrPrune`. Rejected
+  because prune-only apply would commit before the gate.
+
+## Decision 7 - `upgrade --all --strict` fail-fast, including JSON mode
+
+**Decision**: Strict mode is a policy gate that stops `upgrade --all` at the first
+blocked repo. In text mode this matches existing `UpgradeAll` fail-fast behavior. In
+JSON mode, emit complete envelopes through the blocked repo, then stop; non-strict
+`upgrade --all -o json` continues to emit one line per repo per the existing NDJSON
+contract.
+
+**Rationale**: FR-010 requires fail-fast when strict blocks a repo. Existing JSON
+mode normally continues after errors to satisfy the 003 NDJSON contract, but `--strict`
+is a new opt-in policy mode with no existing callers. Emitting the blocked repo's
+envelope before stopping preserves machine-readable context while honoring the gate.
+
+**Alternatives considered**:
+- Continue all repos in JSON mode. Rejected because it violates the strict fail-fast
+  requirement.
+- Stop before emitting the blocked repo's line. Rejected because it would hide the
+  findings from JSON consumers.
+
+## Decision 8 - `upgrade --audit --strict`
+
+**Decision**: Accept the flag combination but leave audit behavior unchanged. The
+audit path does not materialize or scan workflow content today, so strict has no
+findings to evaluate there.
+
+**Rationale**: The spec examples and requirements target normal `upgrade` dry-runs
+and applies, not `--audit`. Rejecting `--audit --strict` would add validation churn
+without improving the Layer 1 gate.
+
+## Decision 9 - Documentation and skills
+
+**Decision**: Update human-facing docs and relevant operator skills in the
+implementation phase:
+
+- `README.md`: mention strict in reconcile/usage guidance.
+- `docs/src/content/docs/reconcile.md`: add a strict gate section and disambiguate
+  compile-strict.
+- `skills/fleet-deploy/SKILL.md`: mention strict dry-run/apply behavior and
+  breadcrumb inspection.
+- `skills/fleet-upgrade-review/SKILL.md`: mention `upgrade --strict` and
+  fail-fast behavior.
+
+**Rationale**: The constitution requires user-facing documentation to move with
+visible flag changes, and AGENTS.md says skills must be updated when command flags
+or operator flows change.

--- a/specs/017-strict-security-gate/spec.md
+++ b/specs/017-strict-security-gate/spec.md
@@ -1,0 +1,253 @@
+# Feature Specification: --strict security gate
+
+**Feature Branch**: `017-strict-security-gate`
+**Created**: 2026-06-22
+**Status**: Draft
+**Input**: GitHub issue #38 — "Add --strict flag: promote HIGH Layer 1
+findings from advisory to blocking" (part of epic #36)
+
+## User Scenarios & Testing *(mandatory)*
+
+The Layer 1 security scanner already runs on every `deploy`, `sync`, and
+`upgrade` and surfaces its findings on stderr, in the JSON envelope's
+`warnings[]`, and in the PR body's `## Security Findings` section. Today every
+finding is **advisory**: even a HIGH-severity finding (e.g. an embedded
+credential or `permissions: write-all`) only makes the output louder — the
+operation still opens a pull request that a human must remember to reject. This
+feature adds an **opt-in gate** that converts HIGH findings from advisory to
+blocking, so an operator (or a CI job) can treat a HIGH finding as a hard stop
+without imposing that policy on the whole team by default.
+
+### User Story 1 - Hard-gate a deploy on HIGH findings (Priority: P1)
+
+A fleet operator runs `deploy`/`sync` (single repo) with `--strict`. If the
+scanner reports any HIGH-severity Layer 1 finding for that repo, the operation
+aborts before any commit/push/PR step and exits non-zero. No pull request is
+created. Without `--strict`, the identical command continues and opens the PR
+exactly as it does today.
+
+**Why this priority**: This is the core value of the feature — turning the
+scanner from a passive reporter into an enforceable gate. It is the minimum
+viable slice: shipping just this delivers the "zero-tolerance on secret leaks /
+dangerous workflow structure" outcome the issue is about.
+
+**Independent Test**: Run `deploy <repo> --strict --apply` against a fixture
+whose workflow contains a fake embedded secret (HIGH finding); assert a non-zero
+exit and that no PR was created on the target. Re-run the same command without
+`--strict` and assert the operation proceeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo whose scan yields at least one HIGH Layer 1 finding, **When**
+   the operator runs `deploy --strict --apply`, **Then** the command exits
+   non-zero, no commit/push/PR occurs, and the findings are still printed.
+2. **Given** the same repo, **When** the operator runs `deploy --apply` without
+   `--strict`, **Then** the command proceeds and opens the PR (current advisory
+   behavior is preserved).
+3. **Given** a repo whose scan yields no HIGH findings (only MEDIUM/LOW/INFO, or
+   none), **When** the operator runs `deploy --strict --apply`, **Then** the
+   command behaves identically to a non-strict run (PR opened, exit 0).
+
+---
+
+### User Story 2 - Gate without applying, for pre-merge CI (Priority: P2)
+
+An operator (or CI pipeline) runs a dry-run (`upgrade --strict`, no `--apply`)
+to catch HIGH findings before any change is staged. The gate still fires: the
+command prints the findings and exits non-zero when HIGH findings exist, even
+though no commit would have been made. This lets a CI job fail a pull-request
+check purely on the advisory scan, without needing write access to push.
+
+**Why this priority**: The gate is most useful in CI, where the common mode is
+dry-run validation rather than `--apply`. Without this, `--strict` would only
+protect the apply path and leave the cheaper, more frequent dry-run path
+ungated.
+
+**Independent Test**: Run `upgrade --strict` (dry-run) against a fleet/fixture
+with a HIGH finding; assert non-zero exit and that the findings were printed,
+with no branch or PR created.
+
+**Acceptance Scenarios**:
+
+1. **Given** a HIGH finding and a dry-run invocation, **When** the operator runs
+   `upgrade --strict` (no `--apply`), **Then** the command exits non-zero after
+   printing findings, and makes no commit/branch/PR.
+2. **Given** a fleet-wide `upgrade --strict` across multiple repos where one repo
+   has a HIGH finding, **When** the run reaches that repo, **Then** the run
+   aborts there (consistent with the command's existing fail-fast error
+   propagation) and exits non-zero.
+
+---
+
+### User Story 3 - Prompt-injection findings stay advisory (Priority: P3)
+
+A repo's scan includes a Layer 3 / prompt-injection finding (rule ID prefixed
+`promptinj:`), even at HIGH severity. Under `--strict`, that finding does
+**not** block the operation — only Layer 1 HIGH findings block. Layer 3 findings
+remain advisory in every mode.
+
+**Why this priority**: This is a guardrail that protects operator trust in
+`--strict`. Indirect prompt-injection detection is the documented blind spot of
+every surveyed classifier (high false-positive rate in the wild). Gating on it
+would produce frequent false aborts and erode confidence in the flag. This is a
+forward-looking carve-out: no `promptinj:` rules exist in the scanner today, so
+the behavior is "future Layer 3 rules are exempt from the gate by construction."
+
+**Independent Test**: Construct a finding with rule ID `promptinj:*` at HIGH
+severity and assert the gate does not block on it, while a non-`promptinj:` HIGH
+finding in the same set does block.
+
+**Acceptance Scenarios**:
+
+1. **Given** a finding set containing only a HIGH `promptinj:`-prefixed finding,
+   **When** `--strict` is in effect, **Then** the operation is NOT blocked.
+2. **Given** a finding set containing a HIGH `promptinj:` finding AND a HIGH
+   Layer 1 finding, **When** `--strict` is in effect, **Then** the operation IS
+   blocked (the Layer 1 finding alone is sufficient).
+
+---
+
+### Edge Cases
+
+- **No HIGH findings, only lower tiers**: any number of MEDIUM/LOW/INFO findings
+  must never trigger the gate — the gate keys on the HIGH tier, not on count.
+- **Strict with no findings at all**: the operation proceeds identically to a
+  non-strict run; `--strict` is a no-op when the scan is clean.
+- **Dry-run abort breadcrumb**: when the gate fires on a dry-run, the work-dir
+  clone is still preserved with the findings breadcrumb so the operator can
+  inspect it (matching the existing "clone dirs are breadcrumbs after failure"
+  convention).
+- **Naming collision with compile-strict**: the tool already has an automatic
+  *compile-strict* policy (public repos are compiled with `gh aw compile
+  --strict`). `--strict` here governs **only** the Layer 1 HIGH security gate; it
+  must not change compile-strict behavior, and operator-facing help/docs must
+  make the distinction clear so the two "strict" concepts are not conflated.
+- **Findings rendered before abort**: the operator must see the findings on
+  stderr before the gate aborts, so the non-zero exit is never an unexplained
+  failure.
+- **`--strict` on a non-mutating command**: `--strict` is meaningful only for
+  `deploy`/`sync`/`upgrade`; it has no effect on read-only commands (`list`,
+  `status`, `consumption`).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `deploy`, `sync`, and `upgrade` commands MUST accept an opt-in
+  `--strict` flag. Its default MUST be off, preserving today's advisory-only
+  behavior for every existing invocation.
+- **FR-002**: When `--strict` is set and at least one **HIGH-severity Layer 1**
+  finding is present for the repo being processed, the operation MUST abort
+  **before** any commit, push, or PR-creation step and MUST exit non-zero.
+- **FR-003**: The gate MUST key on **severity tier, not finding count** — a
+  single HIGH finding blocks; MEDIUM, LOW, and INFO findings MUST NOT block
+  regardless of how many are present.
+- **FR-004**: The gate MUST NOT block on Layer 3 / prompt-injection findings,
+  identified by the `promptinj:` rule-ID prefix. Such findings remain advisory
+  even at HIGH severity under `--strict`.
+- **FR-005**: Without `--strict`, behavior MUST be unchanged from today: findings
+  are printed/surfaced and the operation proceeds (advisory). `--strict` MUST be
+  the only thing that converts a finding into a blocker.
+- **FR-006**: The gate MUST apply in dry-run mode as well as `--apply` mode —
+  `--strict` MUST exit non-zero when HIGH findings exist even though no commit
+  would have been made.
+- **FR-007**: When the gate aborts, the system MUST write a `findings.json` file
+  (a JSON array of all findings from the run) into the work-dir clone, so the
+  operator can inspect findings post-mortem.
+- **FR-008**: The abort error message MUST be actionable: it MUST state the count
+  of blocking HIGH findings and tell the operator how to unblock (re-run without
+  `--strict` to proceed advisory-only, or fix the findings).
+- **FR-009**: The findings MUST already be rendered to stderr at the point the
+  gate aborts, so the operator sees what blocked the run.
+- **FR-010**: For a fleet-wide `upgrade --strict` spanning multiple repos, the
+  gate MUST integrate with the command's existing fail-fast error propagation —
+  the first repo whose scan yields a blocking HIGH finding aborts the run and the
+  command exits non-zero. This strict-mode fail-fast behavior also applies to
+  JSON/NDJSON output mode; any already-emitted per-repo JSON records remain
+  valid, but no additional repositories are processed after the strict failure.
+- **FR-011**: `--strict` MUST govern only the Layer 1 HIGH security gate. It MUST
+  NOT alter compile-strict behavior, the JSON output schema version, or any other
+  gating.
+- **FR-012**: `--strict` MUST be opt-in per invocation only; it MUST NOT be
+  persisted to `fleet.json` / `fleet.local.json`, so the team-wide default
+  remains advisory.
+- **FR-013**: Enabling `--strict` MUST NOT change the set, content, ordering, or
+  severity of findings produced by the scanner — it only changes whether a HIGH
+  finding is treated as blocking.
+
+### Key Entities *(include if feature involves data)*
+
+- **Strict security gate decision**: the per-invocation evaluation that inspects
+  the scan's findings and decides whether to block. Inputs: the findings list and
+  whether `--strict` is active. Output: either "proceed" or "abort with a
+  non-zero error and a `findings.json` breadcrumb."
+- **Security options (per-invocation)**: a small grouping of security-related
+  invocation flags passed into `deploy`/`sync`/`upgrade`, carrying at minimum the
+  strict toggle, with room to grow (e.g. a future deep-scan toggle) without
+  churning command signatures.
+- **Finding / Severity (existing)**: each finding carries a namespaced rule ID
+  and one of INFO/LOW/MEDIUM/HIGH severities. The gate consumes these; the
+  `promptinj:` rule-ID prefix distinguishes Layer 3 findings that are exempt from
+  the gate.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A `deploy --strict --apply` against a repo with at least one HIGH
+  Layer 1 finding exits non-zero and creates **zero** pull requests; the same
+  command without `--strict` creates the pull request.
+- **SC-002**: For any finding set containing only MEDIUM/LOW/INFO findings — at
+  any count — `--strict` never aborts the operation (0% block rate across all
+  non-HIGH tiers).
+- **SC-003**: A HIGH finding whose rule ID is prefixed `promptinj:` never aborts
+  the operation under `--strict`, while a non-`promptinj:` HIGH finding in the
+  same set always does.
+- **SC-004**: After every strict abort, a `findings.json` file exists in the
+  work-dir clone and contains every finding from that run.
+- **SC-005**: Every strict-abort message states both the blocking HIGH-finding
+  count and the unblock path, verifiable from the command's stderr output.
+- **SC-006**: When no HIGH Layer 1 findings exist, a `--strict` run produces the
+  same outcome as the equivalent non-strict run (same PR created or not, same
+  exit status) — `--strict` is observably a no-op on clean scans.
+- **SC-007**: A dry-run `upgrade --strict` (no `--apply`) over a fleet with a
+  HIGH finding exits non-zero without creating any branch, commit, or PR.
+
+## Assumptions
+
+- **Layer 1 scanner is already present.** The scanner (`security.Run`) and the
+  `Finding`/`Severity` types already exist and already attach findings to the
+  deploy/sync/upgrade result structs. This feature adds only the gate; it does
+  not build or modify the scanner. (The issue's "depends on the Layer 1 scanner
+  issue" precondition is already satisfied in the codebase.)
+- **Flag name is `--strict` as specified in the issue.** A naming collision
+  exists with the tool's automatic compile-strict policy; this spec keeps
+  `--strict` (the issue's explicit choice) and mitigates the collision via FR-011
+  (strict governs only the security gate) plus help/doc disambiguation, rather
+  than renaming. If the operator later prefers a disambiguated name, that is a
+  deliberate change to make during planning — not an open question this spec
+  leaves unresolved.
+- **No `promptinj:` rules exist yet.** The Layer 3 carve-out (FR-004) is
+  forward-looking; it is specified now so the gate is correct by construction
+  when Layer 3 rules land in a later slice (the `--deep-scan` issue).
+- **Multi-repo semantics mirror existing behavior.** `deploy`/`sync` are
+  single-repo; fleet-wide `upgrade` already uses fail-fast error propagation,
+  which the gate reuses (FR-010) rather than introducing collect-all-then-fail
+  semantics.
+- **No schema-version bump.** Adding the gate and the `findings.json` breadcrumb
+  is additive and does not change the JSON output envelope's schema version or
+  the on-disk `fleet.json` format.
+- **The breadcrumb file is `findings.json` at the work-dir clone root**, a JSON
+  array of the `Finding` shape, consistent with the existing convention that
+  `/tmp/gh-aw-fleet-*` clone dirs are preserved for post-mortem after a failed
+  `--apply`.
+
+## Out of Scope
+
+- A per-finding ignore/allow mechanism (e.g. a `.fleet-security-ignore` file).
+  Possible follow-up if `--strict` proves noisy in practice.
+- Promoting MEDIUM (or lower) findings to blocking — the severity-tier semantic
+  is kept clean: HIGH blocks under strict, everything else stays advisory.
+- The Layer 3 prompt-injection classifier itself — that is the separate
+  `--deep-scan` issue. This feature only reserves the `promptinj:` carve-out.
+- Renaming or restructuring the existing compile-strict policy.

--- a/specs/017-strict-security-gate/tasks.md
+++ b/specs/017-strict-security-gate/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: Strict Security Gate
+
+**Input**: Design documents from `/specs/017-strict-security-gate/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/strict-gate-contract.md](./contracts/strict-gate-contract.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Required. The feature specification defines independent tests for all three user stories, and quickstart.md requires unit and command-path coverage.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and tested independently after the shared strict-gate foundation is in place.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story label for story phases only (`[US1]`, `[US2]`, `[US3]`)
+- Every task names exact repository file paths to edit or validate
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active feature context and current implementation seams before editing.
+
+- [X] T001 Review strict-gate design artifacts in specs/017-strict-security-gate/plan.md, specs/017-strict-security-gate/data-model.md, and specs/017-strict-security-gate/contracts/strict-gate-contract.md
+- [X] T002 Review existing scanner and mutation ordering seams in internal/fleet/deploy.go, internal/fleet/sync.go, internal/fleet/upgrade.go, cmd/deploy.go, cmd/sync.go, and cmd/upgrade.go
+- [X] T003 [P] Review existing security finding output tests in cmd/output_test.go, cmd/deploy_test.go, cmd/upgrade_test.go, and internal/fleet/deploy_test.go
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared option, predicate, error, and breadcrumb primitives required by every user story.
+
+**CRITICAL**: No user story implementation should begin until this phase compiles.
+
+- [X] T004 [P] Add failing unit tests for SecurityOpts default behavior, HIGH blocking count, lower-severity non-blocking behavior, breadcrumb JSON contents, and strict error text in internal/fleet/security_gate_test.go
+- [X] T005 Implement SecurityOpts, StrictSecurityError, BlockingSecurityFindings, EvaluateStrictSecurityGate, and findings.json breadcrumb writing in internal/fleet/security_gate.go
+- [X] T006 Add Security SecurityOpts fields with godoc-compatible comments to DeployOpts in internal/fleet/deploy.go, SyncOpts in internal/fleet/sync.go, and UpgradeOpts in internal/fleet/upgrade.go
+- [X] T007 Add assertions that findings.json preserves the existing security.Finding JSON field names and numeric severity representation in internal/fleet/security_gate_test.go
+- [X] T008 [P] Add strict gate preservation assertions proving strict evaluation preserves finding count, order, severity, IDs/codes, fields, and rendered breadcrumb JSON content in internal/fleet/security_gate_test.go
+- [X] T009 Run focused foundational tests for the new gate helper from /github/go/src/github.com/rshade/gh-aw-fleet using internal/fleet/security_gate_test.go
+
+**Checkpoint**: Shared gate primitives compile and focused helper tests fail/pass as expected.
+
+---
+
+## Phase 3: User Story 1 - Hard-gate a deploy on HIGH findings (Priority: P1)
+
+**Goal**: `deploy --strict` and `sync --strict` block HIGH Layer 1 findings before commit, push, or PR creation, while non-strict behavior remains advisory.
+
+**Independent Test**: Run the deploy/sync strict tests against a fixture clone with a fake HIGH finding; strict apply returns non-zero and creates no PR, while the equivalent non-strict path proceeds through existing advisory behavior.
+
+### Tests for User Story 1
+
+> Write these tests first and ensure they fail before implementation.
+
+- [X] T010 [P] [US1] Add deploy strict apply tests that assert StrictSecurityError, findings.json, preserved clone, and no compile/manifest/PR step in internal/fleet/deploy_test.go
+- [X] T011 [US1] Add deploy non-strict regression tests proving identical HIGH findings remain advisory in internal/fleet/deploy_test.go
+- [X] T012 [P] [US1] Add clean strict no-op command tests verifying --strict with zero blocking findings follows the same success path, exit status, and mutation behavior as non-strict mode in cmd/deploy_test.go or cmd/sync_test.go
+- [X] T013 [P] [US1] Add sync strict tests for missing-workflow delegation and prune-only apply blocking before commit/push in internal/fleet/sync_test.go
+- [X] T014 [P] [US1] Add deploy and sync Cobra flag/help/propagation tests for --strict in cmd/deploy_test.go and cmd/sync_test.go
+
+### Implementation for User Story 1
+
+- [X] T015 [US1] Add --strict flag wiring to newDeployCmd and pass fleet.SecurityOpts into fleet.Deploy in cmd/deploy.go
+- [X] T016 [US1] Add --strict flag wiring to newSyncCmd and pass fleet.SecurityOpts into fleet.Sync in cmd/sync.go
+- [X] T017 [US1] Evaluate the strict gate in Deploy immediately after security.Run and before dry-run/apply branching in internal/fleet/deploy.go
+- [X] T018 [US1] Preserve deploy dry-run temp clones when StrictSecurityError is returned by adjusting cleanup logic in internal/fleet/deploy.go
+- [X] T019 [US1] Propagate SyncOpts.Security into delegated Deploy calls and evaluate strict gate before direct sync prune/return paths in internal/fleet/sync.go
+- [X] T020 [US1] Ensure strict deploy/sync errors still surface existing security warnings and JSON warning diagnostics in cmd/deploy.go, cmd/sync.go, and cmd/output_test.go
+
+**Checkpoint**: User Story 1 is independently functional for single-repo deploy/sync apply paths.
+
+---
+
+## Phase 4: User Story 2 - Gate without applying, for pre-merge CI (Priority: P2)
+
+**Goal**: `upgrade --strict` blocks in dry-run mode and `upgrade --all --strict` fails fast at the first blocked repo, including JSON mode.
+
+**Independent Test**: Run `upgrade --strict` without `--apply` against a fixture with a HIGH finding and assert non-zero exit, rendered findings, findings.json, preserved clone, and no branch/commit/PR.
+
+### Tests for User Story 2
+
+> Write these tests first and ensure they fail before implementation.
+
+- [X] T021 [P] [US2] Add upgrade dry-run strict abort tests for non-zero error, findings.json, preserved clone, and unchanged compile-strict fields in internal/fleet/upgrade_test.go
+- [X] T022 [US2] Add upgrade apply strict abort tests proving branch/stage/commit/push/PR steps do not run in internal/fleet/upgrade_test.go
+- [X] T023 [US2] Add UpgradeAll text-mode fail-fast strict tests in internal/fleet/upgrade_test.go
+- [X] T024 [P] [US2] Add upgrade --all --strict --output json tests proving NDJSON stops after the blocked repo but emits that repo envelope in cmd/output_test.go
+- [X] T025 [P] [US2] Add upgrade strict abort rendering tests asserting security findings are emitted before StrictSecurityError is returned, including JSON/NDJSON output mode, in cmd/upgrade_test.go and cmd/output_test.go
+- [X] T026 [P] [US2] Add upgrade --audit --strict no-op behavior coverage in cmd/upgrade_test.go
+
+### Implementation for User Story 2
+
+- [X] T027 [US2] Add --strict flag wiring to newUpgradeCmd and pass fleet.SecurityOpts into fleet.Upgrade and fleet.UpgradeAll in cmd/upgrade.go
+- [X] T028 [US2] Evaluate the strict gate in Upgrade immediately after security.Run and before no-change, dry-run, compile-strict, manifest, and PR branches in internal/fleet/upgrade.go
+- [X] T029 [US2] Preserve upgrade dry-run temp clones when StrictSecurityError is returned by adjusting cleanup logic in internal/fleet/upgrade.go
+- [X] T030 [US2] Update runUpgradeAllJSON to stop after emitting the blocked repo envelope when errors.As detects StrictSecurityError in cmd/upgrade.go
+- [X] T031 [US2] Keep upgrade --audit --strict behavior unchanged while ensuring the flag combination is accepted in cmd/upgrade.go and internal/fleet/upgrade.go
+
+**Checkpoint**: User Story 2 is independently functional for dry-run upgrade and fleet-wide strict CI use.
+
+---
+
+## Phase 5: User Story 3 - Prompt-injection findings stay advisory (Priority: P3)
+
+**Goal**: HIGH findings whose rule ID starts with `promptinj:` never block under `--strict`, while a HIGH Layer 1 finding in the same set still blocks.
+
+**Independent Test**: Construct finding sets directly in unit tests: HIGH `promptinj:*` only proceeds, and HIGH `promptinj:*` plus HIGH `fleet.*` blocks with count 1.
+
+### Tests for User Story 3
+
+> Write these tests first and ensure they fail before implementation.
+
+- [X] T032 [US3] Add promptinj-only HIGH non-blocking tests to internal/fleet/security_gate_test.go
+- [X] T033 [US3] Add mixed promptinj HIGH plus Layer 1 HIGH blocking-count tests to internal/fleet/security_gate_test.go
+
+### Implementation for User Story 3
+
+- [X] T034 [US3] Implement the promptinj: prefix carve-out in BlockingSecurityFindings in internal/fleet/security_gate.go
+- [X] T035 [US3] Document the promptinj: strict-gate carve-out in the SecurityOpts or BlockingSecurityFindings godoc in internal/fleet/security_gate.go
+
+**Checkpoint**: User Story 3 is independently verified by pure unit tests and protects future Layer 3 findings from strict blocking.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, schema/help verification, and full project gate.
+
+- [X] T036 [P] Update README.md to document deploy/sync/upgrade --strict, advisory default behavior, and findings.json strict-abort breadcrumb
+- [X] T037 [P] Update docs/src/content/docs/reconcile.md to distinguish the security strict gate from gh aw compile --strict and describe dry-run/apply behavior
+- [X] T038 [P] Update skills/fleet-deploy/SKILL.md with strict dry-run/apply handling, findings rendering, and breadcrumb inspection guidance
+- [X] T039 [P] Update skills/fleet-upgrade-review/SKILL.md with upgrade --strict and upgrade --all --strict fail-fast guidance
+- [X] T040 [P] Verify __schema includes the new --strict flags without documenting the hidden command by updating expectations in cmd/schema_test.go if needed
+- [X] T041 Run quickstart validation commands from specs/017-strict-security-gate/quickstart.md against the completed implementation
+- [X] T042 Run make ci from /github/go/src/github.com/rshade/gh-aw-fleet/Makefile and fix any fmt, vet, lint, or test failures
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational; MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational; can start after shared gate primitives exist, but easiest after US1 establishes command wiring patterns.
+- **User Story 3 (Phase 5)**: Depends on Foundational; pure predicate work can proceed in parallel with US1/US2 after T005.
+- **Polish (Phase 6)**: Depends on completed user stories selected for delivery.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on US2 or US3 after Phase 2. Provides MVP value.
+- **US2 (P2)**: No functional dependency on US1, but reuses the same `--strict` flag wiring and strict gate helper.
+- **US3 (P3)**: No command dependency; validates and documents the shared blocking predicate.
+
+### Within Each User Story
+
+- Tests should be written first and fail before implementation.
+- Command flag wiring before command-level propagation assertions can pass.
+- Gate evaluation before cleanup-preservation assertions can pass.
+- Documentation and full `make ci` run only after story implementation is complete.
+
+### Parallel Opportunities
+
+- T003 can run alongside T001/T002.
+- T004 can be drafted alongside T005 because it targets internal/fleet/security_gate_test.go while T005 targets internal/fleet/security_gate.go.
+- T010, T013, and T014 can be drafted in parallel because they touch separate test areas; T011 and T012 should coordinate with T010 because they may share deploy command or deploy internals fixtures.
+- T021, T024, and T026 can be drafted in parallel because they target upgrade internals, output JSON, and audit behavior separately; T022 and T023 should coordinate with T021 because all three edit internal/fleet/upgrade_test.go; T025 should coordinate with T024 and T026 if it touches shared command-output fixtures.
+- T032 and T033 should be coordinated because both edit internal/fleet/security_gate_test.go.
+- T036, T037, T038, T039, and T040 can run in parallel after behavior is implemented.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add deploy strict apply tests that assert StrictSecurityError, findings.json, preserved clone, and no compile/manifest/PR step in internal/fleet/deploy_test.go"
+Task: "Add sync strict tests for missing-workflow delegation and prune-only apply blocking before commit/push in internal/fleet/sync_test.go"
+Task: "Add deploy and sync Cobra flag/help/propagation tests for --strict in cmd/deploy_test.go and cmd/sync_test.go"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add upgrade dry-run strict abort tests for non-zero error, findings.json, preserved clone, and unchanged compile-strict fields in internal/fleet/upgrade_test.go"
+Task: "Add upgrade --all --strict --output json tests proving NDJSON stops after the blocked repo but emits that repo envelope in cmd/output_test.go"
+Task: "Add upgrade --audit --strict no-op behavior coverage in cmd/upgrade_test.go"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Add promptinj-only HIGH non-blocking tests to internal/fleet/security_gate_test.go"
+Task: "Add mixed promptinj HIGH plus Layer 1 HIGH blocking-count tests to internal/fleet/security_gate_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 for deploy/sync strict apply gating.
+3. Stop and validate US1 independently: strict blocks HIGH findings before mutation; non-strict remains advisory.
+4. Update minimal docs if shipping MVP alone.
+
+### Incremental Delivery
+
+1. Deliver US1: single-repo deploy/sync hard gate.
+2. Deliver US2: dry-run and fleet-wide upgrade strict behavior for CI.
+3. Deliver US3: prompt-injection carve-out for future Layer 3 rules.
+4. Complete polish and run `make ci`.
+
+### Validation Gate
+
+Before reporting implementation complete:
+
+1. Run focused tests for internal/fleet/security_gate_test.go, internal/fleet/deploy_test.go, internal/fleet/sync_test.go, internal/fleet/upgrade_test.go, and cmd/output_test.go.
+2. Run `make ci`.
+3. Confirm `cmd.SchemaVersion` and `fleet.SchemaVersion` were not changed.
+4. Confirm no `--strict` value is written to fleet.json or fleet.local.json.
+
+## Notes
+
+- `--strict` in this feature is the security gate only; it must not change compile-strict behavior.
+- `findings.json` is a failure breadcrumb and should be written only on strict abort.
+- Do not run live `--apply` validation without explicit user approval in the immediately preceding turn.
+- Do not hand-edit CHANGELOG.md; release-please owns it.


### PR DESCRIPTION

## Summary

- Adds an opt-in `--strict` flag to `deploy`, `sync`, and `upgrade`
  that promotes HIGH-severity Layer 1 security findings from advisory
  to blocking. Without the flag, behavior is unchanged: findings are
  surfaced and the operation proceeds.
- The gate fires before any commit/push/PR step and exits non-zero in
  both dry-run and `--apply` modes, so a CI job can fail a pull-request
  check on the scan alone without needing write access.
- Keys on severity tier, not finding count — a single HIGH finding
  blocks; MEDIUM/LOW/INFO never do. Layer 3 prompt-injection findings
  (`promptinj:` rule-ID prefix) are carved out and stay advisory even
  at HIGH, a forward-looking guard against false aborts when the
  `--deep-scan` classifier lands.
- On a strict abort the work-dir clone is preserved with a
  `findings.json` breadcrumb (a JSON array of every finding), reusing
  the existing "clone dirs are breadcrumbs after failure" convention.
  The abort message states the blocking count and the unblock path.
- Disambiguates from the existing automatic compile-strict policy:
  this `--strict` governs only the Layer 1 security gate and does not
  change `gh aw compile --strict`, the JSON schema version, or any
  other gating. The flag is per-invocation only and is never persisted
  to `fleet.json` / `fleet.local.json`.
- Fleet-wide `upgrade --strict` reuses the command's existing
  fail-fast propagation, including in JSON/NDJSON mode: the first repo
  with a blocking HIGH finding aborts the run; already-emitted per-repo
  records stay valid and no further repos are processed.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `~/go/bin/golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes (new gate, flow, and command-seam tests)
- [x] Unit coverage for the gate decision: HIGH blocks, MEDIUM/LOW/INFO
      never block, `promptinj:` HIGH is exempt, mixed sets block on the
      Layer 1 finding alone
- [x] Flow coverage that a strict abort writes `findings.json` and
      preserves the clone in dry-run mode
- [x] Command-level coverage that `--strict` propagates into
      `DeployOpts`/`SyncOpts`/`UpgradeOpts` via the injected run seams

## Changes

### New files

- `internal/fleet/security_gate.go` - `SecurityOpts`,
  `StrictSecurityError`, `BlockingSecurityFindings`, and
  `EvaluateStrictSecurityGate`; the gate decision plus the
  `findings.json` breadcrumb writer and clone-preservation helper
- `internal/fleet/security_gate_test.go` - unit tests for the gate
  decision and blocking-finding selection
- `internal/fleet/strict_gate_flow_test.go` - end-to-end flow tests
  for breadcrumb write and clone preservation
- `cmd/strict_gate_test.go` - command-level tests asserting `--strict`
  flows into the fleet opts via the run seams
- `specs/017-strict-security-gate/` - spec, plan, data model,
  research, quickstart, contracts, checklists, and tasks

### Modified files

- `cmd/deploy.go`, `cmd/sync.go`, `cmd/upgrade.go` - register the
  `--strict` flag, plumb `fleet.SecurityOpts` into the opts, add
  `runFleet*` injection seams, and suppress the "re-run with --apply"
  hint on strict aborts; `upgrade --all` JSON loop breaks on a strict
  error
- `cmd/output.go` - shared `strictFlagUsage` help text that disclaims
  the compile-strict collision
- `internal/fleet/deploy.go`, `internal/fleet/sync.go`,
  `internal/fleet/upgrade.go` - evaluate the gate after `security.Run`,
  return `StrictSecurityError` before any mutation, and replace the
  direct `defer os.RemoveAll` with a mutable `cleanupClone` closure so
  aborts retain the breadcrumb; `sync` apply/preflight paths refactored
  into `runSyncActions`/`runSyncApply`/`runSyncPreflight`
- `cmd/schema_test.go` - schema-command test updates
- `internal/fleet/constants.go`, `internal/fleet/fetch.go`,
  `internal/fleet/status.go` - extract the `"file"` content-type
  literal into a shared `githubContentTypeFile` constant
- `README.md`, `docs/src/content/docs/reconcile.md`, `AGENTS.md` -
  document the `--strict` gate and its distinction from compile-strict
- `skills/fleet-deploy/SKILL.md`,
  `skills/fleet-upgrade-review/SKILL.md` - note `--strict` in the
  operator workflows

Closes #38