### PR TITLE
docs: add tutorial/how-to/reference pages and de-duplicate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,10 @@ and `gh`.
 
 ### Install
 
-**Option 1 — One-liner installer (recommended).** Fetches the installer
-from the latest release's assets (immutable, pinned to a tagged version);
-the installer downloads the matching release archive for your OS/arch,
-verifies its SHA-256 against the release's `checksums.txt`, and drops the
-binary in your install directory.
+**Recommended — one-liner installer.** Fetches the installer from the
+latest release's assets, then downloads the matching archive for your
+OS/arch, verifies its SHA-256 against `checksums.txt`, and installs the
+binary:
 
 ```bash
 # Linux / macOS — installs to $HOME/.local/bin
@@ -200,171 +199,31 @@ iwr -UseBasicParsing https://github.com/rshade/gh-aw-fleet/releases/latest/downl
   | iex
 ```
 
-The release-asset URL is the recommended path — it pins to a tagged
-installer, not a moving `main`. If you're on a release that predates the
-installer assets and `releases/latest/download/install.*` 404s, fall back
-to the `main`-branch installer:
+Prefer `go install github.com/rshade/gh-aw-fleet@latest`, a manual release
+download, or a source build? Need to pin a version, change the install
+directory, or fix a `PATH` that doesn't include the binary? The
+**[Install guide](https://rshade.github.io/gh-aw-fleet/install/)** covers
+every option and the `main`-branch installer fallback.
+
+### First commands
 
 ```bash
-# Fallback — fetches install.sh from main
-curl -sSfL \
-  https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.sh \
-  | bash
+gh-aw-fleet list                                 # tracked repos + resolved workflows
+gh-aw-fleet status                               # drift across the fleet (read-only)
+gh-aw-fleet add acme/widgets --profile default   # onboard a repo (dry-run)
+gh-aw-fleet deploy acme/widgets                  # preview a deploy (dry-run)
+gh-aw-fleet deploy acme/widgets --apply          # commit + push + open a PR
 ```
 
-```powershell
-# Fallback — fetches install.ps1 from main
-iwr -UseBasicParsing https://raw.githubusercontent.com/rshade/gh-aw-fleet/main/install.ps1 `
-  | iex
-```
+`add` writes to **`fleet.local.json`** (private, gitignored), not `fleet.json`.
+`deploy`, `sync`, and `upgrade` are dry-run by default; add `--apply` to commit,
+push, and open a PR on the target repo.
 
-Either way, the installer still installs a tagged release binary by
-default: the latest release unless you pin one.
-
-Customizing the install:
-
-- POSIX env vars — `VERSION=v0.2.0` pins a specific release (default:
-  latest); `INSTALL_DIR=/usr/local/bin` overrides the default location.
-- PowerShell parameters — `-Version v0.2.0` pins a release;
-  `-InstallDir <path>` overrides the install directory; `-NoPath` skips the
-  user-scope PATH update.
-
-PowerShell parameters require invoking the downloaded script as a
-`ScriptBlock`:
-
-```powershell
-$installer = [ScriptBlock]::Create(
-  (iwr -UseBasicParsing https://github.com/rshade/gh-aw-fleet/releases/latest/download/install.ps1).Content
-)
-& $installer -Version v0.2.0 -InstallDir "$env:LOCALAPPDATA\gh-aw-fleet\bin" -NoPath
-```
-
-**Option 2 — Manual release download.** Pre-built binaries are published
-for Linux, macOS, and Windows on amd64 and arm64:
-
-```bash
-# Example: Linux amd64
-gh release download --repo rshade/gh-aw-fleet --pattern '*linux_amd64.tar.gz'
-tar -xzf gh-aw-fleet_*_linux_amd64.tar.gz
-sudo mv gh-aw-fleet /usr/local/bin/
-```
-
-See the
-[latest release](https://github.com/rshade/gh-aw-fleet/releases/latest)
-for all available platform archives and checksums.
-
-**Option 3 — `go install`.** Installs into `$(go env GOPATH)/bin`:
-
-```bash
-go install github.com/rshade/gh-aw-fleet@latest
-```
-
-**Option 4 — Build from source.** For contributors and anyone working off
-`main`:
-
-```bash
-git clone https://github.com/rshade/gh-aw-fleet.git
-cd gh-aw-fleet
-go build -o gh-aw-fleet .
-```
-
-> **Note on examples below:** all command examples use bare `gh-aw-fleet`
-> and assume the binary is on your `PATH`. Option 1 installs to
-> `$HOME/.local/bin` by default — make sure that's on your PATH. Option 3
-> installs to `$(go env GOPATH)/bin`, which is not automatically on PATH —
-> add it yourself if `which gh-aw-fleet` comes back empty. Option 2 lets
-> you pick the destination. If you built from source via Option 4 and
-> didn't install the binary, prefix every `gh-aw-fleet` command with `./`
-> to run it from the build directory.
-
-### Example Workflow
-
-List tracked repos and their resolved workflow sets:
-
-```bash
-gh-aw-fleet list
-```
-
-Fetch the upstream catalog (templates.json) so you can review new
-workflows:
-
-```bash
-gh-aw-fleet template fetch
-```
-
-Onboard a new repo into `fleet.local.json` with a profile (`acme/widgets`
-is a placeholder — substitute your `<owner>/<repo>`). Dry-run first, then
-`--apply`:
-
-```bash
-# dry-run; prints planned change
-gh-aw-fleet add acme/widgets --profile default
-# interactive: prompts for confirmation
-gh-aw-fleet add acme/widgets --profile default --apply
-# non-interactive (CI / scripts): skips prompt
-gh-aw-fleet add acme/widgets --profile default --apply --yes
-```
-
-The repo entry is written to **`fleet.local.json`** (the private,
-gitignored config), not `fleet.json` (the committed example). See
-[Two config files](#two-config-files) below.
-
-Dry-run a deploy to one repo (shows what would be added, no changes
-made):
-
-```bash
-gh-aw-fleet deploy acme/widgets
-```
-
-Apply the deploy (commits, pushes, opens a PR in the target repo):
-
-```bash
-gh-aw-fleet deploy acme/widgets --apply
-```
-
-Fail a deploy dry-run or apply when the Layer 1 scanner reports HIGH findings:
-
-```bash
-gh-aw-fleet deploy acme/widgets --strict
-gh-aw-fleet deploy acme/widgets --strict --apply
-```
-
-Reconcile a repo (add missing workflows, flag unexpected ones):
-
-```bash
-gh-aw-fleet sync HavenTrack/goa-service-shared --apply
-```
-
-Upgrade all repos to the latest gh-aw and agentics versions:
-
-```bash
-gh-aw-fleet upgrade --all --apply
-```
-
-Check drift across the fleet without cloning anything (exits 0 only when
-every repo is aligned — chain it before a deploy in CI):
-
-```bash
-gh-aw-fleet status
-gh-aw-fleet status -o json \
-  | jq '.result.repos | map(select(.drift_state == "drifted")) | length'
-```
-
-Show a joined fleet dashboard for drift, recent run health, no-op run rate,
-and AI-credit spend. The default window is trailing 7 days; run failures are
-advisory, and the exit code is still drift-only:
-
-```bash
-gh-aw-fleet overview
-gh-aw-fleet overview rshade/finfocus --trailing 7d
-gh-aw-fleet overview --output json
-```
-
-`overview` renders `REPO DRIFT RUNS FAIL NOOP HEALTH AIC COST`, followed by a
-pooled `TOTAL` row and detail blocks for drifted, errored, or unhealthy repos.
-`NOOP` counts successful runs that took no action but still consumed credits.
-The command reuses the same `gh aw logs --json` fan-out as `consumption`, so it
-can take minutes on larger fleets.
+New here? The
+**[Getting Started tutorial](https://rshade.github.io/gh-aw-fleet/getting-started/)**
+walks an empty fleet through to a reviewed pull request, and the
+**[CLI reference](https://rshade.github.io/gh-aw-fleet/cli/)** lists every command,
+flag, and exit code.
 
 ## Commands
 
@@ -375,35 +234,20 @@ can take minutes on larger fleets.
 | `deploy <repo>` | Deploy the declared workflow set via `gh aw add` + PR; `--strict` blocks HIGH Layer 1 security findings |
 | `sync <repo>` | Reconcile to declared profile (add missing, flag drift); `--strict` blocks HIGH Layer 1 security findings |
 | `upgrade [repo\|--all]` | Bump profile pins + run `gh aw upgrade`; `--strict` blocks HIGH Layer 1 security findings |
-| `consumption` | Fleet-wide AI-credit (AIC) rollup from `gh aw logs --json` (`--source logs`, default); group `--by repo\|profile\|cost-center\|workflow`, window `--latest\|--trailing Nd\|--since YYYY-MM-DD` |
+| `consumption` | Fleet-wide AI-credit (AIC) rollup from `gh aw logs --json` (`--source logs`, default); group `--by repo\|profile\|cost-center\|workflow`, window `--latest\|--trailing Nd\|--since YYYY-MM-DD`, flag over-budget rows with `--budget <AIC>` |
 | `overview [repo...]` | Joined drift, run-health, no-op, AIC, and cost dashboard; defaults to `--trailing 7d`; exits non-zero only on drift/errored repos |
 | `template fetch` | Refresh `templates.json` from gh-aw and agentics |
 | `status [repo]` | Diff desired vs actual workflow refs (read-only, no clones) |
 
+See the [CLI reference](https://rshade.github.io/gh-aw-fleet/cli/) for every
+flag, argument, and exit code.
+
 ## Configuration
 
-### Global flags
-
-All commands accept these persistent flags:
-
-- **`--dir <path>`** (default: `.`) — Directory containing `fleet.json` /
-  `fleet.local.json`.
-- **`--log-level <level>`** (default: `info`) — Log verbosity: `trace`,
-  `debug`, `info`, `warn`, `error`. Use `debug` to see every subprocess
-  invocation, timing, and exit code.
-- **`--log-format <format>`** (default: `console`) — Log format: `console`
-  (human-readable on stderr) or `json` (structured logs for `jq` /
-  aggregators).
-- **`-o`, `--output <format>`** (default: `text`) — Output format: `text`
-  (tabular human view) or `json` (machine-readable envelopes for
-  scripting). Supported on `list`, `deploy`, `sync`, `upgrade`, `status`,
-  `consumption`, and `overview` (`upgrade --all` emits NDJSON). Rejected with
-  a clear error on `template fetch` and `add`.
-
-For multi-repo failure debugging,
-[`skills/fleet-deploy/SKILL.md`](skills/fleet-deploy/SKILL.md) recommends
-`--log-level=debug --log-format=json 2>/tmp/log.json` and traversing
-subprocess events with `jq`.
+`gh-aw-fleet` is configured through two files (below) plus a set of global
+flags (`--dir`, `--log-level`, `--log-format`, `-o`/`--output`) and
+per-command flags catalogued in the
+[CLI reference](https://rshade.github.io/gh-aw-fleet/cli/).
 
 ### Two config files
 
@@ -438,244 +282,19 @@ To start from scratch, copy `fleet.example.json` to `fleet.local.json`
 (or to `fleet.json` if you want it committed) and edit, or use
 `gh-aw-fleet add` to generate entries.
 
-### fleet.json schema
+### Full schema and flags
 
-The declarative desired state. Top-level keys:
+The complete configuration and CLI surface lives on the docs site:
 
-- **`version`**: Schema version (currently `1`).
-- **`defaults`**: Fleet-wide defaults. Currently: `engine` (e.g.,
-  `"copilot"` for all repos unless overridden).
-- **`profiles`**: Named bundles of workflows. See
-  [Bundled Profiles](#bundled-profiles) below.
-- **`repos`**: Per-repo desired state (profiles, excludes, extras,
-  overrides).
-
-Example fragment:
-
-```json
-{
-  "version": 1,
-  "defaults": {
-    "engine": "copilot"
-  },
-  "profiles": {
-    "default": {
-      "description": "Baseline every tracked repo gets.",
-      "sources": {
-        "github/gh-aw": { "ref": "v0.79.2" },
-        "githubnext/agentics": {
-          "ref": "96b9d4c39aa22359c0b38265927eadb31dcf4e2a"
-        }
-      },
-      "workflows": [
-        { "name": "audit-workflows", "source": "github/gh-aw" },
-        { "name": "ci-doctor", "source": "githubnext/agentics" }
-      ]
-    }
-  },
-  "repos": {
-    "acme/widgets": {
-      "profiles": ["default"],
-      "extra": [
-        {
-          "name": "shadow-engineer",
-          "source": "local",
-          "path": ".github/workflows/shadow-engineer.md"
-        }
-      ]
-    }
-  }
-}
-```
-
-### Annotations (HuJson)
-
-`fleet.json`, `fleet.local.json`, `templates.json`, and
-`profiles/default.json` all accept [HuJson](https://github.com/tailscale/hujson)
-syntax — a JSON superset that allows `//` line comments, `/* */` block
-comments, and trailing commas. Operators can document *why* a pin is set,
-why a workflow is excluded, or why a repo opts into a `*-plus` profile
-right next to the data.
-
-The loader checks for `<base>.hujson` first and falls back to `<base>.json`
-if the HuJson variant is absent; having both files present for the same
-base name is rejected as ambiguous so the unread file can't silently drift.
-Writes preserve operator-authored comments — `gh-aw-fleet add` and
-`fleet template fetch` only touch the keys they need to change.
-
-Example:
-
-```hujson
-{
-  "version": 1,
-  "profiles": {
-    "default": {
-      // Pinned to the v0.79.2 tag — never `main`, which ships unreleased
-      // features like `mount-as-clis` that break the installed CLI.
-      "sources": {
-        "github/gh-aw": { "ref": "v0.79.2" },
-      },
-      "workflows": [
-        { "name": "audit-workflows", "source": "github/gh-aw" },
-      ],
-    },
-  },
-  "repos": {
-    "acme/widgets": {
-      "profiles": ["default", "security-plus"], // legal asked for SAST
-    },
-  },
-}
-```
-
-### RepoSpec
-
-Per-repo configuration. Keys:
-
-- **`profiles`** (required): List of profile names to apply.
-- **`engine`** (optional): AI engine override (e.g., `"gpt-4"`). Defaults
-  to `defaults.engine`.
-- **`compile_strict`** (optional): Tri-state toggle for
-  `gh aw compile --strict` on this repo's deploy and upgrade pipelines.
-  Omit to auto-detect from repo visibility (see "Compile-strict resolution"
-  below). Set to `true` to force strict ON regardless of visibility; set to
-  `false` to force strict OFF (e.g., a legacy public repo that has
-  workflows that can't yet pass strict validation).
-- **`extra`** (optional): Additional workflows not from any profile.
-  Source can be `"local"` (lives in the target repo) or an upstream repo
-  name.
-- **`exclude`** (optional): List of workflow names to skip (useful when a
-  profile mostly fits but one or two workflows don't).
-- **`overrides`** (optional): Map of workflow name → custom path (if the
-  upstream path doesn't match convention).
-
-#### Compile-strict resolution
-
-`gh-aw-fleet deploy` and `gh-aw-fleet upgrade` invoke `gh aw compile --strict`
-on the work-dir clone after `gh aw add` / `gh aw upgrade` succeeds and
-before `git add .github/`. The decision is driven by `RepoSpec.compile_strict`
-with this resolution order (FR-003):
-
-1. **Explicit override** — when `compile_strict` is present in `fleet.json` /
-   `fleet.local.json`, its value wins. The visibility lookup is skipped
-   entirely.
-2. **Auto-detect from visibility** — when `compile_strict` is absent, the
-   tool calls `gh api /repos/<owner>/<repo>` once per invocation and reads
-   the `visibility` field. `"public"` → strict ON; `"private"` or
-   `"internal"` or any other value → strict OFF.
-3. **Fail-secure on lookup failure** — when the visibility lookup errors
-   (HTTP 403/404/5xx, network failure, malformed JSON), the resolver
-   defaults to strict ON and emits one `warn`-level structured log line
-   naming the repo and a truncated reason. Setting `compile_strict`
-   explicitly bypasses this path.
-
-The `--output json` envelope on both Deploy and Upgrade gains three fields:
-
-- `compile_strict_applied` (`bool`) — `true` ONLY when the strict compile
-  ran and exited 0 in this invocation. Always `false` in dry-run mode.
-- `compile_strict_effective` (`bool`) — the resolver's verdict for this
-  repo, independent of whether compile actually ran. In dry-run mode this
-  is the "would apply on `--apply`" signal; in `--apply` mode it equals
-  `compile_strict_applied` unless the probe or compile aborted.
-- `compile_strict_source` (`string`) — one of `"explicit"`, `"auto-public"`,
-  `"auto-private"`, `"auto-fallback"`, or `""` (resolver didn't run —
-  early error path).
-
-**Minimum `gh aw` version**: `v0.79.2` (the FinOps baseline floor; `compile
---strict` itself has shipped since `v0.68.3`). The tool probes `gh aw compile
---help` before invoking compile and aborts with an actionable diagnostic when
-`--strict` is absent. Install with `gh extension install github/gh-aw --pin
-v0.79.2` — v0.79.x are pre-releases, so a bare `gh extension upgrade aw` stops
-at the latest stable.
-
-Example `fleet.local.json` snippet:
-
-```jsonc
-{
-  "repos": {
-    "rshade/regular-public-repo": {
-      "profiles": ["default"]
-      // omitted → auto-detect (public → strict ON)
-    },
-    "rshade/gh-aw-fleet": {
-      "profiles": ["default"],
-      "compile_strict": true        // explicit force-on (skips visibility lookup)
-    },
-    "rshade/legacy-public": {
-      "profiles": ["default"],
-      "compile_strict": false       // opt out for a workflow that can't yet be strict
-    }
-  }
-}
-```
-
-See [`specs/010-compile-strict-public/quickstart.md`](specs/010-compile-strict-public/quickstart.md)
-for the operator troubleshooting walkthrough.
-
-#### Security strict gate
-
-`deploy`, `sync`, and `upgrade` also accept `--strict`. This is a separate
-security gate, not the `compile_strict` config field above and not `gh aw
-compile --strict`. The flag is per invocation only and is never written to
-`fleet.json` or `fleet.local.json`.
-
-Without `--strict`, security findings remain advisory: they are emitted on
-stderr, included in JSON `warnings[]`, and added to PR bodies when a PR is
-created. With `--strict`, any HIGH Layer 1 finding blocks before commit, push, or
-PR creation. MEDIUM, LOW, INFO, and `promptinj:` findings remain advisory.
-
-Strict aborts write a clone-root `findings.json` containing every finding from
-that run and preserve the work-dir clone for inspection. The same gate applies
-to dry-runs, so CI can use commands such as:
-
-```bash
-gh-aw-fleet deploy acme/widgets --strict
-gh-aw-fleet sync acme/widgets --strict
-gh-aw-fleet upgrade --all --strict --output json
-```
-
-For `upgrade --all --strict --output json`, NDJSON records are emitted through
-the blocked repo and then processing stops at that first strict failure.
-
-#### Interactive findings confirmation and `--yes`
-
-Independent of `--strict`, an `--apply` that produces one or more security
-findings (of **any** severity) pauses for a last-chance confirmation before it
-commits, pushes, or opens a PR — but only when stdout is an interactive
-terminal:
-
-```text
-⚠  2 HIGH, 1 MEDIUM. Proceed with commit? [y/N]
-```
-
-The safe default is **No**: a bare Enter, `n`, or any non-`y` answer aborts
-cleanly, exits non-zero, and preserves the work-dir clone so you can inspect it
-and resume with `--work-dir <clone> --yes`. Answering `y` proceeds, and the PR
-body still carries the `## Security Findings` section.
-
-The prompt is the **third** independent surface for findings, alongside the
-stderr warnings and the PR-body section. It differs from `--strict`: `--strict`
-is a non-interactive hard block on HIGH findings; the prompt is an interactive
-last-chance gate on any finding.
-
-Three things skip the prompt without hiding the findings:
-
-- `--yes` on `deploy`, `sync`, or `upgrade` — proceed without the question;
-  stderr findings and the PR-body section are still produced.
-- A non-interactive stdout (piped, redirected, or CI) — the apply proceeds
-  automatically so nothing ever hangs. Use `--strict` when you want a
-  non-interactive *block* instead.
-- `--output json` — treated as non-interactive even at a TTY, so the JSON
-  envelope is never corrupted by a prompt.
-
-```bash
-gh-aw-fleet deploy acme/widgets --apply --yes        # skip the prompt
-gh-aw-fleet deploy acme/widgets --apply | tee out.txt # piped: no prompt, no hang
-```
-
-The prompt only fires on `--apply` (dry-runs never prompt) and only after the
-`--strict` gate, so a HIGH strict block still wins. `--yes` is per invocation
-and is never written to `fleet.json` or `fleet.local.json`.
+- **[Configuration](https://rshade.github.io/gh-aw-fleet/configuration/)** — the
+  full `fleet.json` schema (`version`, `defaults`, `profiles`, `sources`,
+  `workflows`), every `RepoSpec` field (`compile_strict`, `tier`, `cost_center`,
+  `extra`, `exclude`, `overrides`), the compile-strict resolution order, and
+  HuJson (`//` comments, trailing commas) support.
+- **[CLI reference](https://rshade.github.io/gh-aw-fleet/cli/)** — global flags,
+  every command's flags, and exit codes.
+- **[Reconcile workflow](https://rshade.github.io/gh-aw-fleet/reconcile/)** — the
+  `--strict` security gate, interactive findings confirmation, and `--yes`.
 
 ## Bundled Profiles
 
@@ -774,33 +393,12 @@ output for known error patterns and surfaces remediation hints. Examples:
 
 ### gpg signing failed during `--apply`
 
-This is the most common `--apply` failure mode. The tool runs
-`git commit` non-interactively, so a signing-required git config that
-needs a passphrase prompt has nowhere to surface it. **The tool never
-bypasses signing** (no `--no-gpg-sign`, no `commit.gpgsign=false`) — it
-preserves the in-progress clone so you can finish the commit in your own
-shell where gpg-agent can prompt you.
-
-When `--apply` fails on gpg signing:
-
-1. The clone directory is preserved at
-   `/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>/` with all files staged
-   on the deploy branch.
-2. `cd` into that directory and finish manually:
-
-   ```bash
-   cd /tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>
-   git commit -m 'ci(workflows): add <N> agentic workflows via gh-aw-fleet'
-   # branch is fleet/deploy-<timestamp>
-   git push -u origin <branch-name>
-   gh pr create \
-     --title "ci(workflows): add <N> agentic workflows via gh-aw-fleet" \
-     --body "..."
-   ```
-
-3. The full template (with body, conventional-commits validation rules,
-   and edge-case handling for `gh aw init` and skipped workflows) is in
-   [`skills/fleet-deploy/SKILL.md`](skills/fleet-deploy/SKILL.md).
+The most common `--apply` failure: the tool runs `git commit`
+non-interactively, so a signing-required config with a passphrase prompt
+has nowhere to surface it. The tool never bypasses signing — it preserves
+the clone so you can finish the commit in your own shell. See
+**[Recover from a gpg signing failure](https://rshade.github.io/gh-aw-fleet/recover-from-gpg-failure/)**
+for the manual-finish recipe.
 
 ### `Unknown property: mount-as-clis` and similar pre-flight failures
 
@@ -844,17 +442,10 @@ a file its own strict check rejects.
 
 ### Resuming after a partial failure
 
-The `--work-dir <path>` flag points `deploy` / `upgrade` / `sync` at an
-existing clone instead of cloning fresh. Use it with the
-`/tmp/gh-aw-fleet-*` directory preserved from a failed run to re-attempt
-without re-cloning.
-
-When `deploy --apply --work-dir <path>` is run against a preserved clone
-that has staged workflow changes, the tool resumes at the commit gate
-(skipping clone, `gh aw init`, and `gh aw add`). If the user manually
-committed after a GPG failure, the tool detects the unpushed commits and
-resumes at the push gate, proceeding directly to `git push` and
-`gh pr create`.
+The `--work-dir <path>` flag re-runs `deploy` / `sync` / `upgrade` against
+a preserved `/tmp/gh-aw-fleet-*` clone instead of cloning fresh, resuming
+at the commit or push gate. See
+**[Resume an interrupted apply](https://rshade.github.io/gh-aw-fleet/resume-interrupted-apply/)**.
 
 ## Known Limitations & Roadmap
 
@@ -868,6 +459,18 @@ resumes at the push gate, proceeding directly to `git push` and
 
 ## Further reading
 
+- **Docs site** — <https://rshade.github.io/gh-aw-fleet/>:
+  [Getting Started](https://rshade.github.io/gh-aw-fleet/getting-started/)
+  (tutorial); the how-to guides
+  ([gate CI on drift](https://rshade.github.io/gh-aw-fleet/gate-ci-on-drift/),
+  [recover from gpg](https://rshade.github.io/gh-aw-fleet/recover-from-gpg-failure/),
+  [resume an apply](https://rshade.github.io/gh-aw-fleet/resume-interrupted-apply/),
+  [find credit burners](https://rshade.github.io/gh-aw-fleet/find-top-credit-burners/));
+  the [CLI reference](https://rshade.github.io/gh-aw-fleet/cli/) and
+  [Configuration](https://rshade.github.io/gh-aw-fleet/configuration/); and the
+  [Reconcile](https://rshade.github.io/gh-aw-fleet/reconcile/) and
+  [Consumption and FinOps](https://rshade.github.io/gh-aw-fleet/consumption/)
+  explanations.
 - **[CONTEXT.md](CONTEXT.md)** — the project constitution. Architectural
   identity, hard scope boundaries, and what this tool deliberately does
   *not* do. Read before proposing features.
@@ -890,11 +493,6 @@ resumes at the push gate, proceeding directly to `git push` and
     materialize a chosen workflow set as a `fleet.json` profile.
 - **[CLAUDE.md](CLAUDE.md)** — invariants for AI coding agents working
   in this repo. Useful for human contributors too as a quick reference.
-- **[docs/finops.md](docs/finops.md)** — cost tracking for agentic
-  workflows. Frames the two-layer model: deployed aggregate rollup (Layer 1,
-  via `api-consumption-report` and `gh-aw-fleet consumption`) and optional
-  per-run attribution (Layer 2, via agentics `cost-tracker`). Explains the
-  trade-offs and why the fleet stops where it does.
 
 ## Contributing & Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,15 @@ The accent ramp must target both selectors:
 Using only `:root` themes dark mode but lets light mode fall back to Starlight's
 default accent because `:root[data-theme="light"]` has higher specificity.
 
+## Content link convention
+
+Internal links between docs pages must be **base-prefixed root-relative** —
+`/gh-aw-fleet/<slug>/`, matching the `base` in `astro.config.mjs` — not relative
+(`./<slug>/`). `starlight-links-validator` runs with `errorOnRelativeLinks`
+enabled, so a relative link fails `npm run build` (and the docs CI job) with a
+`RelativeLink` error. When copying this wiring to another project, swap the
+`/gh-aw-fleet/` prefix for that project's `base`.
+
 ## Pipeline separation
 
 `.github/workflows/docs.yml` is separate from the Go release pipeline. It runs

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -19,16 +19,43 @@ export default defineConfig({
 					href: 'https://github.com/rshade/gh-aw-fleet',
 				},
 			],
-			plugins: [starlightLinksValidator()],
+			plugins: [
+				// Reject relative links (./foo/): under a base path they resolve
+				// incorrectly, and this validator errors on them by default.
+				// Internal links must be base-prefixed root-relative, e.g.
+				// /gh-aw-fleet/foo/ (see docs/README.md → Content link convention).
+				starlightLinksValidator({ errorOnRelativeLinks: true }),
+			],
 			sidebar: [
 				{
-					label: 'Guide',
+					label: 'Tutorials',
+					items: [
+						{ label: 'Getting Started', slug: 'getting-started' },
+					],
+				},
+				{
+					label: 'How-to guides',
 					items: [
 						{ label: 'Install', slug: 'install' },
+						{ label: 'Recover from a gpg signing failure', slug: 'recover-from-gpg-failure' },
+						{ label: 'Gate CI on fleet drift', slug: 'gate-ci-on-drift' },
+						{ label: 'Resume an interrupted apply', slug: 'resume-interrupted-apply' },
+						{ label: 'Find your top credit burners', slug: 'find-top-credit-burners' },
+					],
+				},
+				{
+					label: 'Reference',
+					items: [
+						{ label: 'CLI reference', slug: 'cli' },
 						{ label: 'Configuration', slug: 'configuration' },
-						{ label: 'Reconcile Workflow', slug: 'reconcile' },
-						{ label: 'Consumption and FinOps', slug: 'consumption' },
 						{ label: 'Fleet Overview', slug: 'overview' },
+					],
+				},
+				{
+					label: 'Explanation',
+					items: [
+						{ label: 'Reconcile workflow', slug: 'reconcile' },
+						{ label: 'Consumption and FinOps', slug: 'consumption' },
 						{ label: 'Roadmap', slug: 'roadmap' },
 					],
 				},

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,9 +21,10 @@ export default defineConfig({
 			],
 			plugins: [
 				// Reject relative links (./foo/): under a base path they resolve
-				// incorrectly, and this validator errors on them by default.
-				// Internal links must be base-prefixed root-relative, e.g.
-				// /gh-aw-fleet/foo/ (see docs/README.md → Content link convention).
+				// incorrectly. Pinned explicitly (matches the validator's own
+				// default) so a future default change can't silently disable
+				// this check. Internal links must be base-prefixed root-relative,
+				// e.g. /gh-aw-fleet/foo/ (see docs/README.md → Content link convention).
 				starlightLinksValidator({ errorOnRelativeLinks: true }),
 			],
 			sidebar: [

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -1,0 +1,173 @@
+---
+title: CLI reference
+description: Every gh-aw-fleet command, flag, and exit code.
+---
+
+Complete reference for the `gh-aw-fleet` command line. For task-oriented recipes
+see the How-to guides; for the config-file schema see
+[Configuration](/gh-aw-fleet/configuration/).
+
+## Global flags
+
+These persistent flags are accepted by every command:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--dir <path>` | `.` | Directory containing `fleet.json` / `fleet.local.json`. |
+| `--log-level <level>` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. `debug` logs every subprocess call, timing, and exit code. |
+| `--log-format <format>` | `console` | Log format: `console` (human, on stderr) or `json` (structured). |
+| `-o`, `--output <format>` | `text` | Output format: `text` or `json`. Not supported on `add` or `template fetch`. |
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. For `status` and `overview`, every in-scope repo is aligned. |
+| `1` | A runtime error; **or** `status`/`overview` detected a drifted or errored repo; **or** a `--strict` HIGH-finding block; **or** a declined interactive findings confirmation. |
+
+## Commands
+
+### `list`
+
+```bash
+gh-aw-fleet list
+```
+
+Lists tracked repos and their resolved workflow sets, including parallel `TIERS`
+and `COST_CENTER` columns. Reads `fleet.json` overlaid with `fleet.local.json`
+and prints the loaded mode on stderr. Takes no arguments. Supports `-o json`.
+
+### `add <owner/repo>`
+
+```bash
+gh-aw-fleet add <owner/repo> --profile <name> [--apply]
+```
+
+Registers one repository in `fleet.local.json`. Requires exactly one
+`owner/repo`. Dry-run by default. Does **not** support `-o json`.
+
+| Flag | Description |
+| --- | --- |
+| `--profile <name>` | **Required.** Profile name(s) to assign; repeatable or comma-separated. |
+| `--engine <name>` | Engine override (e.g. `claude`, `copilot`), validated against known engine secrets. |
+| `--exclude <name>` | Workflow name to exclude from the selected profiles (repeatable). |
+| `--extra-workflow <spec>` | Extra workflow outside profiles (repeatable). Accepts `name`, `owner/repo/name@ref`, or `owner/repo/.github/workflows/name.md@ref`. |
+| `--apply` | Actually write `fleet.local.json` (default is dry-run). |
+| `--yes` | Confirm `--apply` without the interactive prompt (required in a non-TTY). |
+
+### `deploy <repo>`
+
+```bash
+gh-aw-fleet deploy <repo> [--apply]
+```
+
+Installs the declared workflow set into a repo via `gh aw add`, then commits,
+pushes, and opens a PR. Requires exactly one repo. Dry-run by default. Supports
+`-o json`.
+
+| Flag | Description |
+| --- | --- |
+| `--apply` | Actually commit, push, and open a PR (default is dry-run). |
+| `--force` | Overwrite existing workflow files (passes `--force` to `gh aw add`). |
+| `--branch <name>` | Branch name for the deploy PR (default `fleet/deploy-<timestamp>`). |
+| `--pr-title <text>` | PR title (default auto-generated). |
+| `--work-dir <path>` | Deploy into an existing clone; skips clone and auto-cleanup and resumes at the commit/push gate. |
+| `--strict` | Fail when HIGH Layer 1 security findings are present. Does not change `gh aw compile --strict`. |
+| `--yes` | Skip the interactive security-findings confirmation prompt (findings still print). |
+
+### `sync <repo>`
+
+```bash
+gh-aw-fleet sync <repo> [--apply]
+```
+
+Reconciles a repo to its declared profile: adds missing workflows and flags
+drift. Requires exactly one repo. Dry-run by default. Supports `-o json`.
+
+| Flag | Description |
+| --- | --- |
+| `--apply` | Add missing workflows and optionally prune drift (default is dry-run). |
+| `--prune` | Delete drift workflow files (requires `--apply`). |
+| `--force` | Overwrite existing workflow files (passes `--force` to `gh aw add`). |
+| `--work-dir <path>` | Sync in an existing clone; skips clone and auto-cleanup. |
+| `--strict` | Fail when HIGH Layer 1 security findings are present. |
+| `--yes` | Skip the interactive security-findings confirmation prompt. |
+
+### `upgrade [repo | --all]`
+
+```bash
+gh-aw-fleet upgrade <repo> [--apply]
+gh-aw-fleet upgrade --all [--apply]
+```
+
+Bumps profile pins and runs `gh aw upgrade` / `gh aw update`. Target one repo or
+pass `--all`. Dry-run by default. Supports `-o json`; `--all` emits NDJSON (one
+record per repo).
+
+| Flag | Description |
+| --- | --- |
+| `--apply` | Actually commit, push, and open a PR (default is dry-run). |
+| `--all` | Upgrade every repo in the fleet. |
+| `--audit` | Only run `gh aw upgrade --audit`; skip the upgrade. |
+| `--major` | Allow major-version bumps for tag pins (passes `--major` to `gh aw update`). |
+| `--force` | Update even when no changes are detected (passes `--force` to `gh aw update`). |
+| `--work-dir <path>` | Upgrade in an existing clone; skips clone and auto-cleanup. |
+| `--strict` | Fail when HIGH Layer 1 security findings are present. |
+| `--yes` | Skip the interactive security-findings confirmation prompt. |
+
+### `consumption [repo...]`
+
+```bash
+gh-aw-fleet consumption [repo...] [--by <axis>] [window]
+```
+
+Read-only fleet-wide AI-credit (AIC) rollup from `gh aw logs`. Pass zero or more
+repos to scope it. Supports `-o json`.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--by <axis>` | `repo` | Group-by axis: `repo`, `profile`, `cost-center`, or `workflow`. |
+| `--source <src>` | `logs` | Data source: `logs` (needs no deployed report) or `artifacts` (legacy). |
+| `--latest` | on | Most-recent valid report per repo. |
+| `--trailing <Nd>` | — | All reports in the trailing N-day window (e.g. `7d`). |
+| `--since <YYYY-MM-DD>` | — | All reports on or after the date. |
+| `--budget <AIC>` | — | Flag rows whose AIC strictly exceeds this ceiling (adds an `OVER` column). |
+
+`--latest`, `--trailing`, and `--since` are mutually exclusive.
+
+### `overview [repo...]`
+
+```bash
+gh-aw-fleet overview [repo...] [window]
+```
+
+Read-only dashboard joining drift, run health, no-op rate, and AIC/cost. Pass
+zero or more repos to scope it. Exits `1` on any drifted or errored repo; run
+failures stay advisory. Supports `-o json`.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--trailing <Nd>` | `7d` | All runs in the trailing N-day window. |
+| `--since <YYYY-MM-DD>` | — | All runs on or after the date. |
+| `--latest` | — | Most-recent run per workflow (the `NOOP` column is best-effort in this mode). |
+
+`--latest`, `--trailing`, and `--since` are mutually exclusive.
+
+### `status [repo]`
+
+```bash
+gh-aw-fleet status [repo]
+```
+
+Diffs desired (`fleet.json`) versus actual workflow refs — read-only, no clones.
+Accepts at most one repo; omit it to check the whole fleet. Exits `1` if any
+queried repo has drifted. Supports `-o json`.
+
+### `template fetch`
+
+```bash
+gh-aw-fleet template fetch
+```
+
+Refreshes `templates.json` from `github/gh-aw` and `githubnext/agentics`. Takes
+no arguments. Does **not** support `-o json`.

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -135,11 +135,41 @@ Repo fields:
 - `compile_strict`: optional boolean override for `gh aw compile --strict`.
 - `extra`: optional workflows outside any profile.
 - `exclude`: optional workflow names to omit from the resolved profile set.
+- `overrides`: optional map of workflow name to a custom path, for when the
+  upstream path does not match the source's convention.
 - `cost_center`: optional free-form billing tag used by
   `gh-aw-fleet consumption --by cost-center`.
 
 `extra` can reference local workflows or upstream sources. Local extras point at
 workflow markdown already present in the target repository.
+
+## Compile-strict resolution
+
+`deploy` and `upgrade` run `gh aw compile --strict` on the clone after `gh aw
+add` / `gh aw upgrade`, before staging changes. The `compile_strict` field
+controls whether that strict compile runs, resolved in this order:
+
+1. **Explicit override** — a `compile_strict` value in `fleet.json` /
+   `fleet.local.json` wins; the visibility lookup is skipped.
+2. **Auto-detect from visibility** — when `compile_strict` is absent, the tool
+   reads the repo's `visibility` via `gh api /repos/<owner>/<repo>`. `public`
+   turns strict on; `private`, `internal`, or anything else turns it off.
+3. **Fail-secure** — if the visibility lookup fails (HTTP error, network failure,
+   malformed JSON), the resolver defaults to strict on and logs one `warn` line.
+
+The `--output json` envelope for `deploy` and `upgrade` reports the outcome in
+three fields:
+
+- `compile_strict_applied` (`bool`) — true only when the strict compile ran and
+  exited `0` this invocation; always false in dry-run.
+- `compile_strict_effective` (`bool`) — the resolver's verdict regardless of
+  whether compile ran (the "would apply on `--apply`" signal in dry-run).
+- `compile_strict_source` (`string`) — `explicit`, `auto-public`, `auto-private`,
+  `auto-fallback`, or `""`.
+
+This is separate from the per-invocation `--strict` security gate (see
+[Reconcile workflow](/gh-aw-fleet/reconcile/)): compile-strict validates the generated
+GitHub Actions YAML, while the security gate blocks on scanner findings.
 
 ## Overlay granularity
 

--- a/docs/src/content/docs/consumption.md
+++ b/docs/src/content/docs/consumption.md
@@ -69,6 +69,22 @@ a `cost_center` tag fold into the literal `<unset>` bucket.
 - `--trailing 7d`: all runs in the trailing 7-day window.
 - `--since 2026-06-01`: all runs on or after the given date.
 
+### Budget highlighting: `--budget`
+
+Pass `--budget <AIC>` to flag rows whose AI-credit total strictly exceeds the
+given ceiling. It is read-only: it surfaces cost concentration at a glance but
+never enforces or blocks anything.
+
+```bash
+# Flag any group (and top burner) over 500 AIC
+gh-aw-fleet consumption --by repo --budget 500
+```
+
+With a ceiling set, the table and the `TOP 10 BURNERS` footer gain a trailing
+`OVER` column that marks each over-ceiling row with `!`. In `--output json`, the
+same signal appears as an over-budget field on each group instead of a column.
+The ceiling must be a finite, non-negative number.
+
 ### Command examples
 
 ```bash
@@ -158,8 +174,6 @@ These open issues track the fleet's cost-visibility build-out:
   `--source logs`, bounded concurrency and no-download fast path.
 - [#119](https://github.com/rshade/gh-aw-fleet/issues/119):
   paginate Actions workflow discovery for the logs source.
-- [#129](https://github.com/rshade/gh-aw-fleet/issues/129):
-  read-only over-budget highlighting in the rollup (`--budget`).
 - [#59](https://github.com/rshade/gh-aw-fleet/issues/59):
   surface Copilot credit attribution once `aw_info.json` stabilizes upstream.
 - [#105](https://github.com/rshade/gh-aw-fleet/issues/105):

--- a/docs/src/content/docs/find-top-credit-burners.md
+++ b/docs/src/content/docs/find-top-credit-burners.md
@@ -1,0 +1,73 @@
+---
+title: Find your top credit burners
+description: Identify which repositories and workflows consume the most AI credits across the fleet.
+---
+
+`gh-aw-fleet consumption` rolls up AI-credit (AIC) usage across the fleet from
+`gh aw logs`. Change the `--by` axis and the window to answer different "where did
+the credits go?" questions. It is read-only and needs no deployed reporting
+workflow.
+
+## Rank repositories
+
+Start with the per-repo rollup (the default axis):
+
+```bash
+gh-aw-fleet consumption --by repo
+```
+
+Each row is a repository with its API calls, safe writes, AIC, and derived USD
+(`AIC × $0.01`). The highest AIC rows are your biggest spenders.
+
+## Rank individual workflows
+
+To find the single workflows burning the most, group by workflow. The output
+includes a `TOP 10 BURNERS` footer ranked by AIC:
+
+```bash
+gh-aw-fleet consumption --by workflow
+```
+
+## Drill into one repository
+
+Scope the rollup to one repo and break it down by workflow to see where that
+repo's spend concentrates:
+
+```bash
+gh-aw-fleet consumption you/your-repo --by workflow
+```
+
+## Narrow the time window
+
+`consumption` defaults to the most-recent data per repo (`--latest`). To measure
+a period instead, use a trailing window or a start date (the three are mutually
+exclusive):
+
+```bash
+gh-aw-fleet consumption --trailing 7d --by workflow    # last 7 days
+gh-aw-fleet consumption --since 2026-06-01 --by repo   # since a date
+```
+
+## Flag rows over a ceiling
+
+Add `--budget <AIC>` to mark rows whose AIC strictly exceeds a ceiling with a `!`
+in a trailing `OVER` column — useful for spotting concentration at a glance:
+
+```bash
+gh-aw-fleet consumption --by repo --budget 500
+```
+
+## Export for a cost system
+
+Emit the JSON envelope to feed the numbers into a spreadsheet or cost tool:
+
+```bash
+gh-aw-fleet consumption --by cost-center --output json
+```
+
+## See also
+
+- [Consumption and FinOps](/gh-aw-fleet/consumption/) — the two-layer cost model and why
+  AIC, not USD, is the true unit.
+- [Fleet Overview](/gh-aw-fleet/overview/) — drift, health, and cost joined into one
+  dashboard.

--- a/docs/src/content/docs/gate-ci-on-drift.md
+++ b/docs/src/content/docs/gate-ci-on-drift.md
@@ -1,0 +1,66 @@
+---
+title: Gate CI on fleet drift
+description: Fail a CI job when any repository has drifted from its declared fleet state.
+---
+
+`gh-aw-fleet status` and `gh-aw-fleet overview` exit non-zero when a repository
+has drifted from `fleet.json`. That makes either one a drop-in CI gate: run it as
+a step and let the exit code fail the job.
+
+## Use `status` for a fast, clone-free gate
+
+`status` diffs desired versus actual workflow refs over the API without cloning
+anything, so it is the cheapest gate:
+
+```bash
+gh-aw-fleet status
+```
+
+- Exit `0` — every tracked repo is aligned.
+- Exit `1` — at least one repo has drifted (or errored).
+
+Drop it straight into a workflow step; a non-zero exit fails the job:
+
+```yaml
+- name: Fail on fleet drift
+  run: gh-aw-fleet status
+```
+
+## Inspect drift in JSON
+
+To report *which* repos drifted rather than only failing, read the JSON envelope:
+
+```bash
+gh-aw-fleet status -o json \
+  | jq '.result.repos | map(select(.drift_state == "drifted")) | length'
+```
+
+Scope the check to a single repo by passing it as an argument (`status` accepts
+at most one; omit it to check the whole fleet):
+
+```bash
+gh-aw-fleet status you/your-repo
+```
+
+## Use `overview` when you also want health and cost
+
+`overview` shares the same drift-only exit contract but additionally reports run
+health, no-op rate, and AI-credit spend. Its window defaults to the trailing 7
+days:
+
+```bash
+gh-aw-fleet overview
+```
+
+- Exit `0` — every in-scope repo is aligned.
+- Exit `1` — any in-scope repo is drifted or errored.
+
+Run failures stay advisory: a fully aligned fleet with failing agentic runs still
+exits `0`, so `overview` gates on drift, not on flaky runs. It reuses the
+`gh aw logs` fan-out, so it is slower than `status` and can take minutes on large
+fleets — prefer `status` when you only need the drift gate.
+
+## See also
+
+- [CLI reference](/gh-aw-fleet/cli/) — full exit-code table for `status` and `overview`.
+- [Fleet Overview](/gh-aw-fleet/overview/) — column reference for the dashboard.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -1,0 +1,117 @@
+---
+title: Getting Started
+description: Take an empty fleet to a reviewed pull request by installing a workflow profile onto a repository you own.
+---
+
+This tutorial walks you from nothing to a real pull request that adds the
+`default` profile's agentic workflows to a repository you own. By the end you
+will have registered a repo in your fleet, previewed the change, opened a PR, and
+confirmed the repo is aligned.
+
+Everything `gh-aw-fleet` does to a repository happens through a pull request you
+review and merge yourself. Nothing is force-pushed and nothing is committed to
+`main` for you, so this tutorial is safe to follow on a repository you control.
+
+**You will need** the tools from the [Install](/gh-aw-fleet/install/) guide: the `gh` CLI
+authenticated with `repo` and `workflow` scopes, the `gh aw` extension pinned to
+`v0.79.2`, and the `gh-aw-fleet` binary on your `PATH`. Set aside about ten
+minutes.
+
+Throughout, replace `you/your-repo` with a repository you own.
+
+## Step 1 — Confirm your tools are ready
+
+Run these three checks:
+
+```bash
+gh auth status
+gh extension list          # gh-aw should appear, pinned to v0.79.2
+gh-aw-fleet list
+```
+
+`gh-aw-fleet list` prints the repos it already tracks and, on stderr, which
+config files it loaded — `(loaded fleet.json)` on a fresh checkout. If all three
+commands succeed, you are ready.
+
+## Step 2 — Register your first repo
+
+Add your repo to the fleet with the baseline `default` profile. Run it first
+without `--apply` to see what it would write:
+
+```bash
+gh-aw-fleet add you/your-repo --profile default
+```
+
+This is a dry-run: it prints the planned entry and changes nothing. When the plan
+looks right, write it for real:
+
+```bash
+gh-aw-fleet add you/your-repo --profile default --apply
+```
+
+The command asks you to confirm; answer `y`. It writes the entry to
+**`fleet.local.json`** — your private, gitignored fleet state — not to the
+committed `fleet.json`. Run `gh-aw-fleet list` again and your repo now appears in
+the table.
+
+## Step 3 — Preview the deploy
+
+Now see exactly what would be installed, still without touching the repo:
+
+```bash
+gh-aw-fleet deploy you/your-repo
+```
+
+`deploy` is dry-run by default. It resolves the `default` profile into a concrete
+set of workflows, pinned to the fleet's source refs, and prints the plan. Read
+it: these are the workflow files the pull request will add.
+
+## Step 4 — Open the pull request
+
+When the plan looks right, apply it:
+
+```bash
+gh-aw-fleet deploy you/your-repo --apply
+```
+
+This clones the repo to a scratch directory, runs `gh aw` to add and compile the
+workflows, commits them, pushes a branch, and opens a PR. When it finishes it
+prints the PR URL. Open it — you will see the added `.github/workflows/` files,
+ready for review.
+
+If the commit stops on a gpg signing prompt or error, that is expected on
+signing-required setups. Follow
+[Recover from a gpg signing failure](/gh-aw-fleet/recover-from-gpg-failure/) to finish the
+commit in your own shell, then come back here.
+
+## Step 5 — Confirm it worked
+
+Review and **merge** the pull request on GitHub. Once it is merged, ask the fleet
+whether the repo now matches its declared state:
+
+```bash
+gh-aw-fleet status you/your-repo
+```
+
+The repo reports `aligned` — the workflows on `main` match what the `default`
+profile declares. For a fuller picture of the repo's recent run health and
+credit spend, run:
+
+```bash
+gh-aw-fleet overview you/your-repo
+```
+
+## What you did, and where to go next
+
+You registered a repo, previewed a change, opened a reviewable PR, and confirmed
+the repo is aligned — the full `gh-aw-fleet` loop, end to end.
+
+From here:
+
+- **Solve a specific problem** — the [How-to guides](/gh-aw-fleet/gate-ci-on-drift/) cover
+  gating CI on drift, resuming an interrupted apply, and reviewing cost.
+- **Look up a command or flag** — the [CLI reference](/gh-aw-fleet/cli/) lists every
+  command, flag, and exit code.
+- **Understand the model** — [Reconcile workflow](/gh-aw-fleet/reconcile/) and
+  [Consumption and FinOps](/gh-aw-fleet/consumption/) explain how and why the tool behaves
+  as it does.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -108,8 +108,9 @@ the repo is aligned — the full `gh-aw-fleet` loop, end to end.
 
 From here:
 
-- **Solve a specific problem** — the [How-to guides](/gh-aw-fleet/gate-ci-on-drift/) cover
-  gating CI on drift, resuming an interrupted apply, and reviewing cost.
+- **Solve a specific problem** — [gate CI on fleet drift](/gh-aw-fleet/gate-ci-on-drift/),
+  [resume an interrupted apply](/gh-aw-fleet/resume-interrupted-apply/), or
+  [find your top credit burners](/gh-aw-fleet/find-top-credit-burners/).
 - **Look up a command or flag** — the [CLI reference](/gh-aw-fleet/cli/) lists every
   command, flag, and exit code.
 - **Understand the model** — [Reconcile workflow](/gh-aw-fleet/reconcile/) and

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -5,10 +5,14 @@ template: splash
 hero:
   tagline: Keep agentic workflows aligned across repositories with one declarative fleet file and PR-based reconciliation.
   actions:
+    - text: Get started
+      link: /gh-aw-fleet/getting-started/
+      icon: right-arrow
+      variant: primary
     - text: View on GitHub
       link: https://github.com/rshade/gh-aw-fleet
       icon: external
-      variant: primary
+      variant: secondary
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/overview.md
+++ b/docs/src/content/docs/overview.md
@@ -89,7 +89,7 @@ but the logs fan-out is still the slow path.
 
 ## See Also
 
-- [`gh-aw-fleet consumption`](./consumption/) for grouped AIC rollups by repo,
+- [`gh-aw-fleet consumption`](/gh-aw-fleet/consumption/) for grouped AIC rollups by repo,
   profile, cost center, or workflow.
 - [`AGENTS.md`](https://github.com/rshade/gh-aw-fleet/blob/main/AGENTS.md) for
   implementation notes on the shared `gh aw logs` fan-out.

--- a/docs/src/content/docs/reconcile.md
+++ b/docs/src/content/docs/reconcile.md
@@ -77,6 +77,11 @@ When the gate blocks:
 - the clone is preserved for inspection, including dry-run temp clones;
 - commit, push, and PR creation do not run.
 
+Compiled `*.lock.yml` files can themselves trip HIGH `actionlint` findings — most
+commonly the generated `concurrency: queue` key, which standard `actionlint`
+rejects — and block the gate on output you cannot edit. Suppress them per repo
+with a `.github/actionlint.yaml` ignore file.
+
 Lower-severity findings and `promptinj:` findings remain advisory. For
 `upgrade --all --strict --output json`, NDJSON records are emitted through the
 blocked repo and then processing stops.

--- a/docs/src/content/docs/recover-from-gpg-failure.md
+++ b/docs/src/content/docs/recover-from-gpg-failure.md
@@ -1,0 +1,55 @@
+---
+title: Recover from a gpg signing failure
+description: Finish a deploy, sync, or upgrade by hand after gpg signing blocks the automated commit.
+---
+
+`gh-aw-fleet` runs `git commit` non-interactively during `--apply`. If your git
+config requires gpg signing and the agent needs a passphrase, the commit has
+nowhere to prompt and fails. This is the most common `--apply` failure.
+
+The tool **never bypasses signing** — no `--no-gpg-sign`, no
+`commit.gpgsign=false`. Instead it preserves the in-progress clone so you can
+finish the commit in your own shell, where gpg-agent can prompt you.
+
+## Before you start
+
+You need the scratch clone the failed run left behind. It is preserved at:
+
+```text
+/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>/
+```
+
+with all workflow changes already staged on the deploy branch. Do not delete it.
+
+## Finish the commit by hand
+
+Change into the preserved clone and complete the commit, push, and PR yourself:
+
+```bash
+cd /tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>
+git commit -m 'ci(workflows): add <N> agentic workflows via gh-aw-fleet'
+git push -u origin <branch-name>       # branch is fleet/deploy-<timestamp>
+gh pr create \
+  --title "ci(workflows): add <N> agentic workflows via gh-aw-fleet" \
+  --body "Adds the declared workflow set via gh-aw-fleet."
+```
+
+Running `git commit` in your own shell lets gpg-agent prompt for your passphrase.
+Commit messages follow Conventional Commits with the `ci(workflows)` scope; keep
+the subject at or under 72 characters with no trailing period.
+
+## Or let the tool resume
+
+If you would rather the tool finish the push and PR, re-run the same command
+against the preserved clone. It detects the state and picks up where it stopped
+(see [Resume an interrupted apply](/gh-aw-fleet/resume-interrupted-apply/)):
+
+```bash
+gh-aw-fleet deploy <owner>/<repo> --apply --work-dir /tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>
+```
+
+## Full template
+
+The complete PR-body template, commit-message validation rules, and edge cases
+(`gh aw init` output, skipped workflows) live in the
+[`fleet-deploy` skill](https://github.com/rshade/gh-aw-fleet/blob/main/skills/fleet-deploy/SKILL.md).

--- a/docs/src/content/docs/resume-interrupted-apply.md
+++ b/docs/src/content/docs/resume-interrupted-apply.md
@@ -1,0 +1,58 @@
+---
+title: Resume an interrupted apply
+description: Re-run deploy, sync, or upgrade against a preserved clone after a mid-pipeline failure, without re-cloning.
+---
+
+When an `--apply` fails partway through — a gpg signing error, a network blip, a
+`gh aw` failure — `gh-aw-fleet` preserves the scratch clone instead of deleting
+it. You can point a re-run at that clone with `--work-dir` to continue from where
+it stopped rather than starting over.
+
+## Find the preserved clone
+
+Failed applies leave their clone at:
+
+```text
+/tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>/
+```
+
+These directories are breadcrumbs — do not delete them while you are still
+recovering.
+
+## Re-run against the clone
+
+Pass the clone to the same command with `--work-dir`. This skips `git clone`, the
+auto-cleanup, and (when the clone is already prepared) the earlier pipeline
+stages:
+
+```bash
+gh-aw-fleet deploy <owner>/<repo> --apply --work-dir /tmp/gh-aw-fleet-<owner>-<repo>-<timestamp>
+```
+
+The same flag works for `sync` and `upgrade`.
+
+## Where the resume picks up
+
+`deploy --apply --work-dir` inspects the clone and resumes at the right gate:
+
+- **Staged workflow changes, no commit yet** → resumes at the commit gate,
+  skipping clone, `gh aw init`, and `gh aw add`.
+- **You committed by hand (e.g. after a gpg failure) but did not push** → the
+  tool detects the unpushed commit and resumes at the push gate, going straight
+  to `git push` and `gh pr create`.
+
+## If the run produced security findings
+
+An `--apply` that surfaced findings pauses for an interactive confirmation. When
+resuming non-interactively, add `--yes` to proceed past that prompt (the findings
+still print on stderr and land in the PR body):
+
+```bash
+gh-aw-fleet deploy <owner>/<repo> --apply --work-dir <clone> --yes
+```
+
+## See also
+
+- [Recover from a gpg signing failure](/gh-aw-fleet/recover-from-gpg-failure/) — the most
+  common reason to resume.
+- [Reconcile workflow](/gh-aw-fleet/reconcile/) — how the apply pipeline is staged.

--- a/docs/src/content/docs/roadmap.md
+++ b/docs/src/content/docs/roadmap.md
@@ -19,13 +19,17 @@ the layer that knows every workflow pin across every managed repo.
 
 Single-fix hotfix releases are exempt.
 
-## Immediate focus
+## Recently shipped (v0.2.5)
 
-The current release focus pairs one cost item with one security item:
+The v0.2.5 release paired cost and security items:
 
 - Read-only over-budget highlighting in the consumption rollup (`--budget`).
 - Promotion of high-severity Layer 1 security findings from advisory to blocking
-  under an opt-in `--strict` flag.
+  under an opt-in `--strict` gate on `deploy`, `sync`, and `upgrade`.
+- Interactive findings confirmation plus a `--yes` bypass for non-interactive use.
+- A joined drift, run-health, no-op, and cost dashboard (`gh-aw-fleet overview`).
+
+For what's next, see the live issue list in the full `ROADMAP.md` linked above.
 
 ## Near-term FinOps
 
@@ -37,11 +41,11 @@ Planned cost-visibility work includes:
 
 ## Security
 
-Security work continues through the scanner pipeline:
+Security work continues through the scanner pipeline (the `--strict` blocking
+gate for HIGH findings shipped in v0.2.5; see above):
 
 - Layer 1 scanner coverage for secrets, compiled workflow hazards, and
   fleet-structural rules.
-- `--strict` promotion for high findings.
 - Future deeper scans for prompt-injection signatures and risky trigger patterns.
 
 ## Documentation and operator quality of life


### PR DESCRIPTION
## Summary

- Fills the missing Diátaxis quadrants on the docs site: a learning-oriented Getting Started tutorial, four task-oriented how-to guides, and a complete CLI reference. The Starlight sidebar is regrouped into Tutorials / How-to / Reference / Explanation so readers navigate by intent.
- Cuts the root README from 934 to 524 lines by replacing the Install, Configuration, and Troubleshooting deep-dives (now owned by the docs site) with concise pointers, removing the duplication that had already drifted: a broken docs/finops.md link and a --budget flag documented as if unreleased.
- Brings the v0.2.5 surface current: documents consumption --budget, drops the shipped issue #129 from the open-issues cluster, and reframes the docs-site roadmap's shipped items.
- Migrates the two README-only facts (compile-strict resolution and the overrides RepoSpec field) into the Configuration reference before removing them, so no information is lost.
- Guards against the bug class found while building: internal links must be base-prefixed root-relative (`/gh-aw-fleet/<slug>/`), enforced by the links validator and documented for contributors.

## Test plan

- [x] `cd docs && npm run build` passes; the links validator reports "All internal links are valid" (14 pages built)
- [x] Hero button href verified as /gh-aw-fleet/getting-started/ with the target page present in dist/
- [x] markdownlint clean on new and changed pages (only the unenforced MD013 table-width remains; no config enforces it)
- [x] No Go code changed; the Go `make ci` gate does not apply

## Changes

### New files

- `docs/src/content/docs/getting-started.md` - Getting Started tutorial: empty fleet to a reviewed pull request
- `docs/src/content/docs/cli.md` - CLI reference: every command, flag, and exit code
- `docs/src/content/docs/gate-ci-on-drift.md` - how-to: fail CI on fleet drift
- `docs/src/content/docs/recover-from-gpg-failure.md` - how-to: finish a gpg-blocked apply by hand
- `docs/src/content/docs/resume-interrupted-apply.md` - how-to: resume a failed apply via --work-dir
- `docs/src/content/docs/find-top-credit-burners.md` - how-to: locate cost concentration with consumption

### Modified files

- `README.md` - trimmed to a router: pointers replace the duplicated Install/Configuration/Troubleshooting sections; adds --budget to the commands table; fixes the broken finops link; Further reading now indexes the docs-site quadrants
- `docs/astro.config.mjs` - sidebar regrouped by Diátaxis quadrant; explicit errorOnRelativeLinks on the links validator
- `docs/README.md` - new "Content link convention" section
- `docs/src/content/docs/configuration.md` - adds the compile-strict resolution order and the overrides field
- `docs/src/content/docs/consumption.md` - documents --budget; removes shipped #129 from the open-issues list
- `docs/src/content/docs/index.mdx` - hero "Get started" action linking to the tutorial
- `docs/src/content/docs/overview.md` - internal link converted to base-prefixed form
- `docs/src/content/docs/reconcile.md` - strict-gate caveat for actionlint HIGH findings in generated lock files
- `docs/src/content/docs/roadmap.md` - marks --budget, --strict, overview, and interactive findings as shipped in v0.2.5

### Housekeeping

- Converted all internal docs links to base-prefixed root-relative form to satisfy starlight-links-validator 0.25