### PR TITLE
feat(security): add interactive findings confirmation and --yes flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,5 +131,5 @@ Committed at repo root; shared with collaborators and subagents. Allows `go buil
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-[specs/017-strict-security-gate/plan.md](./specs/017-strict-security-gate/plan.md)
+[specs/019-security-finding-prompt/plan.md](./specs/019-security-finding-prompt/plan.md)
 <!-- SPECKIT END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,5 +45,5 @@ Per-slice dependency and storage deltas:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/018-overview-subcommand/plan.md](./specs/018-overview-subcommand/plan.md)
+[specs/019-security-finding-prompt/plan.md](./specs/019-security-finding-prompt/plan.md)
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -637,6 +637,46 @@ gh-aw-fleet upgrade --all --strict --output json
 For `upgrade --all --strict --output json`, NDJSON records are emitted through
 the blocked repo and then processing stops at that first strict failure.
 
+#### Interactive findings confirmation and `--yes`
+
+Independent of `--strict`, an `--apply` that produces one or more security
+findings (of **any** severity) pauses for a last-chance confirmation before it
+commits, pushes, or opens a PR — but only when stdout is an interactive
+terminal:
+
+```text
+⚠  2 HIGH, 1 MEDIUM. Proceed with commit? [y/N]
+```
+
+The safe default is **No**: a bare Enter, `n`, or any non-`y` answer aborts
+cleanly, exits non-zero, and preserves the work-dir clone so you can inspect it
+and resume with `--work-dir <clone> --yes`. Answering `y` proceeds, and the PR
+body still carries the `## Security Findings` section.
+
+The prompt is the **third** independent surface for findings, alongside the
+stderr warnings and the PR-body section. It differs from `--strict`: `--strict`
+is a non-interactive hard block on HIGH findings; the prompt is an interactive
+last-chance gate on any finding.
+
+Three things skip the prompt without hiding the findings:
+
+- `--yes` on `deploy`, `sync`, or `upgrade` — proceed without the question;
+  stderr findings and the PR-body section are still produced.
+- A non-interactive stdout (piped, redirected, or CI) — the apply proceeds
+  automatically so nothing ever hangs. Use `--strict` when you want a
+  non-interactive *block* instead.
+- `--output json` — treated as non-interactive even at a TTY, so the JSON
+  envelope is never corrupted by a prompt.
+
+```bash
+gh-aw-fleet deploy acme/widgets --apply --yes        # skip the prompt
+gh-aw-fleet deploy acme/widgets --apply | tee out.txt # piped: no prompt, no hang
+```
+
+The prompt only fires on `--apply` (dry-runs never prompt) and only after the
+`--strict` gate, so a HIGH strict block still wins. `--yes` is per invocation
+and is never written to `fleet.json` or `fleet.local.json`.
+
 ## Bundled Profiles
 
 Each entry below lists what the profile adds, who it's for, and the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,13 +34,13 @@ fleet-layer tool existing.
 
 **Identifying candidates**:
 
-- **Cost**: items labeled `cost` on GitHub — #153 (Immediate Focus),
-  #102 (Near-Term), #106 / #107 / #113 / #53 / #59 / #60 (Future);
-  #57 / #103 / #108 / #104 / #129 shipped in the v0.2.x line and since.
+- **Cost**: items labeled `cost` on GitHub — #102 (Near-Term),
+  #106 / #107 / #113 / #53 / #59 / #60 (Future);
+  #57 / #103 / #108 / #104 / #129 / #153 shipped in the v0.2.x line and since.
 - **Security**: items labeled `security` on GitHub — the security epic
-  #36 with children #39 / #40 (Future); the `--strict` HIGH-finding
-  promotion #38, the supply-chain conflict scanners #101 / #100, and #49
-  (all shipped).
+  #36 with child #40 (Immediate Focus) and #39 (Future); the `--strict`
+  HIGH-finding promotion #38, the supply-chain conflict scanners #101 / #100,
+  and #49 (all shipped).
 
 **Status**: release-please cuts **patch** bumps for `0.x` (latest tag
 **v0.2.4**, 2026-06-22; `main` has unreleased commits awaiting the next tag).
@@ -49,59 +49,65 @@ scanner); the v0.2.1-v0.2.4 line shipped the cost half repeatedly — the
 consumption rollup (#57), the `gh aw logs --json` AIC source (#103 / PR #116),
 and the v0.79.2 FinOps baseline (#108) — alongside the security half (#49
 `--strict` on public repos, plus the supply-chain conflict scanners #101 / #100
-and the trigger-risk lint #104). The cost + security pair now **closed** on
-`main` and awaiting the next tag is the over-budget highlight (#129, cost,
-PR #160) and the HIGH-finding `--strict` promotion (#38, security, PR #161) —
-both closed 2026-06-23. Immediate Focus has rotated to the cross-repo
-`overview` wedge (#153, cost) to seed the following release's cost slot.
+and the trigger-risk lint #104). The cost + security trio now **closed** on
+`main` and awaiting the next tag: the over-budget highlight (#129, cost,
+PR #160), the HIGH-finding `--strict` promotion (#38, security, PR #161) — both
+closed 2026-06-23 — and the cross-repo `overview` wedge (#153, cost, closed
+2026-06-29). Immediate Focus has rotated to the security epic's
+defense-in-depth UX child (#40, security) to seed the following release's
+security slot.
 
 **Exception**: a release scoped as a single `fix:` hotfix (no feature
 changes) is exempt — the rule applies to feature-bearing releases.
 
 ## Immediate Focus (next release in progress)
 
-Latest tag is **v0.2.4** (2026-06-22). The prior Immediate Focus pair — the
-over-budget rollup highlight (#129, cost, PR #160) and the HIGH-finding
-`--strict` promotion (#38, security, PR #161) — both **closed 2026-06-23** and
-now await the next release-please tag (see Completed Milestones). They cover the
-in-flight release's cost + security composition slots. Per the operator's
-2026-06-22 sequencing note, Immediate Focus has rotated to the cross-repo
-`overview` wedge (#153, cost), which seeds the *following* release's cost slot
-and unblocks the #154 / #155 observability cluster.
+Latest tag is **v0.2.4** (2026-06-22). The cross-repo `overview` wedge (#153,
+cost) **closed 2026-06-29** and now awaits the next release-please tag (see
+Completed Milestones), joining the over-budget highlight (#129, cost, PR #160)
+and the HIGH-finding `--strict` promotion (#38, security, PR #161) already
+closed 2026-06-23. That trio covers the in-flight release's cost + security
+slots. With overview shipped, Immediate Focus has rotated to the security
+epic's defense-in-depth UX child (#40, security), seeding the *following*
+release's security slot. Its drill-down companion #154 (whose
+`ship after overview lands` trigger is now met) and CI gate #155 remain
+eligible for a later rotation.
 
-> `/roadmap sync` (2026-06-23) promoted #153 to single-WIP after both prior
-> `roadmap/current` items closed the same day. Gate state: depth 0 → target 1,
-> composition balanced (the closed pair #129 cost + #38 security covers the
-> in-flight release), so exactly one slot opened. The mechanical top score was
-> #40 (+20, epic-eligible), but the operator confirmed the pre-registered #153
-> designation to keep the security epic from double-stacking this release.
-> Demote/rotate again once #153 lands.
+> `/roadmap sync` (2026-06-28) promoted #40 to single-WIP after #153 closed the
+> same day. Gate state: depth 0 → target 1, composition balanced (the closed
+> trio #129 / #153 cost + #38 security covers the in-flight release), so exactly
+> one slot opened. #40 was the mechanical top (+20: epic-eligible +15, medium
+> +5) — the operator promoted it this round (reversing the 2026-06-23 deferral)
+> now that #153 has shipped. Demote/rotate again once #40 lands; #154 (+15,
+> trigger now met) is the strongest next candidate.
 
-- [ ] [#153](https://github.com/rshade/gh-aw-fleet/issues/153)
-  `gh-aw-fleet overview` — unified cross-repo health + cost + drift view `[L]`
-  `cost` `finops` `cross-repo`
-  *One read-only dashboard joining run health (failures/success %), cost
-  (AIC/USD), and drift per repo, reusing the `Status()` + `gh aw logs`
-  fan-outs. Ships standalone and locally; relates to EPIC #146.
-  `unblocks: 146`. Drill-down companion #154 and CI gate #155 depend on it.*
-  *Promoted by /roadmap sync on 2026-06-23 — refills the single WIP slot
-  vacated by #129 / #38; anchors the next release's cost composition slot.*
+- [ ] [#40](https://github.com/rshade/gh-aw-fleet/issues/40)
+  Defense-in-depth UX: stderr + interactive prompt + PR body Security Findings
+  section `[M]` `security`
+  *Child of the security epic #36 (promotion-eligible since Layer 1 #37 shipped
+  and the `--strict` promotion #38 closed). Surfaces scanner findings across
+  three channels — structured stderr, an interactive confirm prompt, and a
+  PR-body "Security Findings" section — so advisory findings stop dead-ending in
+  logs. Advisory-only; pairs with the still-open `--deep-scan` sibling #39.*
+  *Promoted by /roadmap sync on 2026-06-28 — refills the single WIP slot vacated
+  by #153; seeds the following release's security composition slot.*
 
 ## Near-Term Vision (v0.4 — FinOps build-out + operator QoL)
 
-With the FinOps build-out shipped and the prior cost + security composition
-pair (#129, #38) now closed and awaiting the next tag, Immediate Focus holds
-the cross-repo `overview` wedge (#153). Near-Term holds its drill-down
-companion (#154), the remaining FinOps work — forecast (#102) and consumption
-scale-hardening (#119) — plus the deploy/consumption follow-ups (#112 / #115),
-a diagnostics expansion (#99), the docs-theme adoption (#147), and four docs
-items (#94 / #95 / #127 / #128).
+With the FinOps build-out shipped and the cost + security composition trio
+(#129, #153, #38) now closed and awaiting the next tag, Immediate Focus holds
+the security epic's defense-in-depth UX child (#40). Near-Term holds the
+overview drill-down companion (#154, trigger now met), the remaining FinOps
+work — forecast (#102) and consumption scale-hardening (#119) — plus the
+deploy/consumption follow-ups (#112 / #115), a diagnostics expansion (#99), the
+docs-theme adoption (#147), and four docs items (#94 / #95 / #127 / #128).
 
 ### Observability / cross-repo wedge
 
-The local cross-repo health + cost + drift view. The `overview` lead (#153) is
-now in **Immediate Focus**; its drill-down companion remains here. A separate
-hosted control plane (#146) consumes the same engine for org-wide
+The local cross-repo health + cost + drift view. The `overview` lead (#153)
+**shipped 2026-06-29** (see Completed Milestones); its drill-down companion
+(#154) remains here with its `ship after overview lands` trigger now met. A
+separate hosted control plane (#146) consumes the same engine for org-wide
 observability; this CLI view ships standalone and locally first.
 
 - [ ] [#154](https://github.com/rshade/gh-aw-fleet/issues/154)
@@ -235,7 +241,8 @@ layer to enforce fleet-wide policy that per-repo tools cannot.
   *Umbrella: insert a scanner layer that catches secrets, dangerous
   compiled-YAML patterns, and fleet-structural violations before PRs merge.
   Layer 1 (#37) shipped 2026-05-07 and the `--strict` promotion (#38) shipped
-  2026-06-23; #39 / #40 remain eligible for promotion under the epic's own rule.*
+  2026-06-23; #40 was promoted to Immediate Focus 2026-06-28, and #39 remains
+  eligible for promotion under the epic's own rule.*
   - [x] [#37](https://github.com/rshade/gh-aw-fleet/issues/37) Layer 1
     scanner: secrets + compiled-YAML + fleet-structural rules `[L]`
     (shipped 2026-05-07)
@@ -247,7 +254,7 @@ layer to enforce fleet-wide policy that per-repo tools cannot.
     classifier `[L]`
   - [ ] [#40](https://github.com/rshade/gh-aw-fleet/issues/40)
     Defense-in-depth UX: stderr + interactive prompt + PR body Security
-    Findings section `[M]`
+    Findings section `[M]` — **now in Immediate Focus (promoted 2026-06-28)**
 - [ ] Pin hygiene validator `[S]`
   *New `fleet validate` command: scan `fleet.json` and every resolved
   `SourceRef` for floating refs (`main`, `latest`, branch names) and fail on
@@ -456,6 +463,14 @@ were deferred at v1 to keep the initial command surface small.
 
 ### 2026-Q2
 
+- [x] [#153](https://github.com/rshade/gh-aw-fleet/issues/153)
+  `gh-aw-fleet overview` — unified cross-repo health + cost + drift view `[L]`
+  `cost` `finops` `cross-repo`
+  *Closed 2026-06-29. One read-only dashboard joining run health
+  (failures/success %), cost (AIC/USD), and drift per repo, reusing the
+  `Status()` + `gh aw logs` fan-outs. Shipped standalone and locally;
+  `unblocks: 146` (control-plane epic). Anchored the in-flight release's cost
+  composition slot; drill-down companion #154 and CI gate #155 now eligible.*
 - [x] [#129](https://github.com/rshade/gh-aw-fleet/issues/129) Read-only
   over-budget highlighting in the rollup (`--budget`) `[M]` `cost` `finops`
   `spec-first`
@@ -706,19 +721,21 @@ Any roadmap item that violates these is rejected, not negotiated.
 
 [meta-spec]: ./CONTEXT.md#roadmap-meta-issue-body-convention
 
-> Tracked as GitHub issues: Immediate Focus — the cross-repo `overview` wedge
-> (#153, cost), promoted 2026-06-23; Near-Term — its drill-down companion
-> (#154), the FinOps build-out (#102, #119), the deploy/consumption follow-ups
-> (#112, #115), a diagnostics hint (#99), the docs-theme adoption (#147), and
-> docs items (#94, #95, #127, #128); Future Vision — the security epic (#36
-> with children #39, #40), the FinOps deferred set (#105, #106, #107, #113,
-> #53, #59, #60), the control-plane enablement cluster (#146 epic with
-> #141–#145 and #163), the overview CI gate (#155), and the Status refinements
-> (#61, #62). Closed on `main` awaiting the next tag: the in-flight cost +
-> security composition pair #129 / #38 (both closed 2026-06-23), alongside the
-> ax-go phase 1 (#156) and the `pkg/fleet` export (#148). Excluded as
-> operational noise: #5 (Dependency Dashboard) and the `[aw]` bot failure
-> reports (#140 / #151 / #157). Note: #162 duplicates #163 (Pluggable
-> ConfigSource) and is unlabeled — close it as a dup. The unlinked Near-Term
-> and Future items don't have issues yet — open them as work picks up, then
-> run `/roadmap sync`.
+> Tracked as GitHub issues: Immediate Focus — the security epic's
+> defense-in-depth UX child (#40, security), promoted 2026-06-28; Near-Term —
+> the overview drill-down companion (#154, trigger now met), the FinOps
+> build-out (#102, #119), the deploy/consumption follow-ups (#112, #115), a
+> diagnostics hint (#99), the docs-theme adoption (#147), and docs items (#94,
+> #95, #127, #128); Future Vision — the security epic (#36 with child #39), the
+> FinOps deferred set (#105, #106, #107, #113, #53, #59, #60), the control-plane
+> enablement cluster (#146 epic with #141–#145 and #163), the overview CI gate
+> (#155), and the Status refinements (#61, #62). Closed on `main` awaiting the
+> next tag: the in-flight cost + security composition trio #129 / #153 / #38
+> (#129 and #38 closed 2026-06-23, #153 closed 2026-06-29), alongside the ax-go
+> phase 1 (#156) and the `pkg/fleet` export (#148). Excluded as operational
+> noise: #5 (Dependency Dashboard) and the `[aw]` bot failure reports (#140 /
+> #151 / #157 / #165 / #166 / #167 / #174 / #175). Flagged for manual close:
+> #162 (Pluggable ConfigSource) duplicates #163 and is unlabeled — close it as
+> a dup (`/roadmap sync` lacks permission to close issues it did not open). The
+> unlinked Near-Term and Future items don't have issues yet — open them as work
+> picks up, then run `/roadmap sync`.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -21,6 +21,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 		flagPRTitle string
 		flagWorkDir string
 		flagStrict  bool
+		flagYes     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "deploy <repo>",
@@ -49,14 +50,14 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 				Branch:   flagBranch,
 				PRTitle:  flagPRTitle,
 				WorkDir:  flagWorkDir,
-				Security: fleet.SecurityOpts{Strict: flagStrict},
+				Security: securityOptsFor(flagStrict, flagYes, jsonMode),
 			}
 			res, deployErr := runFleetDeploy(cmd.Context(), cfg, repo, opts)
 			if jsonMode {
 				return emitDeployEnvelope(cmd, repo, flagApply, res, deployErr)
 			}
 			printDeploy(cmd, res, flagApply, deployErr)
-			return deployErr
+			return mapOperatorDecline(cmd, deployErr)
 		},
 	}
 	cmd.Flags().BoolVar(&flagApply, "apply", false,
@@ -70,6 +71,7 @@ func newDeployCmd(flagDir *string) *cobra.Command {
 	cmd.Flags().StringVar(&flagWorkDir, "work-dir", "",
 		"Existing clone to deploy into (skips git clone + auto-cleanup; resumes at commit/push gate if staged changes or unpushed commits exist)")
 	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
+	cmd.Flags().BoolVar(&flagYes, "yes", false, yesFlagUsage)
 	return cmd
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -38,6 +38,11 @@ const (
 // strictFlagUsage is the shared --strict help text for deploy, sync, and upgrade.
 const strictFlagUsage = "Fail when HIGH Layer 1 security findings are present (does not change gh aw compile --strict)"
 
+// yesFlagUsage is the shared --yes help text for deploy, sync, and upgrade. It
+// skips only the interactive findings confirmation — the stderr findings and
+// the PR-body Security Findings section are still produced.
+const yesFlagUsage = "Skip the interactive security-findings confirmation prompt (findings still print on stderr and in the PR body)"
+
 const (
 	diagnosticFieldDrift  = "drift"
 	diagnosticFieldRepo   = "repo"
@@ -135,6 +140,30 @@ func foldCompileStrictError(
 		Message: cse.Message,
 		Fields:  cse.Fields,
 	}), true
+}
+
+// securityOptsFor builds the invocation's SecurityOpts. It forces Yes in JSON
+// mode: a prompt written to stdout would corrupt the JSON envelope and a
+// machine cannot answer it, so --output json is treated as non-interactive
+// (FR-018). Centralizing this keeps the deploy/sync/upgrade RunE closures
+// simple and the JSON-suppression rule in one place.
+func securityOptsFor(strict, yes, jsonMode bool) fleet.SecurityOpts {
+	return fleet.SecurityOpts{Strict: strict, Yes: yes || jsonMode}
+}
+
+// mapOperatorDecline converts a fleet *OperatorDeclinedError into a clean,
+// silent, non-zero exit: it prints the actionable abort message to stderr and
+// returns a commandExitError so main.go skips the fatal-crash logger and the
+// decline is never routed through the diagnostic hint engine. Any other error
+// (including nil) passes through unchanged. Called on the text-mode return
+// paths of deploy/sync/upgrade; the JSON paths suppress the prompt entirely
+// (FR-018), so a decline cannot arise there.
+func mapOperatorDecline(cmd *cobra.Command, err error) error {
+	if err == nil || !fleet.IsOperatorDeclinedError(err) {
+		return err
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+	return newCommandExitError(err, 1, true)
 }
 
 // outputMode reads the resolved --output value. PersistentPreRunE has already

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -16,6 +16,13 @@ type schemaExitCoder interface {
 	ExitCode() int
 }
 
+// schemaCommandUses returns the cobra Use strings for the three mutation
+// commands, shared by the per-command flag-schema tests (kept in one place so
+// goconst doesn't flag the repeated literals).
+func schemaCommandUses() []string {
+	return []string{"deploy <repo>", "sync <repo>", "upgrade [repo|--all]"}
+}
+
 func TestSchemaCommandEmitsAXSchema(t *testing.T) {
 	stdout, stderr, err := executeSchemaCommand("__schema")
 	if err != nil {
@@ -137,7 +144,7 @@ func TestSchemaCommandIncludesStrictFlags(t *testing.T) {
 		t.Fatalf("__schema stdout is not valid schema JSON: %v\nstdout: %s", decodeErr, stdout)
 	}
 
-	for _, use := range []string{"deploy <repo>", "sync <repo>", "upgrade [repo|--all]"} {
+	for _, use := range schemaCommandUses() {
 		cmd := requireSchemaCommand(t, got.Command, use)
 		flag := requireSchemaFlag(t, cmd, "strict")
 		if flag.Type != "bool" {
@@ -150,6 +157,32 @@ func TestSchemaCommandIncludesStrictFlags(t *testing.T) {
 			if !strings.Contains(flag.Usage, want) {
 				t.Fatalf("%s --strict usage = %q; want substring %q", use, flag.Usage, want)
 			}
+		}
+	}
+}
+
+func TestSchemaCommandIncludesYesFlags(t *testing.T) {
+	stdout, stderr, err := executeSchemaCommand("__schema")
+	if err != nil {
+		t.Fatalf("__schema returned error: %v\nstderr: %s", err, stderr)
+	}
+
+	var got axschema.Schema
+	if decodeErr := json.Unmarshal([]byte(stdout), &got); decodeErr != nil {
+		t.Fatalf("__schema stdout is not valid schema JSON: %v\nstdout: %s", decodeErr, stdout)
+	}
+
+	for _, use := range schemaCommandUses() {
+		cmd := requireSchemaCommand(t, got.Command, use)
+		flag := requireSchemaFlag(t, cmd, "yes")
+		if flag.Type != "bool" {
+			t.Fatalf("%s --yes type = %q; want bool", use, flag.Type)
+		}
+		if flag.Default != "false" {
+			t.Fatalf("%s --yes default = %q; want false", use, flag.Default)
+		}
+		if !strings.Contains(flag.Usage, "Skip the interactive") {
+			t.Fatalf("%s --yes usage = %q; want substring %q", use, flag.Usage, "Skip the interactive")
 		}
 	}
 }

--- a/cmd/security_prompt_test.go
+++ b/cmd/security_prompt_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet"
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+	logpkg "github.com/rshade/gh-aw-fleet/internal/log"
+	"github.com/rshade/gh-aw-fleet/internal/testutil"
+)
+
+// --- T019: --yes flag registration, help text, and propagation ---
+
+func TestYesFlagAppearsInHelp(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "deploy", cmd: newDeployCmd(&dir)},
+		{name: "sync", cmd: newSyncCmd(&dir)},
+		{name: "upgrade", cmd: newUpgradeCmd(&dir)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := tc.cmd.Flags().Lookup("yes")
+			if flag == nil {
+				t.Fatal("--yes flag missing")
+			}
+			for _, want := range []string{"Skip the interactive", "stderr", "PR body"} {
+				if !strings.Contains(flag.Usage, want) {
+					t.Fatalf("--yes usage = %q; want substring %q", flag.Usage, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeployYesFlagPropagates(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetDeploy
+	t.Cleanup(func() { runFleetDeploy = orig })
+
+	var got []fleet.DeployOpts
+	runFleetDeploy = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.DeployOpts) (*fleet.DeployResult, error) {
+		got = append(got, opts)
+		return &fleet.DeployResult{Repo: repo, SecurityFindings: []security.Finding{}}, nil
+	}
+
+	if err := executeStandaloneCommand(newDeployCmd(&dir), "acme/widgets"); err != nil {
+		t.Fatalf("deploy error = %v", err)
+	}
+	if err := executeStandaloneCommand(newDeployCmd(&dir), "acme/widgets", "--yes"); err != nil {
+		t.Fatalf("deploy --yes error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("deploy calls = %d; want 2", len(got))
+	}
+	if got[0].Security.Yes {
+		t.Error("default deploy propagated Yes=true")
+	}
+	if !got[1].Security.Yes {
+		t.Error("deploy --yes propagated Yes=false")
+	}
+}
+
+func TestSyncYesFlagPropagates(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetSync
+	t.Cleanup(func() { runFleetSync = orig })
+
+	var got fleet.SyncOpts
+	runFleetSync = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.SyncOpts) (*fleet.SyncResult, error) {
+		got = opts
+		return &fleet.SyncResult{Repo: repo, SecurityFindings: []security.Finding{}}, nil
+	}
+
+	if err := executeStandaloneCommand(newSyncCmd(&dir), "acme/widgets", "--yes"); err != nil {
+		t.Fatalf("sync --yes error = %v", err)
+	}
+	if !got.Security.Yes {
+		t.Error("sync --yes propagated Yes=false")
+	}
+}
+
+func TestUpgradeYesFlagPropagates(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetUpgrade
+	t.Cleanup(func() { runFleetUpgrade = orig })
+
+	var got fleet.UpgradeOpts
+	runFleetUpgrade = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.UpgradeOpts) (*fleet.UpgradeResult, error) {
+		got = opts
+		return &fleet.UpgradeResult{Repo: repo}, nil
+	}
+
+	if err := executeStandaloneCommand(newUpgradeCmd(&dir), "acme/widgets", "--yes"); err != nil {
+		t.Fatalf("upgrade --yes error = %v", err)
+	}
+	if !got.Security.Yes {
+		t.Error("upgrade --yes propagated Yes=false")
+	}
+}
+
+// --- T026 / T027: --output json forces Yes (FR-018), envelope stays valid ---
+
+func TestJSONModeForcesYesOnDeploy(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetDeploy
+	t.Cleanup(func() { runFleetDeploy = orig })
+
+	var got fleet.DeployOpts
+	var stdout bytes.Buffer
+	runFleetDeploy = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.DeployOpts) (*fleet.DeployResult, error) {
+		got = opts
+		return &fleet.DeployResult{
+			Repo:             repo,
+			SecurityFindings: []security.Finding{strictCommandFinding()},
+		}, nil
+	}
+
+	root := NewRootCmd()
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"--dir", dir, "-o", "json", "deploy", "acme/widgets", "--apply"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("deploy -o json error = %v", err)
+	}
+	if !got.Security.Yes {
+		t.Error("json mode did not force Security.Yes=true (FR-018)")
+	}
+	// The JSON envelope must be valid and uncorrupted by any prompt text.
+	var env Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("envelope not valid JSON: %v\nraw=%s", err, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Proceed with commit") {
+		t.Error("prompt text leaked into the JSON envelope")
+	}
+}
+
+func TestTextModeDoesNotForceYes(t *testing.T) {
+	dir := writeStrictCommandConfig(t)
+	orig := runFleetDeploy
+	t.Cleanup(func() { runFleetDeploy = orig })
+
+	var got fleet.DeployOpts
+	runFleetDeploy = func(_ context.Context, _ *fleet.Config, repo string, opts fleet.DeployOpts) (*fleet.DeployResult, error) {
+		got = opts
+		return &fleet.DeployResult{Repo: repo, SecurityFindings: []security.Finding{}}, nil
+	}
+
+	root := NewRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"--dir", dir, "deploy", "acme/widgets", "--apply"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("deploy error = %v", err)
+	}
+	if got.Security.Yes {
+		t.Error("text mode without --yes should leave Security.Yes=false")
+	}
+}
+
+// --- T009: operator-decline mapping ---
+
+func TestMapOperatorDeclineCleanExit(t *testing.T) {
+	declineErr := &fleet.OperatorDeclinedError{Repo: "x/y", Findings: 2}
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&bytes.Buffer{})
+
+	mapped := mapOperatorDecline(cmd, declineErr)
+	if mapped == nil {
+		t.Fatal("mapped error is nil; want a non-zero exit error")
+	}
+	code, ok := ExitCodeForError(mapped)
+	if !ok || code != 1 {
+		t.Errorf("ExitCodeForError = (%d, %v); want (1, true)", code, ok)
+	}
+	if !SuppressErrorLog(mapped) {
+		t.Error("decline should suppress the fatal-crash log")
+	}
+	if !fleet.IsOperatorDeclinedError(mapped) {
+		t.Error("mapped error should still unwrap to *OperatorDeclinedError")
+	}
+	if !strings.Contains(stderr.String(), "aborted by operator") {
+		t.Errorf("stderr = %q; want the abort message", stderr.String())
+	}
+}
+
+func TestMapOperatorDeclinePassthrough(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetOut(&bytes.Buffer{})
+
+	if got := mapOperatorDecline(cmd, nil); got != nil {
+		t.Errorf("mapOperatorDecline(nil) = %v; want nil", got)
+	}
+	other := errors.New("boom")
+	if got := mapOperatorDecline(cmd, other); !errors.Is(got, other) {
+		t.Errorf("mapOperatorDecline(other) = %v; want passthrough of %v", got, other)
+	}
+}
+
+// --- T021: --yes still emits the stderr findings surface (cmd layer) ---
+
+func TestSecurityFindingWarningsIndependentOfPrompt(t *testing.T) {
+	// emitSecurityFindingWarnings is the cmd-layer stderr surface; it never
+	// consults --yes, so findings always print regardless of the prompt choice.
+	finding := strictCommandFinding()
+	buf := testutil.CaptureStderr(t, func() {
+		if err := logpkg.Configure("info", "json"); err != nil {
+			t.Fatal(err)
+		}
+		emitSecurityFindingWarnings([]security.Finding{finding})
+	})
+	if !strings.Contains(buf, finding.RuleID) {
+		t.Errorf("stderr = %q; want finding rule_id %q", buf, finding.RuleID)
+	}
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,6 +22,7 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 		flagForce   bool
 		flagWorkDir string
 		flagStrict  bool
+		flagYes     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "sync <repo>",
@@ -56,14 +57,14 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 				Prune:    flagPrune,
 				Force:    flagForce,
 				WorkDir:  flagWorkDir,
-				Security: fleet.SecurityOpts{Strict: flagStrict},
+				Security: securityOptsFor(flagStrict, flagYes, jsonMode),
 			}
 			res, syncErr := runFleetSync(cmd.Context(), cfg, repo, opts)
 			if jsonMode {
 				return emitSyncEnvelope(cmd, repo, flagApply, res, syncErr)
 			}
 			printSync(cmd, res, flagApply, flagPrune, syncErr)
-			return syncErr
+			return mapOperatorDecline(cmd, syncErr)
 		},
 	}
 	cmd.Flags().BoolVar(&flagApply, "apply", false,
@@ -75,6 +76,7 @@ func newSyncCmd(flagDir *string) *cobra.Command {
 	cmd.Flags().StringVar(&flagWorkDir, "work-dir", "",
 		"Existing clone to sync (skips git clone + auto-cleanup)")
 	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
+	cmd.Flags().BoolVar(&flagYes, "yes", false, yesFlagUsage)
 	return cmd
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -24,6 +24,7 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 		flagWorkDir string
 		flagAll     bool
 		flagStrict  bool
+		flagYes     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "upgrade [repo|--all]",
@@ -57,7 +58,7 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 				Major:    flagMajor,
 				Force:    flagForce,
 				WorkDir:  flagWorkDir,
-				Security: fleet.SecurityOpts{Strict: flagStrict},
+				Security: securityOptsFor(flagStrict, flagYes, jsonMode),
 			}
 			if flagAll {
 				return runUpgradeAll(cmd, cfg, opts, flagApply, flagAudit, jsonMode)
@@ -78,6 +79,7 @@ func newUpgradeCmd(flagDir *string) *cobra.Command {
 	cmd.Flags().BoolVar(&flagAll, "all", false,
 		"Upgrade all repos in fleet.json")
 	cmd.Flags().BoolVar(&flagStrict, "strict", false, strictFlagUsage)
+	cmd.Flags().BoolVar(&flagYes, "yes", false, yesFlagUsage)
 	return cmd
 }
 
@@ -235,7 +237,7 @@ func runUpgradeAll(
 	}
 	results, allErr := fleet.UpgradeAll(cmd.Context(), cfg, opts)
 	printUpgradeAll(cmd, results, audit)
-	return allErr
+	return mapOperatorDecline(cmd, allErr)
 }
 
 // runUpgradeSingle routes the single-repo path. Validates the repo is tracked
@@ -255,7 +257,7 @@ func runUpgradeSingle(
 		return emitUpgradeEnvelope(cmd, repo, apply, res, upErr)
 	}
 	printUpgrade(cmd, res, apply)
-	return upErr
+	return mapOperatorDecline(cmd, upErr)
 }
 
 // emitUpgradeEnvelope writes a single-repo upgrade envelope. Hints come from

--- a/docs/src/content/docs/reconcile.md
+++ b/docs/src/content/docs/reconcile.md
@@ -81,6 +81,36 @@ Lower-severity findings and `promptinj:` findings remain advisory. For
 `upgrade --all --strict --output json`, NDJSON records are emitted through the
 blocked repo and then processing stops.
 
+## Interactive findings confirmation
+
+Separate from `--strict`, an `--apply` that produces one or more findings (of
+any severity) pauses for a last-chance confirmation before it commits, pushes,
+or opens a PR — but only at an interactive terminal:
+
+```text
+⚠  2 HIGH, 1 MEDIUM. Proceed with commit? [y/N]
+```
+
+The default is **No**. Declining aborts cleanly, exits non-zero, and preserves
+the work-dir clone for inspection (resume with `--work-dir <clone> --yes`).
+Accepting proceeds, and the PR body still includes the `## Security Findings`
+section.
+
+Findings have three independent surfaces — stderr warnings, this prompt, and
+the PR-body section. `--strict` is a non-interactive hard block on HIGH
+findings; the prompt is an interactive last-chance gate on any finding.
+
+The prompt is skipped — without suppressing the stderr or PR-body surfaces — by:
+
+- `--yes` on `deploy`, `sync`, or `upgrade`;
+- a non-interactive stdout (piped, redirected, or CI), so nothing hangs;
+- `--output json`, which is treated as non-interactive even at a TTY so the
+  envelope stays valid.
+
+Use `--strict` when you want a non-interactive *block* rather than an
+auto-proceed. The prompt only fires on `--apply` (never on dry-runs) and after
+the `--strict` gate. `--yes` is per invocation and never written to config.
+
 ## The three-turn pattern
 
 Any command that mutates external repositories follows this operator flow:

--- a/internal/fleet/deploy.go
+++ b/internal/fleet/deploy.go
@@ -296,12 +296,26 @@ func Deploy(ctx context.Context, cfg *Config, repo string, opts DeployOpts) (*De
 		return res, manifestErr
 	}
 
+	return finalizeDeployCommit(ctx, res, repo, opts, &cleanupClone)
+}
+
+// finalizeDeployCommit is the fresh-path commit gate: it returns (res, nil) on a
+// no-op apply (nothing added and nothing staged), runs the interactive findings
+// confirmation, and opens the PR. Declining preserves the clone via cleanupClone
+// and returns an *OperatorDeclinedError before createDeployPR runs.
+func finalizeDeployCommit(
+	ctx context.Context, res *DeployResult, repo string, opts DeployOpts, cleanupClone *bool,
+) (*DeployResult, error) {
 	staged, err := hasStagedOrUnstagedWorkflowChanges(ctx, res.CloneDir)
 	if err != nil {
 		return res, err
 	}
 	if len(res.Added) == 0 && !staged {
 		return res, nil
+	}
+	confirmErr := confirmSecurityFindings(repo, res.SecurityFindings, opts.Security, cleanupClone)
+	if confirmErr != nil {
+		return res, confirmErr
 	}
 	return createDeployPR(ctx, res, repo, opts, "")
 }
@@ -365,24 +379,7 @@ func handleWorkDirResume(
 	}
 
 	if staged {
-		fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at commit gate)\n", opts.WorkDir)
-		engine := cfg.EffectiveEngine(repo)
-		res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
-		res.ActionsDisabled, res.WorkflowTokenReadOnly = checkActionsSettings(ctx, repo)
-		if !opts.Apply {
-			effective, source := logCompileStrictResolution(ctx, cfg, repo)
-			res.CompileStrictSource = source
-			res.CompileStrictEffective = effective
-			return res, true, nil
-		}
-		if compileErr := refreshResumeCompileStrict(ctx, cfg, repo, res); compileErr != nil {
-			return res, true, compileErr
-		}
-		if manifestErr := writeDeployManifest(ctx, cfg, repo, res.CloneDir); manifestErr != nil {
-			return res, true, manifestErr
-		}
-		out, prErr := createDeployPR(ctx, res, repo, opts, branch)
-		return out, true, prErr
+		return resumeAtCommitGate(ctx, cfg, repo, res, opts, branch)
 	}
 
 	fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at push gate)\n", opts.WorkDir)
@@ -398,10 +395,47 @@ func handleWorkDirResume(
 		res.CompileStrictEffective = effective
 		return res, true, nil
 	}
+	// The refresh helper may amend the saved commit; ask first so a decline
+	// leaves the resumed branch history untouched.
+	if confirmErr := confirmSecurityFindings(repo, res.SecurityFindings, opts.Security, nil); confirmErr != nil {
+		return res, true, confirmErr
+	}
 	if compileErr := refreshResumePushCompileStrict(ctx, cfg, repo, res, branch); compileErr != nil {
 		return res, true, compileErr
 	}
 	out, prErr := pushAndCreatePR(ctx, res, repo, opts, branch, nil)
+	return out, true, prErr
+}
+
+// resumeAtCommitGate finishes a --work-dir resume that has staged .github/
+// changes: it refreshes preflight + compile-strict, writes the manifest, runs
+// the interactive findings confirmation, and opens the PR. A dry-run returns
+// after logging the resolved compile-strict policy. The clone is already
+// preserved on every resume, so the confirmation passes a nil cleanup flag.
+// Returns the (result, handled, err) tuple handleWorkDirResume propagates.
+func resumeAtCommitGate(
+	ctx context.Context, cfg *Config, repo string, res *DeployResult, opts DeployOpts, branch string,
+) (*DeployResult, bool, error) {
+	fmt.Fprintf(os.Stderr, "(resumed from --work-dir %s at commit gate)\n", opts.WorkDir)
+	engine := cfg.EffectiveEngine(repo)
+	res.MissingSecret, res.SecretKeyURL = checkEngineSecret(ctx, repo, engine)
+	res.ActionsDisabled, res.WorkflowTokenReadOnly = checkActionsSettings(ctx, repo)
+	if !opts.Apply {
+		effective, source := logCompileStrictResolution(ctx, cfg, repo)
+		res.CompileStrictSource = source
+		res.CompileStrictEffective = effective
+		return res, true, nil
+	}
+	if compileErr := refreshResumeCompileStrict(ctx, cfg, repo, res); compileErr != nil {
+		return res, true, compileErr
+	}
+	if manifestErr := writeDeployManifest(ctx, cfg, repo, res.CloneDir); manifestErr != nil {
+		return res, true, manifestErr
+	}
+	if confirmErr := confirmSecurityFindings(repo, res.SecurityFindings, opts.Security, nil); confirmErr != nil {
+		return res, true, confirmErr
+	}
+	out, prErr := createDeployPR(ctx, res, repo, opts, branch)
 	return out, true, prErr
 }
 

--- a/internal/fleet/security/render.go
+++ b/internal/fleet/security/render.go
@@ -57,6 +57,16 @@ func RenderForPRBody(findings []Finding) string {
 	return b.String()
 }
 
+// SeveritySummary returns the per-severity tally used by both the PR-body
+// summary and the interactive findings prompt — e.g. "2 HIGH, 1 MEDIUM" —
+// in HIGH→MEDIUM→LOW→INFO order, omitting zero counts. Returns the empty
+// string when len(findings) == 0. It is a thin exported wrapper over the
+// unexported severityTally so the prompt's one-line summary stays identical
+// to the PR-body summary (one severity-counting code path).
+func SeveritySummary(findings []Finding) string {
+	return severityTally(findings)
+}
+
 // numSeverityBuckets is the count of distinct severity values whose
 // counts are tallied in the PR-body summary line (HIGH, MEDIUM, LOW,
 // INFO). The Renovate config scanner emits LOW (FR-015).

--- a/internal/fleet/security/render_test.go
+++ b/internal/fleet/security/render_test.go
@@ -50,3 +50,57 @@ func TestRenderForStderrFileSlotCorners(t *testing.T) {
 		}
 	}
 }
+
+func TestSeveritySummaryEmpty(t *testing.T) {
+	if got := SeveritySummary(nil); got != "" {
+		t.Errorf("SeveritySummary(nil) = %q; want empty", got)
+	}
+	if got := SeveritySummary([]Finding{}); got != "" {
+		t.Errorf("SeveritySummary([]) = %q; want empty", got)
+	}
+}
+
+func TestSeveritySummaryTallyOrderAndOmission(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []Finding
+		want string
+	}{
+		{
+			name: "single high",
+			in:   []Finding{{Severity: SeverityHigh}},
+			want: "1 HIGH",
+		},
+		{
+			name: "mixed orders HIGH before MEDIUM regardless of input order",
+			in: []Finding{
+				{Severity: SeverityMedium},
+				{Severity: SeverityHigh},
+				{Severity: SeverityHigh},
+			},
+			want: "2 HIGH, 1 MEDIUM",
+		},
+		{
+			name: "all four buckets in HIGH→MEDIUM→LOW→INFO order",
+			in: []Finding{
+				{Severity: SeverityInfo},
+				{Severity: SeverityLow},
+				{Severity: SeverityMedium},
+				{Severity: SeverityHigh},
+			},
+			want: "1 HIGH, 1 MEDIUM, 1 LOW, 1 INFO",
+		},
+		{
+			name: "zero counts omitted (only LOW present)",
+			in:   []Finding{{Severity: SeverityLow}, {Severity: SeverityLow}},
+			want: "2 LOW",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SeveritySummary(tc.in); got != tc.want {
+				t.Errorf("SeveritySummary() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/fleet/security_gate.go
+++ b/internal/fleet/security_gate.go
@@ -14,6 +14,7 @@ const promptInjectionRulePrefix = "promptinj:"
 // SecurityOpts controls invocation-scoped security policy.
 type SecurityOpts struct {
 	Strict bool // block on HIGH non-promptinj security findings
+	Yes    bool // skip the interactive findings confirmation prompt; does NOT suppress stderr or PR-body findings
 }
 
 // StrictSecurityError is returned when the opt-in strict security gate blocks.

--- a/internal/fleet/security_prompt.go
+++ b/internal/fleet/security_prompt.go
@@ -1,0 +1,127 @@
+package fleet
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+)
+
+// stdoutIsTerminal reports whether stdout is an interactive character device.
+// It is the interactivity gate for the security-findings prompt: the question
+// is written to stdout, so detection keys on stdout (not stdin) — `tool | tee`
+// must not prompt into a redirected stream the operator never sees. Stdlib
+// only (mirrors cmd/add.go's isStdinTerminal), so no golang.org/x/term direct
+// dependency. Overridable in tests.
+//
+//nolint:gochecknoglobals // test-injection seam mirroring cmd/add.go isStdinTerminal
+var stdoutIsTerminal = func() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// promptStdin and promptStdout are the production reader/writer the
+// confirmSecurityFindings wrapper feeds to PromptUser. They are package-level
+// seams so placement tests can inject scripted input and capture output
+// without a real terminal.
+//
+//nolint:gochecknoglobals // test-injection seams for the interactive prompt
+var (
+	promptStdin  io.Reader = os.Stdin
+	promptStdout io.Writer = os.Stdout
+)
+
+// PromptUser asks the operator to confirm proceeding to commit despite security
+// findings. It returns (true, nil) on the non-interactive fast paths — findings
+// is empty, yes is true, or stdout is not a terminal — without reading in or
+// writing out. Otherwise it writes a one-line severity summary plus a `[y/N]`
+// prompt to out and reads a single line from in: "y"/"Y"/"yes" (trimmed,
+// case-insensitive) returns (true, nil); any other non-empty or empty line
+// returns (false, nil); an EOF or read error before an answer returns
+// (false, err). The safe default is No, so a bare Enter declines.
+func PromptUser(findings []security.Finding, yes bool, in io.Reader, out io.Writer) (bool, error) {
+	if len(findings) == 0 || yes || !stdoutIsTerminal() {
+		return true, nil
+	}
+	fmt.Fprintf(out, "⚠  %s. Proceed with commit? [y/N] ", security.SeveritySummary(findings))
+	line, readErr := bufio.NewReader(in).ReadString('\n')
+	if readErr != nil && readErr != io.EOF {
+		return false, readErr
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	case "":
+		// A bare Enter is default-No (readErr nil); an empty read at EOF is a
+		// no-answer decline that keeps the EOF cause for the Unwrap chain. The
+		// guard above leaves readErr as exactly nil or io.EOF, so returning it
+		// covers both. (default, by contrast, discards an incidental EOF on a
+		// non-empty explicit answer.)
+		return false, readErr
+	default:
+		return false, nil
+	}
+}
+
+// OperatorDeclinedError is returned when the operator declines the interactive
+// security-findings confirmation — an explicit "no", a bare Enter, EOF, or a
+// read error. The cmd layer recognizes it via IsOperatorDeclinedError and
+// surfaces it as a clean, non-crash, non-zero exit.
+type OperatorDeclinedError struct {
+	Repo     string // repository the apply was aborted for
+	Findings int    // number of findings shown at the prompt
+	Cause    error  // non-nil for EOF / read-error declines; nil for an explicit "no"
+}
+
+// Error returns the actionable abort message naming the finding count, the
+// repo, and the --yes escape hatch.
+func (e *OperatorDeclinedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"aborted by operator: %d security finding(s) for %s not accepted; "+
+			"re-run with --yes to skip the prompt",
+		e.Findings, e.Repo,
+	)
+}
+
+// Unwrap returns the read cause so EOF / read errors remain inspectable via
+// errors.Is / errors.As.
+func (e *OperatorDeclinedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// IsOperatorDeclinedError reports whether err is (or wraps) an
+// *OperatorDeclinedError. Mirrors IsStrictSecurityError so cmd/output.go can
+// map a deliberate decline to a clean exit without the hint engine.
+func IsOperatorDeclinedError(err error) bool {
+	var declined *OperatorDeclinedError
+	return errors.As(err, &declined)
+}
+
+// confirmSecurityFindings runs PromptUser with the production stdin/stdout
+// seams and, on decline, preserves the work-dir clone (sets *cleanupClone =
+// false when the pointer is non-nil; resume paths already disable cleanup and
+// pass nil) and returns a typed *OperatorDeclinedError. Returns nil when the
+// operator proceeds — including every non-interactive fast path.
+func confirmSecurityFindings(repo string, findings []security.Finding, opts SecurityOpts, cleanupClone *bool) error {
+	proceed, err := PromptUser(findings, opts.Yes, promptStdin, promptStdout)
+	if proceed {
+		return nil
+	}
+	if cleanupClone != nil {
+		*cleanupClone = false
+	}
+	return &OperatorDeclinedError{Repo: repo, Findings: len(findings), Cause: err}
+}

--- a/internal/fleet/security_prompt_placement_test.go
+++ b/internal/fleet/security_prompt_placement_test.go
@@ -55,6 +55,26 @@ func (r failOnReadReader) Read([]byte) (int, error) {
 	return 0, io.EOF
 }
 
+// stubCleanActionlint installs a no-op `actionlint` binary at the front of PATH
+// so the actionlint scanner resolves a binary and emits nothing, instead of the
+// `actionlint:not-installed` INFO finding it returns when the binary is absent.
+// Without this, the "zero findings" placement tests pass only on hosts that
+// happen to have actionlint installed (dev machines) and fail in CI, where the
+// graceful-degradation INFO finding is non-empty and — correctly, per FR-015 —
+// fires the confirmation prompt. The stub exits 0 with empty output, which the
+// scanner treats as "no diagnostics," making the baseline deterministic in both
+// environments. Mirrors the fake-gh fixture idiom; safe to combine because the
+// stub binary name does not collide.
+func stubCleanActionlint(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "actionlint"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub actionlint: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func gitOutput(t *testing.T, dir string, arg ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", arg...)
@@ -239,6 +259,7 @@ func TestDeployZeroFindingsNoPrompt(t *testing.T) {
 	_ = installFakeGhForSync(t, remote)
 	installHealthyDeployAPIs(t, repo)
 	stubGhAwVersionForStrictTests(t)
+	stubCleanActionlint(t)          // zero findings regardless of host actionlint
 	withInteractivePrompt(t, "n\n") // queued decline must be ignored
 
 	res, err := Deploy(context.Background(), strictGateTestConfig(repo), repo, DeployOpts{Apply: true})
@@ -318,6 +339,7 @@ func TestSyncPruneOnlyDropsStaleFindingsBeforePrompt(t *testing.T) {
 	repo := "rshade/prompt-sync-prune-stale"
 	remote := newTestRepo(t, seedHighSecurityWorkflow)
 	_ = installFakeGhForSync(t, remote)
+	stubCleanActionlint(t) // pruned repo is finding-free regardless of host actionlint
 	withPromptStdinUnread(t, true)
 
 	res, err := Sync(context.Background(), strictGateTestConfig(repo), repo, SyncOpts{

--- a/internal/fleet/security_prompt_placement_test.go
+++ b/internal/fleet/security_prompt_placement_test.go
@@ -1,0 +1,509 @@
+package fleet
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// withInteractivePrompt drives the security-findings prompt for placement
+// tests: it forces an interactive stdout and feeds promptStdin from stdin,
+// discarding prompt output. All three seams are restored on cleanup. These
+// tests mutate package-level seams, so they must not run with t.Parallel.
+func withInteractivePrompt(t *testing.T, stdin string) {
+	t.Helper()
+	origTTY := stdoutIsTerminal
+	origIn := promptStdin
+	origOut := promptStdout
+	t.Cleanup(func() {
+		stdoutIsTerminal = origTTY
+		promptStdin = origIn
+		promptStdout = origOut
+	})
+	stdoutIsTerminal = func() bool { return true }
+	promptStdin = strings.NewReader(stdin)
+	promptStdout = io.Discard
+}
+
+// withPromptStdinUnread forces a TTY but installs a stdin reader that fails the
+// test if it is ever read — proving a code path proceeded without prompting.
+func withPromptStdinUnread(t *testing.T, isTTY bool) {
+	t.Helper()
+	origTTY := stdoutIsTerminal
+	origIn := promptStdin
+	origOut := promptStdout
+	t.Cleanup(func() {
+		stdoutIsTerminal = origTTY
+		promptStdin = origIn
+		promptStdout = origOut
+	})
+	stdoutIsTerminal = func() bool { return isTTY }
+	promptStdin = failOnReadReader{t}
+	promptStdout = io.Discard
+}
+
+type failOnReadReader struct{ t *testing.T }
+
+func (r failOnReadReader) Read([]byte) (int, error) {
+	r.t.Error("stdin read on a path that must not prompt")
+	return 0, io.EOF
+}
+
+func gitOutput(t *testing.T, dir string, arg ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", arg...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", arg, dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newPromptDeployFixture wires the strict-gate fixtures (a remote seeded with a
+// HIGH finding, a fake gh, healthy Actions APIs, a stubbed gh aw version) and
+// returns the config + repo for a deploy that reaches the commit boundary with
+// findings present but compile-strict off.
+func newPromptDeployFixture(t *testing.T, repo string) *Config {
+	t.Helper()
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	stubGhAwVersionForStrictTests(t)
+	return strictGateTestConfig(repo)
+}
+
+// TestDeployPromptDeclineAbortsBeforePR is the MVP guarantee: an interactive
+// apply with findings and "n" returns a typed decline, makes no remote change,
+// and preserves the clone — all before createDeployPR runs.
+func TestDeployPromptDeclineAbortsBeforePR(t *testing.T) {
+	repo := "rshade/prompt-deploy-decline"
+	cfg := newPromptDeployFixture(t, repo)
+	withInteractivePrompt(t, "n\n")
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{Apply: true})
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	if res.BranchPushed != "" || res.PRURL != "" {
+		t.Fatalf("BranchPushed/PRURL = %q/%q; want no mutation on decline", res.BranchPushed, res.PRURL)
+	}
+	if _, statErr := os.Stat(res.CloneDir); statErr != nil {
+		t.Fatalf("clone not preserved on decline: %v", statErr)
+	}
+	var declined *OperatorDeclinedError
+	if errors.As(err, &declined) {
+		if declined.Findings == 0 {
+			t.Error("decline error should carry a positive finding count")
+		}
+		if declined.Repo != repo {
+			t.Errorf("declined.Repo = %q; want %q", declined.Repo, repo)
+		}
+	}
+}
+
+// TestDeployPromptAcceptProceedsToPR proves "y" passes the prompt and reaches
+// createDeployPR (which fails at the fake gh pr create) — so the prompt is
+// reached before the commit boundary, with findings visible pre-commit.
+func TestDeployPromptAcceptProceedsToPR(t *testing.T) {
+	repo := "rshade/prompt-deploy-accept"
+	cfg := newPromptDeployFixture(t, repo)
+	withInteractivePrompt(t, "y\n")
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create failure after accept (proves prompt passed)", err)
+	}
+}
+
+// TestDeployDryRunNeverPrompts proves --apply absence skips the prompt even with
+// findings and queued "n": a dry-run returns nil, never a decline.
+func TestDeployDryRunNeverPrompts(t *testing.T) {
+	repo := "rshade/prompt-deploy-dryrun"
+	cfg := newPromptDeployFixture(t, repo)
+	withPromptStdinUnread(t, true)
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{Apply: false})
+	if err != nil {
+		t.Fatalf("dry-run err = %v; want nil (no prompt)", err)
+	}
+	if res != nil && res.CloneDir != "" {
+		// dry-run on a tmp clone auto-cleans; nothing to remove if already gone.
+		_ = os.RemoveAll(res.CloneDir)
+	}
+}
+
+// TestDeployYesBypassesPromptWithoutReadingStdin proves --yes (SecurityOpts.Yes)
+// skips the prompt without consulting stdin even at a TTY with findings.
+func TestDeployYesBypassesPromptWithoutReadingStdin(t *testing.T) {
+	repo := "rshade/prompt-deploy-yes"
+	cfg := newPromptDeployFixture(t, repo)
+	withPromptStdinUnread(t, true)
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{
+		Apply:    true,
+		Security: SecurityOpts{Yes: true},
+	})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create (proceeded past skipped prompt)", err)
+	}
+	if IsOperatorDeclinedError(err) {
+		t.Fatal("--yes must not produce an operator-decline error")
+	}
+}
+
+// TestDeployNonTTYProceedsWithoutReadingStdin proves a non-interactive apply
+// with findings proceeds without reading stdin (FR-009) — nothing hangs.
+func TestDeployNonTTYProceedsWithoutReadingStdin(t *testing.T) {
+	repo := "rshade/prompt-deploy-nontty"
+	cfg := newPromptDeployFixture(t, repo)
+	withPromptStdinUnread(t, false)
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create (non-TTY proceeded)", err)
+	}
+}
+
+// TestDeployPushGateResumePromptDeclineBeforeAmend proves a push-gate
+// --work-dir resume asks before the compile/manifest refresh that may amend
+// the saved local commit.
+func TestDeployPushGateResumePromptDeclineBeforeAmend(t *testing.T) {
+	repo := "rshade/prompt-deploy-resume-push-decline"
+	dir := newTestRepo(t, func(d string) {
+		gitInDir(d, "checkout", "-b", "fleet/deploy-test")
+		seedHighSecurityWorkflow(d)
+	})
+	withInteractivePrompt(t, "n\n")
+	installHealthyDeployAPIs(t, repo)
+
+	origExists := ghAPIExists
+	t.Cleanup(func() { ghAPIExists = origExists })
+	ghAPIExists = func(_ context.Context, _ string) bool { return false }
+
+	seams := &compileStrictSeams{
+		helpOut:    "  --strict  enable strict validation\n",
+		versionOut: "v0.79.2",
+	}
+	installCompileStrictSeams(t, seams)
+
+	cfg := strictGateTestConfig(repo)
+	cfg.Repos[repo] = RepoSpec{Profiles: []string{"default"}, CompileStrict: boolPtr(true)}
+	beforeHead := gitOutput(t, dir, "rev-parse", "HEAD")
+
+	res, err := Deploy(context.Background(), cfg, repo, DeployOpts{
+		Apply:   true,
+		WorkDir: dir,
+	})
+	if res != nil && res.CloneDir != dir {
+		t.Fatalf("CloneDir = %q; want resumed work-dir %q", res.CloneDir, dir)
+	}
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError", err)
+	}
+	if seams.compileCalls != 0 || seams.versionCalls != 0 {
+		t.Fatalf(
+			"compile/version calls = %d/%d; want 0/0 before declined prompt",
+			seams.compileCalls, seams.versionCalls,
+		)
+	}
+	if afterHead := gitOutput(t, dir, "rev-parse", "HEAD"); afterHead != beforeHead {
+		t.Fatalf("HEAD = %s; want unchanged %s after decline", afterHead, beforeHead)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, FleetManifestPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest stat err = %v; want absent before accepted resume refresh", statErr)
+	}
+}
+
+// TestDeployZeroFindingsNoPrompt proves a clean repo (no findings) never prompts
+// even with a TTY and queued "n", and prBody omits the Security Findings section.
+func TestDeployZeroFindingsNoPrompt(t *testing.T) {
+	repo := "rshade/prompt-deploy-clean"
+	remote := newTestRepo(t, nil) // no high-security workflow → zero findings
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	stubGhAwVersionForStrictTests(t)
+	withInteractivePrompt(t, "n\n") // queued decline must be ignored
+
+	res, err := Deploy(context.Background(), strictGateTestConfig(repo), repo, DeployOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if IsOperatorDeclinedError(err) {
+		t.Fatal("zero findings must not fire the prompt")
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create (clean repo proceeded)", err)
+	}
+	if strings.Contains(prBody(res, repo, 0), "## Security Findings") {
+		t.Error("zero findings must not render a ## Security Findings PR section")
+	}
+}
+
+// TestDeployPRBodyKeepsSecurityFindingsUnderYes proves --yes does not suppress
+// the PR-body Security Findings section (surface coexistence, FR-008).
+func TestDeployPRBodyKeepsSecurityFindingsUnderYes(t *testing.T) {
+	res := &DeployResult{
+		Repo:             "rshade/example",
+		SecurityFindings: oneHighFinding(),
+	}
+	body := prBody(res, res.Repo, 0)
+	if !strings.Contains(body, "## Security Findings") {
+		t.Errorf("prBody missing ## Security Findings section:\n%s", body)
+	}
+}
+
+// --- sync placement (T013) ---
+
+// TestSyncAddPathPromptsOnceDecline proves the sync add path inherits Deploy's
+// single prompt: a decline surfaces as one *OperatorDeclinedError.
+func TestSyncAddPathPromptsOnceDecline(t *testing.T) {
+	repo := "rshade/prompt-sync-add-decline"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	withInteractivePrompt(t, "n\n")
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError via delegated Deploy", err)
+	}
+}
+
+// TestSyncAddPathAcceptProceeds proves a single "y" passes the delegated Deploy
+// prompt and there is no second sync-level prompt (it would read EOF and decline
+// otherwise) — the run proceeds to the fake gh pr create failure.
+func TestSyncAddPathAcceptProceeds(t *testing.T) {
+	repo := "rshade/prompt-sync-add-accept"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	installHealthyDeployAPIs(t, repo)
+	withInteractivePrompt(t, "y\n")
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if IsOperatorDeclinedError(err) {
+		t.Fatal("single y should pass; a second prompt would have declined at EOF")
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create after accept", err)
+	}
+}
+
+// TestSyncPruneOnlyDropsStaleFindingsBeforePrompt proves prune-only sync
+// recomputes findings after deleting drift workflows, so warnings that existed
+// only in deleted files cannot trigger the confirmation prompt.
+func TestSyncPruneOnlyDropsStaleFindingsBeforePrompt(t *testing.T) {
+	repo := "rshade/prompt-sync-prune-stale"
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	withPromptStdinUnread(t, true)
+
+	res, err := Sync(context.Background(), strictGateTestConfig(repo), repo, SyncOpts{
+		Apply: true,
+		Prune: true,
+	})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want no prompt for findings removed by prune", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "git push prune") {
+		t.Fatalf("err = %v; want nil or later git push prune failure", err)
+	}
+	if res == nil {
+		t.Fatal("Sync returned nil result")
+	}
+	if !slices.Contains(res.Pruned, "strict-high") {
+		t.Fatalf("Pruned = %v, want strict-high", res.Pruned)
+	}
+	if len(res.SecurityFindings) != 0 {
+		t.Fatalf("SecurityFindings = %#v; want empty after pruning stale finding", res.SecurityFindings)
+	}
+}
+
+// TestSyncPruneOnlyPromptDeclineBeforeCommit proves the prune-only path prompts
+// before commitAndPushPrune when findings remain after pruning, and a decline
+// aborts.
+func TestSyncPruneOnlyPromptDeclineBeforeCommit(t *testing.T) {
+	repo := "rshade/prompt-sync-prune-decline"
+	remote := newTestRepo(t, func(dir string) {
+		seedDeclaredHighWorkflow(dir)
+		seedDriftedWorkflow(dir)
+	})
+	_ = installFakeGhForSync(t, remote)
+	withInteractivePrompt(t, "n\n")
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{
+		Apply: true,
+		Prune: true,
+	})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError before prune commit", err)
+	}
+}
+
+func seedDeclaredHighWorkflow(dir string) {
+	wf := filepath.Join(dir, ".github", "workflows", "ci-doctor.md")
+	if err := os.MkdirAll(filepath.Dir(wf), 0o755); err != nil {
+		panic(err)
+	}
+	content := `---
+source: githubnext/agentics/ci-doctor@v1.0.0
+on:
+  schedule:
+    - cron: "0 0 * * *"
+permissions: write-all
+---
+`
+	if err := os.WriteFile(wf, []byte(content), 0o644); err != nil {
+		panic(err)
+	}
+	gitInDir(dir, "add", ".github/workflows/ci-doctor.md")
+	gitInDir(dir, "commit", "-m", "seed declared high workflow")
+}
+
+// TestSyncCleanPathNoPrompt proves a fully in-state sync (nothing to add or
+// prune) never prompts, even with a TTY.
+func TestSyncCleanPathNoPrompt(t *testing.T) {
+	repo := "rshade/prompt-sync-clean"
+	remote := newTestRepo(t, seedDeclaredWorkflow)
+	_ = installFakeGhForSync(t, remote)
+	withPromptStdinUnread(t, true)
+
+	res, err := Sync(context.Background(), strictGateMissingWorkflowConfig(repo), repo, SyncOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err != nil {
+		t.Fatalf("clean sync err = %v; want nil (no prompt)", err)
+	}
+}
+
+// --- upgrade placement (T014) ---
+
+// newPromptUpgradeFixture wires the upgrade fake-gh + a HIGH-finding remote and
+// returns the config for an apply that reaches the PR boundary with findings.
+func newPromptUpgradeFixture(t *testing.T, repo string) *Config {
+	t.Helper()
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	installFakeGhForUpgrade(t, remote)
+	stubGhAwVersionForStrictTests(t)
+	return strictGateTestConfig(repo)
+}
+
+// TestUpgradePromptDeclineAbortsBeforePR proves an apply upgrade with findings
+// and "n" aborts before createUpgradePR with a typed decline.
+func TestUpgradePromptDeclineAbortsBeforePR(t *testing.T) {
+	repo := "rshade/prompt-upgrade-decline"
+	cfg := newPromptUpgradeFixture(t, repo)
+	withInteractivePrompt(t, "n\n")
+
+	res, err := Upgrade(context.Background(), cfg, repo, UpgradeOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError", err)
+	}
+	if res.BranchPushed != "" || res.PRURL != "" {
+		t.Fatalf("BranchPushed/PRURL = %q/%q; want no mutation on decline", res.BranchPushed, res.PRURL)
+	}
+}
+
+// TestUpgradePromptAcceptProceedsToPR proves "y" passes the prompt and reaches
+// createUpgradePR (fake gh pr create failure).
+func TestUpgradePromptAcceptProceedsToPR(t *testing.T) {
+	repo := "rshade/prompt-upgrade-accept"
+	cfg := newPromptUpgradeFixture(t, repo)
+	withInteractivePrompt(t, "y\n")
+
+	res, err := Upgrade(context.Background(), cfg, repo, UpgradeOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create after accept", err)
+	}
+}
+
+// TestUpgradeDryRunNeverPrompts proves a dry-run upgrade never prompts even with
+// findings and queued "n".
+func TestUpgradeDryRunNeverPrompts(t *testing.T) {
+	repo := "rshade/prompt-upgrade-dryrun"
+	cfg := newPromptUpgradeFixture(t, repo)
+	withPromptStdinUnread(t, true)
+
+	res, err := Upgrade(context.Background(), cfg, repo, UpgradeOpts{Apply: false})
+	if res != nil && res.CloneDir != "" {
+		_ = os.RemoveAll(res.CloneDir)
+	}
+	if err != nil {
+		t.Fatalf("dry-run err = %v; want nil (no prompt)", err)
+	}
+}
+
+// TestUpgradeAllDeclineFailsFast proves a decline on the first repo halts the
+// batch (fail-fast) with a single result and a typed decline.
+func TestUpgradeAllDeclineFailsFast(t *testing.T) {
+	remote := newTestRepo(t, seedHighSecurityWorkflow)
+	installFakeGhForUpgrade(t, remote)
+	stubGhAwVersionForStrictTests(t)
+	cfg := strictGateTestConfig("rshade/prompt-upgrade-all-one")
+	cfg.Repos["rshade/prompt-upgrade-all-two"] = RepoSpec{Profiles: []string{"default"}, CompileStrict: boolPtr(false)}
+	withInteractivePrompt(t, "n\n")
+
+	results, err := UpgradeAll(context.Background(), cfg, UpgradeOpts{Apply: true})
+	for _, r := range results {
+		if r != nil && r.CloneDir != "" {
+			t.Cleanup(func() { _ = os.RemoveAll(r.CloneDir) })
+		}
+	}
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d; want fail-fast after first decline", len(results))
+	}
+}
+
+// TestUpgradeNonTTYProceedsWithoutReadingStdin proves a non-interactive upgrade
+// apply with findings proceeds without reading stdin (FR-009).
+func TestUpgradeNonTTYProceedsWithoutReadingStdin(t *testing.T) {
+	repo := "rshade/prompt-upgrade-nontty"
+	cfg := newPromptUpgradeFixture(t, repo)
+	withPromptStdinUnread(t, false)
+
+	res, err := Upgrade(context.Background(), cfg, repo, UpgradeOpts{Apply: true})
+	if res != nil && res.CloneDir != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(res.CloneDir) })
+	}
+	if err == nil || !strings.Contains(err.Error(), "gh pr create") {
+		t.Fatalf("err = %v; want gh pr create (non-TTY proceeded)", err)
+	}
+}

--- a/internal/fleet/security_prompt_test.go
+++ b/internal/fleet/security_prompt_test.go
@@ -1,0 +1,230 @@
+package fleet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/rshade/gh-aw-fleet/internal/fleet/security"
+)
+
+// withStdoutTerminal overrides the stdoutIsTerminal seam for one test and
+// restores it on cleanup.
+func withStdoutTerminal(t *testing.T, isTTY bool) {
+	t.Helper()
+	orig := stdoutIsTerminal
+	t.Cleanup(func() { stdoutIsTerminal = orig })
+	stdoutIsTerminal = func() bool { return isTTY }
+}
+
+func oneHighFinding() []security.Finding {
+	return []security.Finding{{RuleID: "fleet.permissions.write-on-schedule", Severity: security.SeverityHigh}}
+}
+
+func TestPromptUserDecisionTable(t *testing.T) {
+	cases := []struct {
+		name        string
+		findings    []security.Finding
+		yes         bool
+		tty         bool
+		stdin       string
+		wantProceed bool
+		wantErr     bool
+		wantOutput  bool // whether the summary/prompt line was written
+	}{
+		{name: "a empty findings auto-proceeds silently", findings: nil, tty: true, wantProceed: true},
+		{name: "b yes auto-proceeds silently", findings: oneHighFinding(), yes: true, tty: true, wantProceed: true},
+		{name: "c non-tty auto-proceeds silently", findings: oneHighFinding(), tty: false, wantProceed: true},
+		{
+			name:        "d interactive y accepts",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "y\n",
+			wantProceed: true,
+			wantOutput:  true,
+		},
+		{
+			name:        "e interactive n declines",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "n\n",
+			wantProceed: false,
+			wantOutput:  true,
+		},
+		{
+			name:        "f interactive EOF declines with error",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "",
+			wantProceed: false,
+			wantErr:     true,
+			wantOutput:  true,
+		},
+		{
+			name:        "empty line is default-No",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "\n",
+			wantProceed: false,
+			wantOutput:  true,
+		},
+		{
+			name:        "uppercase Y accepts",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "Y\n",
+			wantProceed: true,
+			wantOutput:  true,
+		},
+		{
+			name:        "YES accepts",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "YES\n",
+			wantProceed: true,
+			wantOutput:  true,
+		},
+		{
+			name:        "other word declines",
+			findings:    oneHighFinding(),
+			tty:         true,
+			stdin:       "maybe\n",
+			wantProceed: false,
+			wantOutput:  true,
+		},
+		{
+			name:        "INFO-only findings still fire the prompt (FR-015)",
+			findings:    []security.Finding{{RuleID: "actionlint:not-installed", Severity: security.SeverityInfo}},
+			tty:         true,
+			stdin:       "n\n",
+			wantProceed: false,
+			wantOutput:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withStdoutTerminal(t, tc.tty)
+			var out bytes.Buffer
+			proceed, err := PromptUser(tc.findings, tc.yes, strings.NewReader(tc.stdin), &out)
+			if proceed != tc.wantProceed {
+				t.Errorf("proceed = %v; want %v", proceed, tc.wantProceed)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v; wantErr = %v", err, tc.wantErr)
+			}
+			if (out.Len() > 0) != tc.wantOutput {
+				t.Errorf("output written = %q; wantOutput = %v", out.String(), tc.wantOutput)
+			}
+		})
+	}
+}
+
+// TestPromptUserSummaryContainsSeverityTally asserts the prompt line embeds the
+// shared SeveritySummary string so the count matches the PR-body summary.
+func TestPromptUserSummaryContainsSeverityTally(t *testing.T) {
+	withStdoutTerminal(t, true)
+	findings := []security.Finding{
+		{Severity: security.SeverityHigh},
+		{Severity: security.SeverityHigh},
+		{Severity: security.SeverityMedium},
+	}
+	var out bytes.Buffer
+	if _, err := PromptUser(findings, false, strings.NewReader("y\n"), &out); err != nil {
+		t.Fatalf("PromptUser err = %v", err)
+	}
+	want := security.SeveritySummary(findings) // "2 HIGH, 1 MEDIUM"
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("prompt %q does not contain summary %q", out.String(), want)
+	}
+	if !strings.Contains(out.String(), "[y/N]") {
+		t.Errorf("prompt %q missing [y/N] default marker", out.String())
+	}
+}
+
+// TestPromptUserFastPathsNeverRead proves the empty/yes/non-tty branches return
+// before consulting the reader (so a non-interactive run never blocks on stdin).
+func TestPromptUserFastPathsNeverRead(t *testing.T) {
+	cases := []struct {
+		name     string
+		findings []security.Finding
+		yes      bool
+		tty      bool
+	}{
+		{name: "empty findings", findings: nil, tty: true},
+		{name: "yes set", findings: oneHighFinding(), yes: true, tty: true},
+		{name: "non-tty", findings: oneHighFinding(), tty: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withStdoutTerminal(t, tc.tty)
+			var out bytes.Buffer
+			proceed, err := PromptUser(tc.findings, tc.yes, failingReader{t}, &out)
+			if !proceed || err != nil {
+				t.Fatalf("proceed=%v err=%v; want true/nil", proceed, err)
+			}
+			if out.Len() != 0 {
+				t.Errorf("fast path wrote %q; want no output", out.String())
+			}
+		})
+	}
+}
+
+// TestConfirmSecurityFindingsDeclinePreservesAndTypes verifies the wrapper flips
+// the cleanup flag and returns a typed *OperatorDeclinedError carrying the read
+// cause on EOF.
+func TestConfirmSecurityFindingsDeclinePreservesAndTypes(t *testing.T) {
+	withStdoutTerminal(t, true)
+	restoreIn := promptStdin
+	restoreOut := promptStdout
+	t.Cleanup(func() { promptStdin = restoreIn; promptStdout = restoreOut })
+	promptStdin = strings.NewReader("") // EOF
+	promptStdout = io.Discard
+
+	cleanup := true
+	err := confirmSecurityFindings("rshade/example", oneHighFinding(), SecurityOpts{}, &cleanup)
+	if !IsOperatorDeclinedError(err) {
+		t.Fatalf("err = %T %[1]v; want *OperatorDeclinedError", err)
+	}
+	if cleanup {
+		t.Error("cleanupClone not flipped to false on decline")
+	}
+	var declined *OperatorDeclinedError
+	if errors.As(err, &declined) {
+		if declined.Repo != "rshade/example" || declined.Findings != 1 {
+			t.Errorf("declined = %+v; want repo=rshade/example findings=1", declined)
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Error("EOF decline should keep io.EOF in the Unwrap chain")
+		}
+	}
+}
+
+// TestConfirmSecurityFindingsProceed verifies the wrapper returns nil and does
+// not touch the cleanup flag when the operator proceeds.
+func TestConfirmSecurityFindingsProceed(t *testing.T) {
+	withStdoutTerminal(t, true)
+	restoreIn := promptStdin
+	restoreOut := promptStdout
+	t.Cleanup(func() { promptStdin = restoreIn; promptStdout = restoreOut })
+	promptStdin = strings.NewReader("y\n")
+	promptStdout = io.Discard
+
+	cleanup := true
+	if err := confirmSecurityFindings("rshade/example", oneHighFinding(), SecurityOpts{}, &cleanup); err != nil {
+		t.Fatalf("confirmSecurityFindings err = %v; want nil", err)
+	}
+	if !cleanup {
+		t.Error("cleanupClone should be untouched when the operator proceeds")
+	}
+}
+
+// failingReader fails the test if Read is ever called — used to prove the
+// fast paths never consult stdin.
+type failingReader struct{ t *testing.T }
+
+func (r failingReader) Read([]byte) (int, error) {
+	r.t.Fatal("Read called on a fast-path that should never read stdin")
+	return 0, io.EOF
+}

--- a/internal/fleet/sync.go
+++ b/internal/fleet/sync.go
@@ -246,6 +246,13 @@ func applyDeployOrPrune(
 		if stageErr := gitCmd(ctx, res.CloneDir, addToken, ".github/"); stageErr != nil {
 			return fmt.Errorf("git add manifest after prune: %w", stageErr)
 		}
+		// Apply-only path, so the clone-cleanup flag is already false; pass nil.
+		// The add path (len(res.Missing) > 0, above) inherits Deploy's single
+		// prompt, so this is the only standalone sync confirmation.
+		res.SecurityFindings = security.Run(ctx, res.CloneDir)
+		if confirmErr := confirmSecurityFindings(repo, res.SecurityFindings, opts.Security, nil); confirmErr != nil {
+			return confirmErr
+		}
 		return commitAndPushPrune(ctx, res)
 	}
 	return nil

--- a/internal/fleet/upgrade.go
+++ b/internal/fleet/upgrade.go
@@ -173,6 +173,12 @@ func Upgrade(ctx context.Context, cfg *Config, repo string, opts UpgradeOpts) (*
 		return res, manifestErr
 	}
 
+	if confirmErr := confirmSecurityFindings(
+		repo, res.SecurityFindings, opts.Security, &cleanupClone,
+	); confirmErr != nil {
+		return res, confirmErr
+	}
+
 	return createUpgradePR(ctx, res)
 }
 
@@ -189,6 +195,10 @@ func finishNoChangeUpgrade(
 	}
 	if !manifestBackfilled {
 		return res, nil
+	}
+	// Apply-only path, so the clone-cleanup flag is already false; pass nil.
+	if confirmErr := confirmSecurityFindings(repo, res.SecurityFindings, opts.Security, nil); confirmErr != nil {
+		return res, confirmErr
 	}
 	return createUpgradePR(ctx, res)
 }

--- a/skills/fleet-deploy/SKILL.md
+++ b/skills/fleet-deploy/SKILL.md
@@ -46,6 +46,28 @@ writes `<clone>/findings.json` with every finding from the run. Report that path
 to the user and inspect it before deciding whether to fix the workflow or rerun
 without `--strict`.
 
+### Interactive confirmation on `--apply`
+
+Separate from `--strict`, an `--apply` that produces **any** finding pauses for
+a last-chance `⚠  <tally>. Proceed with commit? [y/N]` confirmation before it
+commits, pushes, or opens a PR — but only at an interactive terminal. The
+default is **No**; declining aborts cleanly, exits non-zero, and preserves the
+clone (resume with `--work-dir <clone> --yes`). This is a normal in-tool gate,
+not a crash — when you (the assistant) run `--apply` and findings are present,
+stdout is typically not a TTY, so the prompt is auto-skipped and the apply
+proceeds; the findings still print on stderr and in the PR body.
+
+To skip the prompt deliberately while keeping every finding visible, pass
+`--yes`:
+
+```bash
+go run . deploy <owner>/<repo> --apply --yes
+```
+
+`--yes` bypasses only the prompt — it does not suppress stderr findings, the
+PR-body `## Security Findings` section, or the `--strict` gate. Use it only
+after the user has reviewed the dry-run findings in Turn 1.
+
 ## The flow
 
 Three turns. Don't collapse them — the confirmation gates are deliberate.
@@ -111,6 +133,7 @@ Expected outcomes:
 
 - **Clean success**: output ends with `PR: https://github.com/...`. Report the URL to the user; declare the deploy complete.
 - **Strict security abort**: output includes security findings, exits non-zero, writes `<clone>/findings.json`, and creates no PR. Report the blocking count, clone path, and breadcrumb path. Ask whether to fix the findings or rerun without `--strict`; do not auto-downgrade the policy.
+- **Operator decline at the prompt** (interactive runs only): output ends with `aborted by operator: <N> security finding(s) ... re-run with --yes to skip the prompt`, exits non-zero, creates no PR, and preserves the clone. This is a deliberate choice, not a failure — relay it plainly and ask whether the user wants to re-run with `--yes` or fix the findings first. Don't auto-add `--yes` without the user's go-ahead.
 - **gpg signing failure**: exit status 1, output contains `gpg failed to sign the data` or `gpg: signing failed`. The tool preserves the clone dir (`/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>`) with all files staged on the deploy branch. Two recovery options exist:
   1. **Resume via `--work-dir`** (preferred): re-run `go run . deploy <owner>/<repo> --apply --work-dir <clone-dir>`. The tool detects the staged changes, skips clone/init/add, and re-enters at the commit gate.
   2. **Manual-finish paste**: compose the shell paste below for the user to run in their own terminal where gpg-agent can prompt. Use this when the user explicitly asks for manual steps or when `--work-dir` resume is not desired.

--- a/skills/fleet-upgrade-review/SKILL.md
+++ b/skills/fleet-upgrade-review/SKILL.md
@@ -92,6 +92,15 @@ commit, push, or PR steps. On strict abort, the clone is preserved and
 --strict` stops at the first blocked repo; JSON mode emits the blocked repo's
 envelope before stopping.
 
+Separate from `--strict`, an `--apply` upgrade that produced **any** finding
+pauses for a `⚠  <tally>. Proceed with commit? [y/N]` confirmation at an
+interactive terminal (default No). When you run `--apply` non-interactively the
+prompt is auto-skipped and the upgrade proceeds, with findings still on stderr
+and in the PR body. Pass `--yes` to skip the prompt deliberately while keeping
+every finding visible; `--yes` does not suppress findings or the `--strict`
+gate. For `upgrade --all`, the prompt is per repo and a decline halts that repo
+and the batch (fail-fast), exactly like a strict block.
+
 Dry-run output shows:
 - `gh aw upgrade` log (dispatcher updates, action bumps).
 - `gh aw update` log (per-workflow pulls, 3-way merges, compile results).
@@ -124,6 +133,7 @@ go run . upgrade <owner>/<repo> --strict --apply
 Outcomes match `fleet-deploy`:
 - **Clean success**: output ends with `PR: <url>`. Report the URL.
 - **Strict security abort**: no branch, commit, push, or PR is created. Report the clone path and `findings.json`; do not rerun without `--strict` unless the user explicitly chooses advisory-only behavior.
+- **Operator decline at the prompt** (interactive runs only): output ends with `aborted by operator: ... re-run with --yes`, exits non-zero, creates no PR, and preserves the clone. Relay it as a deliberate choice; ask whether to re-run with `--yes` or fix the findings. Don't add `--yes` without the user's go-ahead.
 - **gpg signing failure**: same failure mode; generate the manual-finish paste.
 - **Conflict (missed in dry-run)**: report, don't retry.
 

--- a/specs/019-security-finding-prompt/checklists/requirements.md
+++ b/specs/019-security-finding-prompt/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Interactive security-finding prompt
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The specification was validated against the actual codebase rather than the
+  issue's claims. Two corrections were folded into the Assumptions section:
+  (1) `--yes` does not yet exist on `deploy`/`sync`/`upgrade` (only on `add`),
+  so it is introduced here; (2) the prompt fires on *any* finding severity, per
+  the binding acceptance criteria, not only on high-severity findings.
+- No [NEEDS CLARIFICATION] markers were needed: every open question had a
+  reasonable default grounded in an existing in-repo precedent (the `add`
+  command's confirmation flow, the `--strict` gate ordering, and the
+  preserved-clone breadcrumb invariant).

--- a/specs/019-security-finding-prompt/contracts/security-prompt-contract.md
+++ b/specs/019-security-finding-prompt/contracts/security-prompt-contract.md
@@ -1,0 +1,123 @@
+# Contract: Interactive security-finding confirmation + `--yes`
+
+This contract defines the CLI surface, the confirmation decision, the abort
+behavior, and the per-command placement for the security-finding prompt. It is
+the authority the unit and placement tests assert against.
+
+## CLI surface
+
+### `--yes` flag (new on `deploy`, `sync`, `upgrade`)
+
+```text
+--yes   Skip the interactive security-findings confirmation. Does NOT suppress
+        findings from stderr output or the generated PR body — it only bypasses
+        the y/N prompt.
+```
+
+- Boolean, default `false`. Registered on `deploy`, `sync`, and `upgrade` with
+  identical help text.
+- Wired as `fleet.SecurityOpts{Strict: flagStrict, Yes: flagYes}`.
+- No effect without `--apply` (the prompt only exists on the apply path). Passing
+  `--yes` on a dry run is silently inert (no prompt would have fired anyway). It
+  is NOT an error.
+- Exposed automatically by the hidden `__schema` command via the existing schema
+  generator; not separately documented.
+
+## Confirmation decision (`PromptUser`)
+
+`PromptUser(findings, yes, in, out) (proceed bool, err error)`:
+
+| # | Condition | Output to `out` | Returns |
+|---|-----------|-----------------|---------|
+| 1 | `len(findings) == 0` | nothing | `(true, nil)` |
+| 2 | `yes == true` | nothing | `(true, nil)` |
+| 3 | stdout not a terminal | nothing | `(true, nil)` |
+| 4 | interactive, input `y`/`Y`/`yes` (trimmed, case-insensitive) | summary + prompt | `(true, nil)` |
+| 5 | interactive, input `n` / anything else / empty line | summary + prompt | `(false, nil)` |
+| 6 | interactive, EOF or read error before an answer | summary + prompt | `(false, err)` |
+
+- **Summary + prompt line** (rows 4–6): a single line of the form
+  `⚠  <severity summary>. Proceed with commit? [y/N]` where `<severity summary>`
+  is `security.SeveritySummary(findings)` (e.g. `2 HIGH, 1 MEDIUM`). The `[y/N]`
+  capitalization signals N is the default.
+- **Default**: empty input (bare Enter) → decline (row 5). The safe default is No.
+- **Order of checks** is exactly 1→2→3 before any terminal interaction, so the
+  empty / `--yes` / non-TTY fast-paths never read stdin and never hang.
+
+## Interactivity gate
+
+- "Interactive" ⇔ `stdoutIsTerminal()` is true, computed from
+  `os.Stdout.Stat()` + `os.ModeCharDevice` (stdlib; no `golang.org/x/term`).
+- Detection is on **stdout**, not stdin: `tool | tee` (stdout redirected, stdin a
+  TTY) does NOT prompt; `tool < script` (stdin redirected, stdout a TTY) still
+  prompts (and an EOF answer declines per row 6).
+- `--output json` mode is treated as non-interactive (no prompt) per **FR-018**,
+  even when stdout is a TTY, because a prompt on stdout would corrupt the JSON
+  envelope and a machine cannot answer.
+
+## Abort behavior on decline
+
+When `confirmSecurityFindings` observes a decline (rows 5 or 6):
+
+1. No commit, no branch push, no PR is created (the apply boundary is not
+   entered).
+2. The work-dir clone is preserved (`cleanupClone=false`; resume paths already
+   disable cleanup) as a breadcrumb for `--work-dir … --yes` resumption.
+3. The fleet function returns an `*OperatorDeclinedError` (wrapping the read
+   error for row 6).
+4. `cmd/output.go` recognizes it (`IsOperatorDeclinedError`) and prints a clean
+   `aborted by operator … re-run with --yes` message, exiting non-zero. It is NOT
+   routed through the hint engine and is NOT rendered as a crash/stack.
+
+## Surface coexistence (defense in depth)
+
+For a single apply with findings, all three surfaces are produced independently:
+
+| Surface | Mechanism | Affected by `--yes`? | Affected by decline? |
+|---------|-----------|----------------------|----------------------|
+| 1. stderr findings | existing `emitSecurityFindingWarnings` (cmd layer) | No | Still emitted |
+| 2. interactive prompt | `PromptUser` (this feature) | **Skipped** | The decline itself |
+| 3. PR body `## Security Findings` | existing `security.RenderPRSection` | No | Not reached (no PR) |
+
+`--yes` suppresses surface 2 only. A decline suppresses the PR (surface 3) only
+because no PR is created; surface 1 has already been produced.
+
+## Per-command placement (after strict gate, apply only, commit pending)
+
+### `deploy`
+
+- **Fresh path** (`Deploy`): after `security.Run` + `evaluateStrictGatePreservingClone`,
+  after the `if !opts.Apply { return }` dry-run return and the
+  `len(res.Added)==0 && !staged` no-op guard, **before** `createDeployPR`. On
+  decline, set the in-scope `cleanupClone=false`.
+- **`--work-dir` resume** (`handleWorkDirResume`): after the re-run scan + strict
+  gate, **before** the commit-gate `createDeployPR` call and **before** the
+  push-gate `pushAndCreatePR` call. Cleanup is already disabled on resume, so no
+  flag flip is needed.
+
+### `sync`
+
+- **Add path**: delegates to `Deploy` via `applyDeployOrPrune` with
+  `Security: opts.Security` → inherits Deploy's single prompt. Sync MUST NOT add
+  a second prompt here ("prompt exactly once").
+- **Prune-only path** (`len(res.Missing)==0 && opts.Prune && len(res.Pruned)>0`):
+  after the direct strict gate, **before** `commitAndPushPrune`.
+- **Clean path** (nothing to add or prune): no commit, no prompt.
+
+### `upgrade`
+
+- After `security.Run` + strict gate and the `if !opts.Apply { return }` dry-run
+  return, **before** `createUpgradePR` on the changed-files path.
+- The no-change manifest-backfill path (`finishNoChangeUpgrade`) that can still
+  open a PR is also guarded before its `createUpgradePR`.
+- `upgrade --all`: per repo; a decline on one repo aborts that repo and the batch
+  continues to stop/continue per the existing fail-fast behavior.
+
+## Invariants (assertable)
+
+- Dry-run (`--apply` absent) NEVER prompts.
+- A `--strict` HIGH block returns before the prompt is reached.
+- The prompt is reached at most once per repo per invocation.
+- `cmd.SchemaVersion` and `fleet.SchemaVersion` are unchanged.
+- No new entry in `go.mod`'s direct `require()` block.
+- Zero findings ⇒ no prompt AND no `## Security Findings` PR section.

--- a/specs/019-security-finding-prompt/data-model.md
+++ b/specs/019-security-finding-prompt/data-model.md
@@ -1,0 +1,161 @@
+# Phase 1 Data Model: Interactive security-finding prompt before commit
+
+This feature adds no persistent data and no new wire/config schema. It adds one
+options field, one pure decision function, one typed error, and one exported
+render helper. All "entities" below are in-memory Go values consumed during a
+single command invocation.
+
+## Consumed (unchanged) types
+
+### `security.Finding` (existing — `internal/fleet/security/finding.go`)
+
+Consumed read-only. The prompt reads `Severity` for the summary tally and the
+slice length for the fire/skip decision. No field is added, reordered, or
+modified. Ordering of `[]security.Finding` is preserved.
+
+### `security.Severity` (existing)
+
+`SeverityHigh | SeverityMedium | SeverityLow | SeverityInfo`. The summary line
+tallies these in HIGH→MEDIUM→LOW→INFO order, omitting zero counts (existing
+`severityTally` behavior).
+
+## Added / modified types
+
+### `SecurityOpts.Yes` (modified — `internal/fleet/security_gate.go`)
+
+```go
+// SecurityOpts controls invocation-scoped security policy.
+type SecurityOpts struct {
+    Strict bool // block on HIGH non-promptinj security findings
+    Yes    bool // skip the interactive findings confirmation prompt (does not suppress stderr/PR-body findings)
+}
+```
+
+- **Field meaning**: `Yes` skips *only* the interactive confirmation. It does not
+  affect the strict gate, the stderr findings warnings, or the PR-body section.
+- **Lifecycle**: set from the `--yes` Cobra flag in `cmd/{deploy,sync,upgrade}.go`;
+  threaded unchanged through `DeployOpts`/`SyncOpts`/`UpgradeOpts` and through
+  sync's delegated `Deploy` call (so the "prompt once" delegation keeps working).
+- **Not persisted**: never written to `fleet.json`/`fleet.local.json`; no schema
+  bump.
+- **Zero value**: `false` → prompt is eligible to fire (the default, gated by
+  findings-present + interactive-stdout).
+
+### `PromptUser` (new — `internal/fleet/security_prompt.go`)
+
+```go
+// PromptUser asks the operator to confirm proceeding despite findings.
+// Returns (true, nil) automatically when: findings is empty, yes is true, or
+// stdout is not a terminal. Otherwise it writes a one-line severity summary to
+// out and reads a line from in: "y"/"Y"/"yes" → (true, nil); any other non-empty
+// or empty line → (false, nil); a read error or EOF before an answer → (false, err).
+func PromptUser(findings []security.Finding, yes bool, in io.Reader, out io.Writer) (proceed bool, err error)
+```
+
+Pure and fully injectable for tests. The stdout-TTY check is a package-level seam
+(`stdoutIsTerminal`) so the non-TTY branch is unit-testable without a real
+terminal.
+
+**Decision table**:
+
+| findings | yes | stdout TTY | input line | result |
+|----------|-----|-----------|-----------|--------|
+| empty | any | any | — | `(true, nil)` |
+| present | true | any | — | `(true, nil)` |
+| present | false | no | — | `(true, nil)` |
+| present | false | yes | `y` / `Y` / `yes` | `(true, nil)` |
+| present | false | yes | `n` / other / empty | `(false, nil)` |
+| present | false | yes | EOF / read error | `(false, err)` |
+
+### `stdoutIsTerminal` (new seam — `internal/fleet/security_prompt.go`)
+
+```go
+// stdoutIsTerminal reports whether stdout is an interactive character device.
+// Overridable in tests. Stdlib only — mirrors cmd/add.go's isStdinTerminal.
+var stdoutIsTerminal = func() bool {
+    fi, err := os.Stdout.Stat()
+    if err != nil {
+        return false
+    }
+    return fi.Mode()&os.ModeCharDevice != 0
+}
+```
+
+### `OperatorDeclinedError` (new — `internal/fleet/security_prompt.go`)
+
+```go
+// OperatorDeclinedError is returned when the operator declines the interactive
+// security-findings confirmation (including empty input, EOF, or a read error).
+type OperatorDeclinedError struct {
+    Repo     string // repository the apply was aborted for
+    Findings int    // number of findings shown at the prompt
+    Cause    error  // non-nil for EOF / read-error declines; nil for an explicit "no"
+}
+```
+
+- `Error()` → actionable message, e.g. `aborted by operator: <N> security
+  finding(s) for <repo> not accepted; re-run with --yes to skip the prompt`.
+- `Unwrap()` → `Cause` (so EOF/read errors remain inspectable).
+- A package predicate `IsOperatorDeclinedError(err) bool` (via `errors.As`)
+  mirrors `IsStrictSecurityError`, letting `cmd/output.go` print the decline
+  cleanly and exit non-zero without hint-engine noise.
+
+### `confirmSecurityFindings` (new internal wrapper — `internal/fleet/security_prompt.go`)
+
+```go
+// confirmSecurityFindings runs PromptUser with the production stdin/stdout seams
+// and, on decline, preserves the clone and returns an *OperatorDeclinedError.
+func confirmSecurityFindings(repo string, findings []security.Finding, opts SecurityOpts, cleanupClone *bool) error
+```
+
+- Returns `nil` when `PromptUser` reports proceed.
+- On decline, sets `*cleanupClone = false` (mirrors `preserveCloneForStrictError`;
+  on resume paths cleanup is already disabled, so the pointer may be nil) and
+  returns the typed error. This is the function the apply boundaries call.
+
+### `security.SeveritySummary` (new export — `internal/fleet/security/render.go`)
+
+```go
+// SeveritySummary returns "2 HIGH, 1 MEDIUM" — the per-severity tally used by
+// both the PR-body summary and the interactive prompt. Empty string for no findings.
+func SeveritySummary(findings []Finding) string
+```
+
+Thin exported wrapper over the existing unexported `severityTally`; no behavior
+change to the PR-body rendering that already uses it.
+
+## Relationships & flow
+
+```text
+cmd/{deploy,sync,upgrade}.go
+  flag --yes ──► fleet.SecurityOpts{Strict, Yes}
+                      │
+                      ▼
+internal/fleet/{deploy,sync,upgrade}.go  (apply path, per repo)
+  security.Run ─► EvaluateStrictSecurityGate ─► [pending commit?] ─► confirmSecurityFindings
+                                                                          │
+                                   PromptUser(findings, opts.Yes, stdin, stdout)
+                                     │ proceed                    │ decline
+                                     ▼                            ▼
+                         createDeployPR / createUpgradePR    *OperatorDeclinedError
+                         / commitAndPushPrune / pushAndCreatePR   (clone preserved)
+                                     │                            │
+                                     ▼                            ▼
+                         PR body includes ## Security Findings   cmd/output.go → clean non-zero exit
+```
+
+## Validation rules (from Functional Requirements)
+
+- Prompt eligible **only** when `apply && len(findings) > 0 && !opts.Yes &&
+  stdoutIsTerminal()` and a commit is pending (FR-001, FR-009, FR-010, FR-015).
+- Prompt fires **after** the strict gate; a strict abort returns before the
+  prompt (FR-011).
+- Affirmative = `y` / `Y` / `yes` (case-insensitive, trimmed); empty = decline
+  (FR-003, FR-004).
+- Decline → no commit/push/PR, typed error, non-zero exit, clone preserved
+  (FR-005).
+- `--yes` skips the prompt but never suppresses stderr warnings or the PR-body
+  section (FR-007, FR-008).
+- `--output json` mode suppresses the prompt even when stdout is a TTY; the
+  apply proceeds and stderr/PR-body surfaces remain (FR-018).
+- Zero findings → no prompt, no PR-body section (FR-010).

--- a/specs/019-security-finding-prompt/plan.md
+++ b/specs/019-security-finding-prompt/plan.md
@@ -1,0 +1,173 @@
+# Implementation Plan: Interactive security-finding prompt before commit
+
+**Branch**: `019-security-finding-prompt` | **Date**: 2026-06-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/019-security-finding-prompt/spec.md`
+
+## Summary
+
+Add an interactive `[y/N]` confirmation that fires after the Layer 1 scanner
+runs and the `--strict` gate passes, but before any commit/push/PR, whenever an
+apply (`deploy`/`sync`/`upgrade --apply`) produced one or more security
+findings and is running at an interactive terminal. Add a `--yes` flag to
+`deploy`, `sync`, and `upgrade` that skips only this prompt — it does not
+suppress the findings already emitted on stderr or in the PR body. In
+non-interactive contexts (piped/redirected stdout, CI, or `--output json`) the
+prompt is suppressed and the apply proceeds, so nothing ever hangs; operators
+who want a non-interactive *block* use the existing `--strict` gate.
+
+The implementation is a thin operator-confirmation layer over the existing
+scanner output, mirroring how slice 017 added the strict gate: extend the
+existing `SecurityOpts` with a `Yes bool`, add the Cobra `--yes` flag to the
+three commands, add a shared `internal/fleet/security_prompt.go` helper
+(`PromptUser` plus a stdout-TTY seam built on the stdlib `os.Stat` +
+`ModeCharDevice` pattern already used by `cmd/add.go`), and call the helper at
+each apply-mode commit/push/PR boundary after the strict gate. No scanner
+rules, finding ordering, stderr/PR rendering, output-schema versions, or
+compile-strict behavior change. **No new third-party dependency** — the
+`golang.org/x/term` package the issue suggested is rejected in favor of the
+in-repo stdlib TTY pattern (see research.md), avoiding a Constitution
+§Third-Party Dependencies amendment.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.4 local toolchain; `go.mod` records the same floor.  
+**Primary Dependencies**: Existing `github.com/spf13/cobra` v1.10.2 (flag wiring), existing `github.com/rs/zerolog` v1.35.1 (stderr warnings), existing `internal/fleet/security`; stdlib `bufio`, `errors`, `fmt`, `io`, `os`, `strings`. **No new third-party dependencies** (Constitution Principle I / §Third-Party Dependencies). `golang.org/x/term` remains an indirect-only entry in `go.sum` and is NOT promoted to a direct require.  
+**Storage**: N/A — no persistent state, cache, or new on-disk artifact. On decline the existing work-dir clone is left in place as a breadcrumb (no new file written; `--strict`'s `findings.json` is unchanged and unrelated).  
+**Testing**: Table-driven unit tests for `PromptUser` (the six issue cases), the severity-summary line, the stdout-TTY seam, the typed decline error, and the command flag propagation; placement tests asserting the prompt fires only on apply, only after the strict gate, and only when a commit is pending, across `deploy`/`sync`/`upgrade` using existing seams + temp dirs and an injected non-TTY stub. Full gate: `make ci` (fmt-check, vet, lint, test).  
+**Target Platform**: Linux / macOS developer and CI environments running the `gh-aw-fleet` CLI.  
+**Project Type**: Single Go module CLI orchestrator (`cmd/` plus `internal/fleet/...`).  
+**Performance Goals**: Negligible — one O(findings) severity tally and, only in the interactive-with-findings case, one line read from stdin. No network, no extra scanner pass, no parallelism impact.  
+**Constraints**: Prompt is per-invocation and per-repo; never persisted to fleet config; fires only on `--apply`, only after the `--strict` gate, and only when a commit is actually pending; suppressed when stdout is not a terminal and when `--yes` is set; declining aborts before any commit/push/PR, exits non-zero with re-run guidance, and preserves the clone; `cmd.SchemaVersion` and `fleet.SchemaVersion` do not change; `--yes` does not alter stderr or PR-body findings output.  
+**Scale/Scope**: Per-repo confirmation over typical fleets of ≤10 repos and ≤20 workflows each. Multi-repo `upgrade --all` confirms per repo as each repo reaches its commit; batch continuation after a decline follows the command's existing fail-fast behavior.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against Constitution v1.3.0.
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| **I. Thin-Orchestrator Code Quality** | PASS | No workflow-markdown rewriting and no re-implemented detection. Adds one small operator-confirmation helper over the existing `security.Finding` slice plus a stdlib TTY check. New exported identifiers (`SecurityOpts.Yes`, `PromptUser`, the decline error, `security.SeveritySummary`) get godoc. Files stay well under the 300-line guidance. |
+| **II. Testing Standards** | PASS | `PromptUser` is pure enough for table-driven unit tests via injected `io.Reader`/`io.Writer` and a TTY stub. Command placement is covered with existing seams and dry-run mode; no live PR creation needed. `make ci` required before done; any live `--apply` validation remains user-approved only. |
+| **III. User Experience Consistency** | PASS | Strengthens the three-turn mutation pattern: dry-run stays the default and unprompted; the new prompt is an *additional* explicit gate before mutation, not a bypass. Decline routes an actionable "re-run with --yes" message; the clone is preserved on decline per the breadcrumb convention. No commit-message/PR-title format changes. |
+| **IV. Performance Requirements** | PASS | One in-memory tally over findings and, only in the interactive case, one stdin read. No network, no cache change, no new scanner pass. |
+| **Declarative Reconcile Invariants** | PASS | `--yes`/prompt are invocation state, never written to `fleet.json`/`fleet.local.json`. No signing bypass; git is still only invoked by the Go tool inside Deploy/Sync/Upgrade. |
+| **Third-Party Dependencies** | PASS | **No new direct dependency.** The issue's suggested `golang.org/x/term` is rejected for the stdlib `os.Stat`+`ModeCharDevice` pattern already in `cmd/add.go`, so no amendment is required. |
+| **Documentation Impact** | PASS | User-facing `--yes` flag added and apply-time behavior changes when findings are present, so README, the Starlight reconcile/security docs, and the relevant operator skills must be updated (see below). |
+
+**Result**: All gates pass. No Complexity Tracking entries required.
+
+## Documentation Impact
+
+*GATE: Record which user-facing documentation surfaces this feature touches.*
+
+- **Surfaces touched**: Cobra help for `deploy`, `sync`, and `upgrade` (new `--yes` flag); `README.md` reconcile/quickstart usage; `docs/src/content/docs/reconcile.md` (and the security/scanner doc page if one exists) to describe the prompt + `--yes` + the three-surface model; `skills/fleet-deploy/SKILL.md` and `skills/fleet-upgrade-review/SKILL.md` (the three-turn flow now includes an in-tool confirmation, and the `--yes` bypass must be shown alongside `--apply`).
+- **Update planned**: yes. The feature adds a visible CLI flag and changes apply-time behavior when findings are present; per the constitution's Development Workflow rule the human-facing docs and the affected skills must be updated in the same change.
+- **Hidden surfaces**: none. The hidden `__schema` command will expose `--yes` automatically through the existing schema generator; it remains deliberately undocumented.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-security-finding-prompt/
+├── plan.md                       # This file (/speckit-plan output)
+├── spec.md                       # Feature spec (/speckit-specify output)
+├── research.md                   # Phase 0 output
+├── data-model.md                 # Phase 1 output
+├── quickstart.md                 # Phase 1 output
+├── contracts/
+│   └── security-prompt-contract.md   # Phase 1 output
+├── checklists/
+│   └── requirements.md           # /speckit-specify output
+└── tasks.md                      # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── deploy.go               # add --yes flag; pass into fleet.SecurityOpts{Strict, Yes}
+├── deploy_test.go          # --yes flag/help registration + decline-exit surface coverage
+├── sync.go                 # add --yes flag; thread into SecurityOpts
+├── sync_test.go            # sync --yes propagation coverage
+├── upgrade.go              # add --yes flag; thread into SecurityOpts (incl. --all)
+├── upgrade_test.go         # single-repo and --all --yes coverage
+├── findings.go             # unchanged; stderr warning emission stays shared (surface 1)
+└── output.go               # map the typed decline error to a clean non-zero failure (no hint spam)
+
+internal/fleet/
+├── security_prompt.go      # NEW: PromptUser, stdoutIsTerminal seam, OperatorDeclinedError,
+│                           #      confirmSecurityFindings wrapper (preserves clone on decline)
+├── security_prompt_test.go # NEW: six PromptUser cases, TTY-stub, summary line, decline error
+├── security_gate.go        # SecurityOpts gains `Yes bool` (sits beside `Strict bool`)
+├── deploy.go               # call confirm after strict gate / before createDeployPR (fresh);
+│                           #   before resume commit-gate + push-gate PR calls (handleWorkDirResume)
+├── deploy_test.go          # prompt fires only on apply, after strict, before commit; decline aborts
+├── sync.go                 # prune-only path: confirm before commitAndPushPrune (add path inherits Deploy's)
+├── sync_test.go            # delegated-add prompts once (via Deploy); prune-only prompts; clean path silent
+├── upgrade.go              # confirm before createUpgradePR (main + no-change manifest backfill)
+└── upgrade_test.go         # dry-run no prompt; apply prompts; --all decline halts that repo
+
+internal/fleet/security/
+└── render.go               # export SeveritySummary(findings) wrapping the existing severityTally
+
+README.md                            # --yes flag + three-surface UX
+docs/src/content/docs/reconcile.md   # prompt + --yes + non-interactive behavior
+skills/fleet-deploy/SKILL.md         # in-tool confirmation step + --yes bypass
+skills/fleet-upgrade-review/SKILL.md # same for upgrade
+CLAUDE.md / AGENTS.md                # managed Spec Kit plan reference (SPECKIT markers)
+```
+
+**Structure Decision**: Keep the confirmation in `internal/fleet`
+(`security_prompt.go`), not in `internal/fleet/security`, exactly as slice 017
+kept the strict gate in `internal/fleet/security_gate.go`. The `security`
+package means "produce findings"; the `fleet` package decides what a command
+invocation *does* with them — render, block (`--strict`), or confirm (this
+feature). The only `security`-package change is exporting the existing
+severity-tally helper for the prompt's one-line summary.
+
+## Phase 0: Outline & Research
+
+The spec contains no unresolved `NEEDS CLARIFICATION` markers. Phase 0 resolves
+the placement and compatibility decisions the issue's sketch left open or got
+wrong against the current code — most notably rejecting the suggested
+`golang.org/x/term` dependency in favor of the in-repo stdlib TTY pattern. See
+[research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+- [data-model.md](./data-model.md) defines the `SecurityOpts.Yes` field,
+  `PromptUser`, the `stdoutIsTerminal` seam, `OperatorDeclinedError`, the
+  `confirmSecurityFindings` wrapper, and the exported `SeveritySummary` helper —
+  all consuming the existing `security.Finding` shape unchanged.
+- [contracts/security-prompt-contract.md](./contracts/security-prompt-contract.md)
+  defines the `--yes` flag, the six-row `PromptUser` decision table, the
+  interactivity gate, the decline/abort behavior, surface coexistence, and the
+  per-command placement (after the strict gate, apply-only, commit-pending).
+- [quickstart.md](./quickstart.md) lists the offline unit/placement scenarios and
+  the user-approved live `--apply` validation.
+- Agent context: the managed Spec Kit block in `CLAUDE.md` and `AGENTS.md` is
+  retargeted to this plan.
+
+## Post-Design Constitution Check
+
+All Phase 1 artifacts preserve the pre-design decisions:
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| **I. Thin-Orchestrator Code Quality** | PASS | The contract keeps detection in `security` and confirmation policy in `fleet`; the only new abstractions are one pure function, one seam, one typed error, and one exported tally wrapper. |
+| **II. Testing Standards** | PASS | Quickstart specifies table-driven unit tests plus offline placement tests and `make ci`; live `--apply` stays user-approved. |
+| **III. User Experience Consistency** | PASS | The prompt adds an explicit pre-mutation gate; decline preserves the clone and emits an actionable re-run message; dry-run stays unprompted. |
+| **IV. Performance Requirements** | PASS | One tally + at most one stdin read; no network or extra scanner pass. |
+| **Third-Party Dependencies** | PASS | No new direct dependency — stdlib TTY check confirmed in research.md. |
+| **Documentation Impact** | PASS | README, Starlight reconcile/security docs, and the deploy/upgrade skills are listed for update. |
+
+## Complexity Tracking
+
+> No constitution violations or justified complexity exceptions.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |

--- a/specs/019-security-finding-prompt/quickstart.md
+++ b/specs/019-security-finding-prompt/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Interactive security-finding prompt before commit
+
+Runnable validation scenarios. Unit/placement scenarios run offline against
+existing seams; the live `--apply` scenario requires explicit user approval and
+a scratch target repo (never run `--apply` unattended in a subagent).
+
+## Build & gate
+
+```bash
+go build ./...
+make ci          # fmt-check, vet, lint, test — required before "done"
+```
+
+## Unit scenarios (`internal/fleet/security_prompt_test.go`)
+
+Table-driven over `PromptUser(findings, yes, in, out)` with `bytes.Buffer` for
+`in`/`out` and the `stdoutIsTerminal` seam overridden per case:
+
+| Case | findings | yes | TTY stub | stdin | expect |
+|------|----------|-----|----------|-------|--------|
+| a | empty | false | true | — | `(true, nil)`, no output |
+| b | 1 HIGH | true | true | — | `(true, nil)`, no output |
+| c | 1 HIGH | false | **false** | — | `(true, nil)`, no output |
+| d | 1 HIGH | false | true | `"y\n"` | `(true, nil)`, summary written |
+| e | 1 HIGH | false | true | `"n\n"` | `(false, nil)` |
+| f | 1 HIGH | false | true | `""` (EOF) | `(false, err)` |
+
+Also assert: empty stdin line (`"\n"`) → `(false, nil)` (default No); `"YES\n"`
+and `"Y\n"` → `(true, nil)`; the written summary contains
+`security.SeveritySummary(findings)` (e.g. `2 HIGH, 1 MEDIUM`).
+
+## Placement scenarios (deploy/sync/upgrade, offline)
+
+Use existing test seams + temp dirs + an injected non-TTY (so prompts never
+block) and a forced finding fixture:
+
+- **Dry-run never prompts**: `Deploy(..., opts{Apply:false})` with findings →
+  `PromptUser` is not invoked; no `OperatorDeclinedError`.
+- **Apply + non-TTY proceeds**: `opts{Apply:true}`, findings, TTY stub false →
+  proceeds to the commit boundary; clone not preserved for this reason.
+- **Apply + TTY + decline aborts**: TTY stub true, stdin `"n\n"` → returns
+  `*OperatorDeclinedError`, no `createDeployPR` call, clone preserved.
+- **`--yes` skips**: `opts.Security.Yes=true`, findings, TTY stub true → proceeds
+  with no stdin read; stderr findings + PR-body section still produced.
+- **Strict precedes prompt**: `opts.Security.Strict=true` with a HIGH finding →
+  `*StrictSecurityError` returned before the prompt is reached.
+- **Sync prompts once**: sync add path (Missing>0) prompts via the delegated
+  `Deploy` exactly once; sync prune-only path (Missing==0, Pruned>0) prompts once
+  before `commitAndPushPrune`; sync clean path prompts zero times.
+- **Zero findings**: apply with no findings → no prompt, no `## Security
+  Findings` PR section.
+
+## Command flag scenarios (`cmd/*_test.go`)
+
+- `--yes` is registered on `deploy`, `sync`, and `upgrade` with the documented
+  help text; `__schema` lists it for all three.
+- A decline surfaces as a clean non-zero failure (mapped via
+  `IsOperatorDeclinedError` in `output.go`), not a hint-engine dump.
+
+## Manual live validation (user-approved `--apply` only)
+
+> Three-turn pattern: dry-run → explicit "go" → apply. Never apply unattended.
+
+1. Prepare a scratch repo whose clone trips a scanner rule (e.g. an embedded
+   fake secret in a workflow).
+2. **Interactive decline**: `./gh-aw-fleet deploy <scratch> --apply` in a
+   terminal → severity summary + `Proceed with commit? [y/N]`; answer `n` →
+   assert no branch/commit/PR was created and the command exited non-zero.
+3. **Interactive accept**: re-run, answer `y` → assert the PR was created and its
+   body contains a `## Security Findings` section.
+4. **`--yes` bypass**: `./gh-aw-fleet deploy <scratch> --apply --yes` → no prompt;
+   PR created with the `## Security Findings` section still present, and findings
+   still printed on stderr.
+5. **Pipe bypass**: `./gh-aw-fleet deploy <scratch> --apply | cat` → no prompt,
+   does not hang; findings still on stderr; PR body still has the section.
+6. **Zero findings**: deploy a clean repo `--apply` → no prompt, no `## Security
+   Findings` section.
+
+## Success signals (maps to Success Criteria)
+
+- SC-001/002: interactive decline blocks 100% (no remote change).
+- SC-003: piped/CI never hangs.
+- SC-004: confirmed or `--yes` apply always carries the PR-body section.
+- SC-005: zero findings adds no friction.
+- SC-006: identical behavior across `deploy`/`sync`/`upgrade`.

--- a/specs/019-security-finding-prompt/research.md
+++ b/specs/019-security-finding-prompt/research.md
@@ -1,0 +1,169 @@
+# Phase 0 Research: Interactive security-finding prompt before commit
+
+The spec carries no unresolved `[NEEDS CLARIFICATION]` markers. Phase 0 records
+the implementation-placement and compatibility decisions that the issue's
+implementation sketch glossed over or got wrong against the current codebase.
+
+## Decision 1: TTY detection — stdlib `os.Stat`, not `golang.org/x/term`
+
+**Decision**: Detect whether stdout is an interactive terminal with the stdlib
+pattern `fi, _ := os.Stdout.Stat(); fi.Mode()&os.ModeCharDevice != 0`. Do **not**
+add `golang.org/x/term` as a direct dependency.
+
+**Rationale**: The issue suggests `term.IsTerminal(int(os.Stdout.Fd()))`, but a
+new direct dependency in `go.mod`'s `require()` block requires a Constitution
+§Third-Party Dependencies amendment (MINOR bump) and must first be evaluated
+against the standard library. The standard library already suffices: `cmd/add.go`
+already ships `isStdinTerminal()` using exactly the `os.Stat` + `ModeCharDevice`
+approach. Reusing that pattern (applied to stdout) is constitutionally required
+("evaluate the Go standard library first"), avoids the amendment, and keeps the
+build's dependency surface unchanged. `golang.org/x/term` stays an indirect-only
+entry in `go.sum`.
+
+**Alternatives considered**:
+
+- *Promote `golang.org/x/term` to a direct dep* — rejected: constitution
+  amendment for zero functional gain over stdlib; `IsTerminal` is a two-line
+  `ModeCharDevice` check the repo already implements.
+- *Probe `os.Getenv("CI")` / `TERM`* — rejected: brittle and incomplete;
+  `ModeCharDevice` is the canonical, env-independent signal.
+
+## Decision 2: Gate on stdout, write the prompt to stdout, read from stdin
+
+**Decision**: Key the interactivity gate on **stdout** being a character device
+(per FR-014), write the one-line prompt to the `out` writer wired to `os.Stdout`,
+and read the answer from `in` wired to `os.Stdin`. Suppress the prompt entirely
+when the command is in `--output json` mode (treated as non-interactive).
+
+**Rationale**: FR-014 requires detecting on the surface the question is written
+to, so that `tool | tee` (stdout redirected, stdin still a TTY) does **not**
+prompt — the operator cannot see a question written to a redirected stdout. This
+deliberately diverges from `cmd/add.go`, which gates on stdin; the divergence is
+already recorded in the spec's Assumptions. JSON mode is suppressed because a
+prompt written to stdout would corrupt the JSON envelope, and a machine
+consuming JSON cannot answer anyway — consistent with FR-009's "non-interactive
+contexts proceed automatically" and codified as **FR-018** (JSON mode is
+non-interactive even when stdout is a TTY). Operators wanting a JSON-mode block
+use `--strict`.
+
+**Alternatives considered**:
+
+- *Gate on stdin (mirror `add`)* — rejected: FR-014 + the `tool | tee` edge case
+  in the spec require the stdout surface; prompting into a redirected stdout that
+  the human never sees is the exact footgun the spec calls out.
+- *Write the prompt to stderr while gating on stdout* — viable and JSON-safe, but
+  contradicts FR-014's "the surface the question is written to" and the issue's
+  `out`-is-stdout contract; rejected to keep the gate and the write on one
+  surface. JSON-mode suppression (above) closes the only corruption gap.
+
+## Decision 3: Placement — after the strict gate, at each apply commit/push/PR boundary
+
+**Decision**: Fire the confirmation inside the `internal/fleet` functions,
+immediately after `security.Run` + the `--strict` gate, on the apply path only,
+at each boundary that is about to commit/push/PR — and only when a commit is
+actually pending:
+
+- **Deploy fresh path** — after the `if !opts.Apply { return }` dry-run return
+  and the `len(res.Added)==0 && !staged` no-op guard, before `createDeployPR`.
+- **Deploy `--work-dir` resume** (`handleWorkDirResume`) — before the
+  commit-gate `createDeployPR` call and before the push-gate `pushAndCreatePR`
+  call (both already re-run the scanner + strict gate).
+- **Sync prune-only path** — before `commitAndPushPrune`. Sync's *add* path
+  delegates to `Deploy` (`applyDeployOrPrune` calls `Deploy` with
+  `Security: opts.Security`), so it inherits Deploy's single prompt; sync must
+  **not** add a second prompt there.
+- **Upgrade** — before `createUpgradePR` (both the main changed-files path and
+  the no-change manifest-backfill path that can still open a PR).
+
+**Rationale**: FR-011 requires the prompt to run after `--strict` (no point
+asking "proceed?" about a decision strict already made). FR-001 limits it to
+apply. Asking "proceed with commit?" when nothing will be committed is noise, so
+the prompt sits after the no-op guards. Placing it at the *fleet* layer (not the
+`cmd` layer like `add`) is mandatory because findings are unknown until after the
+clone is made and the scanner runs deep inside `Deploy`/`Sync`/`Upgrade`.
+
+**The "prompt exactly once" guarantee** (spec edge case) is structural: sync's
+add path runs through `Deploy`, which owns the single prompt; the only sync path
+that commits *outside* `Deploy` is prune-only, which gets its own prompt.
+
+**Alternatives considered**:
+
+- *Prompt in the `cmd` layer (mirror `add`)* — impossible: the cmd layer has no
+  findings until `Deploy`/`Sync`/`Upgrade` returns, which is after the commit.
+- *Prompt inside `createDeployPR`* — rejected: the clone-cleanup flag
+  (`cleanupClone`) needed to preserve the clone on decline is in the
+  `Deploy`-function scope, not inside `createDeployPR`; and `createDeployPR` is
+  also the resume commit-gate, which would double-count against the push-gate.
+
+## Decision 4: Decline semantics — typed error, non-zero exit, preserve clone
+
+**Decision**: On decline (including empty input and EOF/read error), return a
+typed `OperatorDeclinedError` from the fleet function. The fleet layer preserves
+the work-dir clone (set `cleanupClone=false`, mirroring
+`preserveCloneForStrictError`; on resume paths cleanup is already disabled). The
+`cmd` layer recognizes the typed error and prints a clean, actionable
+"aborted by operator — re-run with --yes to skip the prompt" message, exiting
+non-zero, without routing it through the hint engine as if it were a crash.
+
+**Rationale**: `cmd/add.go` already establishes the in-repo precedent: declining
+its confirmation returns `errors.New("aborted: re-run with --apply --yes to
+confirm")` → non-zero exit. Mirroring that keeps the fleet's confirmation UX
+consistent (spec Assumptions). A *typed* error (rather than `errors.New`) lets
+`output.go` distinguish a deliberate operator decline from a real failure and
+present it cleanly. Preserving the clone matches the Constitution's
+failure-breadcrumb invariant and lets the operator resume with `--work-dir
+<clone> --yes` instead of re-cloning.
+
+**Alternatives considered**:
+
+- *Exit 0 on decline* — rejected: the operator requested `--apply` and it did not
+  complete; non-zero is the correct signal and matches `add`.
+- *Untyped `errors.New`* — rejected: the cmd layer needs to tell a decline apart
+  from a genuine error to avoid emitting misleading remediation hints.
+
+## Decision 5: `--yes` lives on `SecurityOpts`; prompt fires on any severity
+
+**Decision**: Add `Yes bool` to the existing `SecurityOpts` struct (beside
+`Strict bool`), wire `--yes` on all three commands via
+`fleet.SecurityOpts{Strict: flagStrict, Yes: flagYes}`. The prompt fires on the
+presence of **any** finding regardless of severity (FR-015).
+
+**Rationale**: `SecurityOpts` is already the grouping threaded into
+`DeployOpts`/`SyncOpts`/`UpgradeOpts` and into sync's delegated `Deploy` call, so
+`Yes` rides the same path that already carries `Strict` — including the
+delegation that makes "prompt once" work. Any-severity triggering matches the
+binding acceptance criteria ("findings present"), not the user story's
+illustrative "HIGH" (spec Assumptions). The lowest-severity informational
+findings therefore prompt too; a severity floor is explicitly out of scope.
+
+**Alternatives considered**:
+
+- *New top-level `Yes` on each Opts struct* — rejected: duplicates wiring and
+  misses the sync→Deploy delegation that `SecurityOpts` already rides.
+- *Prompt only on HIGH/MEDIUM* — rejected: contradicts the binding acceptance
+  criteria; `--strict` already owns severity-thresholded behavior.
+
+## Decision 6: Reuse the existing severity tally for the summary line
+
+**Decision**: Export the existing unexported `severityTally` from
+`internal/fleet/security/render.go` as `SeveritySummary(findings) string` and use
+it verbatim for the prompt's one-line summary (e.g. `2 HIGH, 1 MEDIUM`).
+
+**Rationale**: The PR-body summary already renders exactly this tally
+(`**Summary**: 2 HIGH, 1 MEDIUM`). Reusing it keeps the prompt's count
+consistent with the PR body and avoids a second severity-counting code path
+(DRY; FR-002).
+
+**Alternatives considered**:
+
+- *Inline a new tally in `security_prompt.go`* — rejected: duplicates logic that
+  already exists and must stay in sync with the PR-body summary.
+
+## No-amendment / no-schema-bump confirmation
+
+- **No new direct dependency** (Decision 1) → no Constitution amendment.
+- `cmd.SchemaVersion` (JSON envelope) and `fleet.SchemaVersion` (on-disk config)
+  are **unchanged**: `--yes` is invocation state, not config; the decline path is
+  a failure, not a new envelope field.
+- No change to scanner rules, finding ordering, stderr rendering, PR-body
+  rendering, or `gh aw compile --strict` resolution.

--- a/specs/019-security-finding-prompt/spec.md
+++ b/specs/019-security-finding-prompt/spec.md
@@ -1,0 +1,343 @@
+# Feature Specification: Interactive security-finding prompt before commit
+
+**Feature Branch**: `019-security-finding-prompt`  
+**Created**: 2026-06-28  
+**Status**: Draft  
+**Input**: GitHub issue #40 — "Defense-in-depth UX: stderr + interactive prompt + PR body Security Findings section" (part of epic #36)
+
+## Overview
+
+When a fleet operator runs `deploy`, `sync`, or `upgrade` with `--apply` in an
+interactive terminal and the security scanner reports findings, the tool must
+**pause and ask the operator to confirm** before any commit, branch push, or
+pull request is created. This is the second of three independent "defense in
+depth" surfaces that put scanner findings in front of a human:
+
+1. **Terminal output** — findings already appear on the operator's standard
+   error before the run finishes (delivered by the Layer 1 scanner).
+2. **Interactive confirmation** — *this feature*: a one-line, severity-summary
+   `[y/N]` prompt that gives the operator a last chance to abort.
+3. **Pull-request body** — findings already appear as a `## Security Findings`
+   section in the generated PR description (delivered by the Layer 1 scanner),
+   so a reviewer sees them too.
+
+The premise is that a single output surface is a single chance to miss a
+problem; three independent surfaces (the operator's screen, the operator's
+active attention, the reviewer's attention) make a bad change far harder to let
+through by accident.
+
+This feature also adds a `--yes` skip flag to `deploy`, `sync`, and `upgrade`
+that bypasses **only** the interactive prompt — it must not suppress the
+terminal output or the PR-body section.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Last-chance abort before a commit lands (Priority: P1)
+
+A fleet operator runs `gh-aw-fleet deploy <repo> --apply` from their terminal.
+The scanner reports security findings. Before anything is committed or pushed,
+the tool stops and asks: a short severity summary followed by `Proceed with
+commit? [y/N]`. The operator can type `n` to abort with nothing changed on the
+remote, or `y` to continue. When they continue, the resulting pull request
+contains the `## Security Findings` section so a teammate reviewing the PR sees
+the same findings.
+
+**Why this priority**: This is the entire point of the feature — the
+interactive confirmation is the only one of the three surfaces that can *stop*
+a change rather than merely report it after the fact. Without it there is no
+"last chance to abort." Everything else in this spec exists to support or
+constrain this interaction.
+
+**Independent Test**: In an interactive terminal, deploy a repo whose clone
+contains a scanner-triggering artifact with `--apply`. Confirm the prompt
+appears with a severity summary, that answering `n` produces no commit, no
+branch push, and no PR, and that answering `y` produces a PR whose body
+contains `## Security Findings`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal and a repo with at least one finding,
+   **When** the operator runs `deploy <repo> --apply` and answers `n` at the
+   prompt, **Then** no commit, branch push, or PR is created and the command
+   reports that it was aborted by the operator.
+2. **Given** the same setup, **When** the operator answers `y`, **Then** the
+   apply proceeds and the resulting PR body contains a `## Security Findings`
+   section.
+3. **Given** an interactive terminal and a repo with **zero** findings,
+   **When** the operator runs `deploy <repo> --apply`, **Then** no
+   confirmation prompt appears and the PR body contains no `## Security
+   Findings` section.
+4. **Given** an interactive terminal and a repo with findings, **When** the
+   operator presses Enter without typing anything, **Then** the empty response
+   is treated as "No" and the apply is aborted.
+
+---
+
+### User Story 2 - Skip the prompt without hiding the findings (Priority: P2)
+
+An operator who has already reviewed the findings (or who is driving an apply
+they have decided to trust) runs the command with `--yes`. The interactive
+prompt is skipped and the apply proceeds, but the findings still appear on the
+terminal and the generated PR body still contains the `## Security Findings`
+section. `--yes` buys speed, not silence.
+
+**Why this priority**: Without a documented bypass, operators who legitimately
+want to skip the prompt would have no supported path and might resort to
+piping output to defeat the terminal check — which would also be confusing. The
+explicit `--yes` flag makes the intent clear and guarantees the other two
+surfaces stay intact.
+
+**Independent Test**: In an interactive terminal, deploy a repo with findings
+using `--apply --yes`. Confirm no prompt appears, the apply proceeds, the
+findings appear on standard error, and the PR body contains `## Security
+Findings`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal and a repo with findings, **When** the
+   operator runs `deploy <repo> --apply --yes`, **Then** no prompt appears,
+   the apply proceeds, and the PR body still contains `## Security Findings`.
+2. **Given** the same setup, **When** the apply runs with `--yes`, **Then**
+   the findings are still surfaced on standard error.
+3. **Given** `deploy`, `sync`, and `upgrade`, **When** an operator inspects
+   their flags, **Then** all three expose a `--yes` flag with the same
+   meaning.
+
+---
+
+### User Story 3 - Non-interactive runs never hang (Priority: P3)
+
+An operator (or an automation script) runs the command with output piped or
+redirected, or in CI where there is no terminal. Even when findings are
+present, the command must **not** stop to wait for a keypress that will never
+come. It proceeds automatically, and the findings still appear on standard
+error and in the PR body. Operators who want findings to *block* a
+non-interactive run use the separate `--strict` gate, not this prompt.
+
+**Why this priority**: A prompt that hangs in CI or under a pipe would be a
+worse outcome than no prompt at all — it would silently stall pipelines. This
+story is lower priority than P1/P2 because it largely preserves today's
+behavior (deploy/sync/upgrade have no interactive prompt today), but it is a
+hard correctness constraint on the P1 prompt.
+
+**Independent Test**: Run `deploy <repo> --apply` with standard output piped to
+another command, against a repo with findings. Confirm the command does not
+wait for input, completes the apply, and still emits the findings on standard
+error and in the PR body.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo with findings and standard output redirected (not a
+   terminal), **When** the operator runs `deploy <repo> --apply`, **Then** no
+   prompt appears, the command does not wait for input, and the apply
+   proceeds.
+2. **Given** the same non-interactive run, **When** it proceeds, **Then** the
+   findings still appear on standard error and the PR body still contains
+   `## Security Findings`.
+
+---
+
+### Edge Cases
+
+- **Strict gate already blocked the run**: When `--strict` is active and the
+  findings are severe enough to block, the run is aborted by the strict gate
+  *before* the confirmation prompt is reached — the operator is never asked
+  "proceed?" about a decision that has already been made. The prompt only
+  appears for runs the strict gate let through (no `--strict`, or findings
+  below the strict threshold).
+- **Output redirected but input still a terminal** (`tool | tee`): Because the
+  question is written to standard output and the operator cannot see it when
+  output is redirected, no prompt is shown and the apply proceeds
+  automatically.
+- **Machine-readable output** (`--output json`): The prompt is suppressed even
+  when standard output is an interactive terminal, because writing the question
+  to standard output would corrupt the JSON envelope and an automated consumer
+  cannot answer. The apply proceeds (findings still on standard error and in the
+  PR body); a machine-readable run that must block on findings uses `--strict`.
+- **Input closed / end-of-file at the prompt**: Treated as a decline (fail
+  safe) — the apply is aborted rather than proceeding on an unanswered
+  question.
+- **Informational-only findings**: A run whose only findings are the lowest,
+  purely informational severity (e.g. an unparseable advisory config) still
+  triggers the prompt in an interactive terminal, because the confirmation
+  fires on the presence of *any* finding. A severity floor for the prompt is
+  explicitly out of scope for this version (see Out of Scope).
+- **`--yes` without `--apply`**: `--yes` only governs the apply-time
+  confirmation, so passing it on a dry run has no effect; the tool surfaces
+  this consistently with how `--yes` already behaves on the existing `add`
+  command (an informational note, not an error).
+- **Multi-repo runs** (e.g. `upgrade` across several repos): Each repo's
+  findings gate that repo's own commit, so the confirmation is asked per repo
+  as each repo is about to be committed. Declining one repo aborts that repo;
+  whether the remaining repos continue follows the command's existing
+  multi-repo failure behavior.
+- **`sync` delegating to `deploy`**: `sync` reuses the deploy pipeline on its
+  apply path. The operator must be prompted exactly once for a given repo, not
+  twice.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When an apply (`deploy`, `sync`, or `upgrade` with `--apply`)
+  produces one or more security findings, is running in an interactive
+  terminal, and `--yes` was not supplied, the system MUST ask the operator to
+  confirm before creating any commit, branch push, or pull request.
+- **FR-002**: The confirmation prompt MUST present a one-line summary of the
+  findings by severity so the operator can decide without scrolling back through
+  earlier output. The summary MUST list only the severities actually present,
+  using the labels `HIGH` / `MEDIUM` / `LOW` / `INFO` (e.g. `2 HIGH, 1 INFO`);
+  severities with a zero count are omitted.
+- **FR-003**: An affirmative response (`y`, `Y`, or `yes`, case-insensitive)
+  MUST be treated as "proceed." Any other non-empty response MUST be treated
+  as "decline."
+- **FR-004**: An empty response (the operator presses Enter with no input)
+  MUST default to "decline" — the safe default is No.
+- **FR-005**: When the operator declines, the system MUST NOT create any
+  commit, branch push, or pull request, MUST report that the run was aborted
+  by the operator with guidance on how to re-run non-interactively (re-run with
+  `--yes`), and MUST exit with a non-zero status.
+- **FR-006**: When the operator confirms, the apply MUST proceed and complete
+  as it would have without the prompt.
+- **FR-007**: When `--yes` is supplied, the system MUST skip the interactive
+  prompt and proceed, without otherwise changing the apply.
+- **FR-008**: `--yes` MUST NOT suppress the findings shown on standard error,
+  and MUST NOT suppress the `## Security Findings` section of the generated PR
+  body. It governs the interactive prompt only.
+- **FR-009**: When standard output is not an interactive terminal (CI, piped,
+  or redirected output), the system MUST NOT display the prompt and MUST NOT
+  wait for input; it MUST proceed automatically. The findings MUST still be
+  surfaced on standard error and in the PR body.
+- **FR-010**: When there are zero findings, the system MUST NOT display the
+  prompt and MUST NOT add a `## Security Findings` section to the PR body,
+  regardless of terminal state or `--yes`.
+- **FR-011**: The interactive prompt MUST run only *after* the `--strict`
+  security gate. If the strict gate aborts the run, the prompt MUST NOT appear.
+- **FR-012**: If reading the operator's response fails or reaches end-of-file
+  before an answer arrives, the system MUST treat it as a decline (abort the
+  apply rather than proceed).
+- **FR-013**: A `--yes` flag with the semantics above MUST be available on
+  `deploy`, `sync`, and `upgrade`, with consistent behavior across all three.
+- **FR-014**: Terminal detection MUST key on the surface the question is
+  written to (standard output), so that a run whose output is redirected does
+  not prompt even if input happens to be a terminal. Machine-readable output
+  (`--output json`) is an explicit exception that suppresses the prompt even on
+  a terminal (FR-018).
+- **FR-015**: The confirmation MUST fire on the presence of *any* finding,
+  irrespective of severity (the prompt is not limited to high-severity
+  findings).
+- **FR-016**: The operator MUST be able to see the findings (at minimum the
+  severity summary in the prompt) *before* the apply commits — the findings
+  must not be visible only after the change has already landed. This is the
+  pre-commit visibility guarantee underlying the FR-001 confirmation.
+- **FR-017**: The flag's help text MUST state that `--yes` skips interactive
+  confirmation and does **not** suppress findings from terminal output or the
+  PR body.
+- **FR-018**: When the command is producing machine-readable output (`--output
+  json`), the system MUST treat the run as non-interactive and MUST NOT display
+  the prompt, regardless of whether standard output is a terminal — a prompt
+  written to standard output would corrupt the JSON envelope and an automated
+  consumer cannot answer it. The findings MUST still be surfaced on standard
+  error and in the PR body; operators who want a machine-readable run to *block*
+  on findings use `--strict`.
+
+### Key Entities
+
+- **Security finding**: A single scanner result with a severity (HIGH /
+  MEDIUM / LOW / informational), an identifying rule, an optional file and
+  line location, a human-readable message, and a suggested remedy. Findings
+  are produced by the existing Layer 1 scanner; this feature consumes them but
+  does not define or modify them.
+- **Severity summary**: An aggregate count of findings grouped by severity,
+  used as the single human-readable line the confirmation prompt shows.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In an interactive terminal, an apply that produces at least one
+  finding pauses for confirmation before any remote change, in 100% of runs.
+- **SC-002**: When the operator declines, zero remote changes occur — no
+  commit, no branch push, and no PR — in 100% of declined runs.
+- **SC-003**: In non-interactive contexts (piped, redirected, CI, or `--output
+  json`), an apply with findings never waits for input; it either completes or
+  fails without blocking on a prompt, in 100% of runs.
+- **SC-004**: When findings exist and the apply proceeds (confirmed or
+  `--yes`), the resulting PR body contains the `## Security Findings` section
+  in 100% of such runs.
+- **SC-005**: When there are zero findings, the operator sees no new prompt and
+  no empty findings section — there is no added friction relative to today's
+  behavior.
+- **SC-006**: `deploy`, `sync`, and `upgrade` expose identical prompt and
+  `--yes` behavior, verifiable by inspecting each command's behavior under the
+  same finding and terminal conditions.
+
+## Out of Scope
+
+- **Per-finding accept/reject**: The confirmation is whole-batch. There is no
+  "skip this one finding, keep the rest" interaction in this version.
+- **Rich terminal UI**: No scrollable or expandable finding list. A single
+  terse severity-summary line plus the `[y/N]` prompt is sufficient.
+- **A severity floor for the prompt**: The prompt fires on any finding; there
+  is no option to only prompt on high-severity findings. Operators who want
+  severity-gated *blocking* in non-interactive contexts use `--strict`.
+- **A flag that forces the prompt in non-interactive contexts**: There is no
+  "always prompt even without a terminal" mode. Non-interactive gating is the
+  job of `--strict`, not this prompt.
+- **Changing what the scanner detects or how findings render**: The set of
+  findings, their severities, the standard-error rendering, and the PR-body
+  rendering are all delivered by the Layer 1 scanner and are not modified here.
+- **Changing the `--strict` gate**: This feature orders itself after the strict
+  gate but does not alter strict's behavior.
+
+## Assumptions
+
+- **`--yes` is newly introduced on `deploy`, `sync`, and `upgrade`.** Today the
+  flag exists only on the `add` command; `deploy`/`sync`/`upgrade` gate solely
+  on `--apply` and have no interactive confirmation. This feature adds the flag
+  and the prompt to those three commands. The issue's statement that "`--yes`
+  already exists on deploy" does not match the current code and is treated as
+  intent to add it.
+- **Non-interactive `--apply` proceeds without requiring `--yes`.** This
+  deliberately diverges from the existing `add` command, which *requires*
+  `--yes` for `--apply` in a non-interactive shell. For `deploy`/`sync`/
+  `upgrade`, a non-interactive apply with findings auto-proceeds (findings
+  still surfaced), because CI gating is the responsibility of the separate
+  `--strict` gate, not this prompt.
+- **Terminal detection keys on standard output, not standard input.** This
+  diverges from `add` (which checks standard input) and is chosen so that a run
+  whose output is redirected — where the operator cannot see the question —
+  does not prompt.
+- **"Findings present" means any severity.** The user story emphasizes
+  high-severity findings, but the binding acceptance criteria say "findings
+  present," and the lowest-severity informational findings still trigger the
+  prompt in an interactive terminal.
+- **Declining exits non-zero with re-run guidance.** This mirrors the existing
+  `add` command's decline behavior (which returns an error advising the
+  operator to re-run with `--yes`), keeping the fleet's confirmation UX
+  consistent across commands.
+- **The local clone is preserved on decline.** Consistent with the existing
+  invariant that apply-time clones are breadcrumbs, declining the prompt leaves
+  the work-dir clone in place so the operator can re-run against it (e.g. with
+  `--work-dir` and `--yes`) without re-cloning.
+- **Surface 1 (standard error) and surface 3 (PR body) already exist.** The
+  Layer 1 scanner already surfaces findings on standard error and in the PR
+  body. This feature adds surface 2 (the prompt) and must ensure the three
+  coexist — in particular it must not duplicate or contradict the existing
+  standard-error output, and the operator must be able to see findings before
+  the commit, not only after it.
+- **Confirmation is per repo for multi-repo runs.** Findings are computed per
+  repo and gate that repo's own commit, so each repo is confirmed
+  independently; batch-continuation after a decline follows each command's
+  existing multi-repo failure behavior.
+
+## Dependencies
+
+- **Layer 1 security scanner** (slice 006): supplies the findings, the
+  standard-error rendering, and the PR-body `## Security Findings` section that
+  this feature's prompt and `--yes` semantics wrap around.
+- **Strict security gate** (slice 017): already implemented; this feature
+  orders its prompt to run after the strict gate so a strict block is never
+  followed by a redundant "proceed?" question.
+- **Parent epic #36**: establishes the three-surface defense-in-depth model;
+  this feature delivers the middle surface.

--- a/specs/019-security-finding-prompt/tasks.md
+++ b/specs/019-security-finding-prompt/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: Interactive security-finding prompt before commit
+
+**Input**: Design documents from `/specs/019-security-finding-prompt/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/security-prompt-contract.md](./contracts/security-prompt-contract.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Required. The spec's Testing Strategy defines table-driven unit tests for the six `PromptUser` cases plus per-command placement coverage; quickstart.md enumerates them.
+
+**Organization**: Tasks are grouped by user story so each story is independently implementable and testable on top of the shared confirmation foundation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story label for story phases only (`[US1]`, `[US2]`, `[US3]`)
+- Every task names exact repository file paths to edit or validate
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature context and the existing seams before editing.
+
+- [x] T001 Review the design artifacts in specs/019-security-finding-prompt/plan.md, specs/019-security-finding-prompt/data-model.md, and specs/019-security-finding-prompt/contracts/security-prompt-contract.md
+- [x] T002 Review the apply-boundary and option seams in internal/fleet/deploy.go (createDeployPR, handleWorkDirResume push/commit gates), internal/fleet/sync.go (applyDeployOrPrune, commitAndPushPrune), internal/fleet/upgrade.go (createUpgradePR, finishNoChangeUpgrade), internal/fleet/security_gate.go (SecurityOpts), internal/fleet/security/render.go (severityTally), cmd/add.go (isStdinTerminal precedent), and cmd/output.go (error mapping)
+- [x] T003 [P] Review existing test patterns in internal/fleet/deploy_test.go, internal/fleet/sync_test.go, internal/fleet/upgrade_test.go, internal/fleet/strict_gate_flow_test.go, and cmd/output_test.go
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared confirmation primitives — the prompt function, options field, typed decline error, summary export, and cmd error mapping — that every user story depends on.
+
+**⚠️ CRITICAL**: No user story implementation should begin until this phase compiles and its focused tests pass.
+
+- [x] T004 Export `SeveritySummary(findings []Finding) string` wrapping the existing unexported `severityTally`, with a godoc sentence, in internal/fleet/security/render.go
+- [x] T005 [P] Add unit tests for `SeveritySummary` (empty → "", tally order HIGH→MEDIUM→LOW→INFO, zero-count omission) in internal/fleet/security/render_test.go
+- [x] T006 Add a `Yes bool` field (godoc: skips the interactive confirmation; does not suppress stderr/PR-body findings) beside `Strict bool` on `SecurityOpts` in internal/fleet/security_gate.go
+- [x] T007 Add failing table-driven unit tests for `PromptUser` covering the six contract rows plus empty-line default-No, `"Y\n"`/`"YES\n"` accept, an **INFO-only** finding set that still fires the prompt (FR-015 / the informational-only edge case — the prompt triggers on any severity, not just HIGH), and the written summary containing `SeveritySummary`, using bytes.Buffer in/out and an overridden `stdoutIsTerminal` seam, in internal/fleet/security_prompt_test.go
+- [x] T008 Implement `PromptUser`, the stdlib `stdoutIsTerminal` seam (os.Stdout.Stat + ModeCharDevice), `OperatorDeclinedError` (Error/Unwrap), `IsOperatorDeclinedError`, and the `confirmSecurityFindings` wrapper (preserves the clone on decline) in internal/fleet/security_prompt.go
+- [x] T009 Map `OperatorDeclinedError` to a clean non-zero failure (recognized via `IsOperatorDeclinedError`, not routed through the hint engine) in cmd/output.go, with coverage in cmd/output_test.go
+- [x] T010 Run focused foundational tests for internal/fleet/security_prompt_test.go and internal/fleet/security/render_test.go from /github/go/src/github.com/rshade/gh-aw-fleet
+
+**Checkpoint**: The shared prompt primitives compile; `PromptUser` and `SeveritySummary` tests pass; no command wiring exists yet.
+
+---
+
+## Phase 3: User Story 1 - Last-chance abort before a commit lands (Priority: P1) 🎯 MVP
+
+**Goal**: An interactive `deploy`/`sync`/`upgrade --apply` with findings pauses for `[y/N]` before any commit/push/PR; `n` aborts cleanly (no remote change, clone preserved, non-zero exit); `y` proceeds and the PR body carries `## Security Findings`.
+
+**Independent Test**: With the `stdoutIsTerminal` stub true and injected stdin, run the deploy/sync/upgrade apply paths against a fixture clone with a forced finding; `"n"` returns `*OperatorDeclinedError` and skips the PR step while preserving the clone, `"y"` proceeds, and dry-run never prompts.
+
+### Tests for User Story 1
+
+> Write these tests first and ensure they fail before implementation.
+
+- [x] T011 [P] [US1] Add Deploy fresh-path placement tests (prompt only on apply, only after the strict gate, only when a commit is pending; TTY+"n" → OperatorDeclinedError, no createDeployPR, clone preserved; TTY+"y" → proceeds; zero findings → no prompt and no `## Security Findings` PR section per FR-010/SC-005; prompt reached before `createDeployPR` so findings are visible pre-commit per FR-016) in internal/fleet/deploy_test.go
+- [x] T012 [P] [US1] Add Deploy `--work-dir` resume placement tests (prompt before the commit-gate createDeployPR and before the push-gate pushAndCreatePR; decline aborts before PR) in internal/fleet/deploy_test.go
+- [x] T013 [P] [US1] Add sync placement tests (add path prompts exactly once via the delegated Deploy; prune-only path prompts before commitAndPushPrune; clean path prompts zero times) in internal/fleet/sync_test.go
+- [x] T014 [P] [US1] Add Upgrade placement tests (apply prompts before createUpgradePR; dry-run never prompts; decline aborts before the PR; `--all` decline on one repo halts that repo and the batch continues per the existing fail-fast behavior) in internal/fleet/upgrade_test.go
+
+### Implementation for User Story 1
+
+- [x] T015 [US1] Call `confirmSecurityFindings` in Deploy after the strict gate and the no-op guard, before `createDeployPR` (so the findings summary is shown pre-commit per FR-016), setting `cleanupClone=false` on decline, in internal/fleet/deploy.go
+- [x] T016 [US1] Call `confirmSecurityFindings` in `handleWorkDirResume` before the commit-gate `createDeployPR` and before the push-gate `pushAndCreatePR` (cleanup already disabled on resume) in internal/fleet/deploy.go
+- [x] T017 [US1] Call `confirmSecurityFindings` in the sync prune-only path before `commitAndPushPrune`, and confirm the add path inherits Deploy's single prompt (no second prompt), in internal/fleet/sync.go
+- [x] T018 [US1] Call `confirmSecurityFindings` in Upgrade before `createUpgradePR` on both the changed-files path and the no-change manifest-backfill path in internal/fleet/upgrade.go
+
+**Checkpoint**: The interactive prompt gates every apply commit/push/PR boundary across deploy/sync/upgrade; decline preserves the clone and exits non-zero; the MVP is independently testable.
+
+---
+
+## Phase 4: User Story 2 - Skip the prompt without hiding the findings (Priority: P2)
+
+**Goal**: `--yes` on `deploy`/`sync`/`upgrade` bypasses only the interactive prompt; the stderr findings and the PR-body `## Security Findings` section are still produced.
+
+**Independent Test**: With `SecurityOpts.Yes=true`, findings present, and the TTY stub true, the apply proceeds with no stdin read; the stderr warnings still emit and `RenderPRSection` still returns the section.
+
+### Tests for User Story 2
+
+> Write these tests first and ensure they fail before implementation.
+
+- [x] T019 [P] [US2] Add Cobra flag/help/propagation tests for `--yes` on all three commands (registered, documented help text, threaded into `fleet.SecurityOpts.Yes`) in cmd/deploy_test.go, cmd/sync_test.go, and cmd/upgrade_test.go
+- [x] T020 [P] [US2] Add bypass tests proving `Yes=true` + findings + TTY stub proceeds without reading stdin (no OperatorDeclinedError) in internal/fleet/deploy_test.go
+- [x] T021 [P] [US2] Add surface-coexistence tests proving `--yes` still emits stderr findings warnings (cmd) and still includes the `## Security Findings` PR section (`security.RenderPRSection`) in cmd/deploy_test.go and internal/fleet/deploy_test.go
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] Add the `--yes` flag to newDeployCmd and set `fleet.SecurityOpts{Strict: flagStrict, Yes: flagYes}` in cmd/deploy.go
+- [x] T023 [US2] Add the `--yes` flag to newSyncCmd and thread it into the SyncOpts SecurityOpts in cmd/sync.go
+- [x] T024 [US2] Add the `--yes` flag to newUpgradeCmd (covering the single-repo and `--all` paths) and thread it into the UpgradeOpts SecurityOpts in cmd/upgrade.go
+
+**Checkpoint**: `--yes` skips the prompt on all three commands while the other two surfaces remain intact; US1 and US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Non-interactive runs never hang (Priority: P3)
+
+**Goal**: A non-interactive apply with findings (piped/redirected stdout, CI, or `--output json`) auto-proceeds without waiting for input; the stderr and PR-body surfaces still appear.
+
+**Independent Test**: With the `stdoutIsTerminal` stub false, an apply with findings proceeds with no stdin read and no decline error; in `--output json` mode the prompt is suppressed and the envelope is uncorrupted.
+
+### Tests for User Story 3
+
+> Write these tests first and ensure they fail before implementation.
+
+- [x] T025 [P] [US3] Add command-level non-TTY placement tests proving an apply with findings and the stdoutIsTerminal stub false proceeds without reading stdin and without an OperatorDeclinedError in internal/fleet/deploy_test.go and internal/fleet/upgrade_test.go
+- [x] T026 [P] [US3] Add `--output json` suppression tests (FR-018) proving an apply with findings (TTY stub true) emits no prompt into the JSON envelope and the envelope stays valid in cmd/output_test.go and cmd/deploy_test.go
+
+### Implementation for User Story 3
+
+- [x] T027 [US3] Suppress the prompt in `--output json` mode (FR-018 — treat JSON output as non-interactive even when stdout is a TTY) by passing the skip through the SecurityOpts from cmd/deploy.go, cmd/sync.go, and cmd/upgrade.go where the resolved output mode is JSON
+
+**Checkpoint**: Non-interactive contexts never block; JSON output is never corrupted by a prompt; all three stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: User-facing docs, skills, schema verification, and the full project gate.
+
+- [x] T028 [P] Document the `--yes` flag, the interactive prompt, and the non-interactive/CI behavior in README.md
+- [x] T029 [P] Document the three-surface confirmation UX (prompt + `--yes` + non-interactive) and how it differs from `--strict` in docs/src/content/docs/reconcile.md
+- [x] T030 [P] Update skills/fleet-deploy/SKILL.md so the three-turn flow includes the in-tool confirmation and the `--yes` bypass alongside `--apply`
+- [x] T031 [P] Update skills/fleet-upgrade-review/SKILL.md with the same confirmation/`--yes` guidance for upgrade
+- [x] T032 [P] Verify `__schema` lists `--yes` for deploy/sync/upgrade without documenting the hidden command, updating expectations in cmd/schema_test.go if needed
+- [x] T033 Run the offline quickstart scenarios from specs/019-security-finding-prompt/quickstart.md against the completed implementation
+- [x] T034 Run `make ci` from /github/go/src/github.com/rshade/gh-aw-fleet/Makefile and fix any fmt, vet, lint, or test failures
+- [x] T035 Confirm `cmd.SchemaVersion` and `fleet.SchemaVersion` are unchanged, `golang.org/x/term` is NOT promoted to a direct require in go.mod, and no `--yes` value is written to fleet.json/fleet.local.json
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories. `PromptUser` + `confirmSecurityFindings` + `SecurityOpts.Yes` must exist first.
+- **User Story 1 (Phase 3)**: Depends on Foundational; MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational; reuses the same boundaries US1 wired but adds the `--yes` flag. Can proceed after Phase 2, easiest after US1 establishes the wiring.
+- **User Story 3 (Phase 5)**: Depends on Foundational; the non-TTY branch already exists in `PromptUser`, so this phase mostly adds command-level assertions plus JSON suppression.
+- **Polish (Phase 6)**: Depends on the user stories selected for delivery.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on US2/US3 after Phase 2. Delivers the core value.
+- **US2 (P2)**: No functional dependency on US1, but the `--yes` flag governs the prompt US1 wired; their command-file edits (cmd/deploy.go, internal/fleet/deploy.go) overlap and should be coordinated.
+- **US3 (P3)**: No command dependency; hardens and documents the non-interactive path of the shared `PromptUser`.
+
+### Within Each User Story
+
+- Tests are written first and must fail before implementation.
+- Foundational `confirmSecurityFindings` exists before any boundary wiring (T015–T018) can pass placement tests.
+- Command flag wiring (T022–T024) before flag/propagation tests (T019) can pass.
+- Documentation and full `make ci` run only after the selected stories are complete.
+
+### Parallel Opportunities
+
+- T003 can run alongside T001/T002.
+- T005 (render_test.go) can be drafted alongside T004 (render.go); T007 (security_prompt_test.go) alongside T008 (security_prompt.go).
+- T011, T012 both edit internal/fleet/deploy_test.go — coordinate; T013 (sync_test.go) and T014 (upgrade_test.go) are independent and parallel.
+- T015 and T016 both edit internal/fleet/deploy.go — sequential; T017 (sync.go) and T018 (upgrade.go) are independent and parallel with each other.
+- T019 spans three cmd test files and can be split per command; T020/T021 touch deploy tests and should coordinate.
+- T028, T029, T030, T031, T032 can all run in parallel after behavior is implemented.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add Deploy fresh-path placement tests ... in internal/fleet/deploy_test.go"
+Task: "Add sync placement tests ... in internal/fleet/sync_test.go"
+Task: "Add Upgrade placement tests ... in internal/fleet/upgrade_test.go"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add Cobra flag/help/propagation tests for --yes ... in cmd/deploy_test.go, cmd/sync_test.go, cmd/upgrade_test.go"
+Task: "Add bypass tests proving Yes=true proceeds without reading stdin ... in internal/fleet/deploy_test.go"
+Task: "Add surface-coexistence tests for --yes ... in cmd/deploy_test.go and internal/fleet/deploy_test.go"
+```
+
+## Parallel Example: Polish
+
+```text
+Task: "Document the --yes flag and the interactive prompt in README.md"
+Task: "Document the confirmation UX in docs/src/content/docs/reconcile.md"
+Task: "Update skills/fleet-deploy/SKILL.md with the confirmation step and --yes bypass"
+Task: "Update skills/fleet-upgrade-review/SKILL.md with the same guidance"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational).
+2. Complete Phase 3 (US1): the interactive prompt gating every apply boundary.
+3. **STOP and VALIDATE**: interactive decline blocks before any commit/push/PR and preserves the clone; accept proceeds with the PR-body section; dry-run never prompts.
+4. Ship MVP with minimal docs if delivering US1 alone.
+
+### Incremental Delivery
+
+1. Deliver US1: the interactive last-chance abort (MVP).
+2. Deliver US2: the `--yes` bypass that keeps stderr + PR-body surfaces intact.
+3. Deliver US3: non-interactive robustness and JSON-mode suppression.
+4. Complete Polish and run `make ci`.
+
+### Validation Gate
+
+Before reporting implementation complete:
+
+1. Run focused tests for internal/fleet/security_prompt_test.go, internal/fleet/security/render_test.go, internal/fleet/deploy_test.go, internal/fleet/sync_test.go, internal/fleet/upgrade_test.go, and cmd/output_test.go.
+2. Run `make ci`.
+3. Confirm `cmd.SchemaVersion` / `fleet.SchemaVersion` are unchanged and no new direct dependency was added.
+
+## Notes
+
+- The prompt is the security confirmation only; it fires after the `--strict` gate and only on `--apply` when a commit is pending.
+- "Prompt exactly once" is structural: sync's add path inherits Deploy's prompt; only sync's standalone prune commit gets its own.
+- TTY detection is stdlib (os.Stdout.Stat + ModeCharDevice) — do NOT add `golang.org/x/term` as a direct dependency.
+- Decline preserves the work-dir clone as a breadcrumb; resume with `--work-dir <clone> --yes`.
+- Do not run live `--apply` validation (the spec's fake-secret end-to-end flow) without explicit user approval in the immediately preceding turn; dry-runs and injected-seam tests are the offline surface.
+- Do not hand-edit CHANGELOG.md; release-please owns it.


### PR DESCRIPTION
## Summary

- Completes the defense-in-depth UX: security findings now surface on a third independent channel — an interactive `[y/N]` confirmation — alongside the existing stderr warnings and PR-body section.
- On `--apply`, when the Layer 1 scanner reports one or more findings of any severity and stdout is an interactive terminal, the run pauses with `⚠  <tally>. Proceed with commit? [y/N]` before any commit, push, or PR. The safe default is No.
- Declining aborts cleanly (non-zero exit, no remote change) and preserves the work-dir clone so the operator can inspect it and resume with `--work-dir <clone> --yes`.
- `--yes` on `deploy`, `sync`, and `upgrade` skips only the prompt; it never suppresses the stderr findings or the PR-body section, and is never written to fleet config.
- Nothing ever hangs in non-interactive contexts: a piped/redirected stdout, CI, or `--output json` auto-proceeds (JSON mode is treated as non-interactive even at a TTY so the envelope is never corrupted).
- The prompt fires only on `--apply`, only after the `--strict` gate, and only once per repo per invocation (sync's add path inherits deploy's single prompt). It is additive: neither `cmd.SchemaVersion` nor `fleet.SchemaVersion` changes, and no new third-party dependency is added — TTY detection uses the stdlib `os.Stat` + `ModeCharDevice` pattern rather than `golang.org/x/term`.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l` clean (make fmt-check)
- [x] `golangci-lint run ./...` (v2.12.2) reports 0 issues
- [x] `go test ./...` passes (PromptUser decision table, deploy/sync/ upgrade placement tests, `--yes` flag propagation, JSON-mode suppression, decline mapping, `__schema` flag exposure)
- [ ] Live `--apply` walkthrough against a scratch repo — deferred; requires explicit operator approval and an external target

## Changes

### New files

- `internal/fleet/security_prompt.go` - `PromptUser` decision logic, the stdout-TTY seam, `OperatorDeclinedError` / `IsOperatorDeclinedError`, and the `confirmSecurityFindings` wrapper that preserves the clone on decline.
- `internal/fleet/security_prompt_test.go` - table-driven `PromptUser` and `confirmSecurityFindings` unit tests.
- `internal/fleet/security_prompt_placement_test.go` - deploy/sync/ upgrade placement tests (decline aborts pre-PR, accept proceeds, dry-run/non-TTY/`--yes`/zero-findings never prompt).
- `cmd/security_prompt_test.go` - `--yes` flag registration, propagation, JSON-mode suppression, and decline-mapping tests.

### Modified files

- `internal/fleet/security_gate.go` - add `SecurityOpts.Yes`.
- `internal/fleet/security/render.go` - export `SeveritySummary` over the existing severity tally (shared by the prompt and PR body).
- `internal/fleet/deploy.go` - confirm at the fresh and both resume commit/push gates; extract `finalizeDeployCommit` and `resumeAtCommitGate` to keep complexity in check.
- `internal/fleet/sync.go` - confirm on the prune-only commit path.
- `internal/fleet/upgrade.go` - confirm before the PR on the changed-files and no-change manifest-backfill paths.
- `cmd/output.go` - `securityOptsFor` (forces Yes in JSON mode), `mapOperatorDecline` (clean non-zero exit), shared `--yes` usage text.
- `cmd/deploy.go`, `cmd/sync.go`, `cmd/upgrade.go` - register `--yes` and route a decline to a clean exit.
- `internal/fleet/security/render_test.go` - `SeveritySummary` tests.
- `cmd/schema_test.go` - assert `--yes` appears in `__schema`; share the command-use strings helper.
- `README.md`, `docs/src/content/docs/reconcile.md`, `skills/fleet-deploy/SKILL.md`, `skills/fleet-upgrade-review/SKILL.md` - document the prompt, `--yes`, and the non-interactive behavior.

### Housekeeping

- `specs/019-security-finding-prompt/` - spec, plan, research, data model, contract, quickstart, and the completed task checklist.

Closes #40